### PR TITLE
Add nn.Flatten() layers

### DIFF
--- a/amulet/models/linear_net.py
+++ b/amulet/models/linear_net.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 
 class LinearNet(nn.Module):
     """
-    Builds a dense neural network for a multiclass classification task.
+    Builds a dense neural network for a multiclass image classification task.
 
     Args:
         num_features: int
@@ -20,12 +20,13 @@ class LinearNet(nn.Module):
         super().__init__()
 
         layers = []
-        for i in range(len(hidden_layer_sizes)):
+        for i, hidden_size in enumerate(hidden_layer_sizes):
             if i == 0:
-                layers += [nn.Linear(28 * 28, hidden_layer_sizes[i])]
+                layers += [nn.Flatten()]
+                layers += [nn.Linear(28 * 28, hidden_size)]
                 layers += [nn.Tanh()]
             else:
-                layers += [nn.Linear(hidden_layer_sizes[i - 1], hidden_layer_sizes[i])]
+                layers += [nn.Linear(hidden_layer_sizes[i - 1], hidden_size)]
                 layers += [nn.Tanh()]
 
         self.features = nn.Sequential(*layers)
@@ -42,7 +43,6 @@ class LinearNet(nn.Module):
         Returns:
             Output from the model of type :class:`~torch.Tensor`
         """
-        x = x.view(x.size(0), -1)
         hidden_out = self.features(x)
         return self.classifier(hidden_out)
 

--- a/amulet/models/vgg.py
+++ b/amulet/models/vgg.py
@@ -73,22 +73,6 @@ class VGG(nn.Module):
         self.classifier = nn.Linear(512, num_classes)
         self.features = self._make_layers(cfgs[vgg_name])
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        Runs the forward pass on the neural network.
-
-        Args:
-            x: :class:`~torch.Tensor`
-                Input data
-
-        Returns:
-            Output from the model of type :class:`~torch.Tensor`
-        """
-        out = self.features(x)
-        out = out.view(out.size(0), -1)
-        out = self.classifier(out)
-        return out
-
     def _make_layers(self, cfg: list[str | int]) -> nn.Sequential:
         layers: list[nn.Module] = []
         in_channels = 3
@@ -110,8 +94,25 @@ class VGG(nn.Module):
 
                 in_channels = x
         layers += [nn.AvgPool2d(kernel_size=1, stride=1)]
+        layers += [nn.Flatten()]
 
         return nn.Sequential(*layers)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Runs the forward pass on the neural network.
+
+        Args:
+            x: :class:`~torch.Tensor`
+                Input data
+
+        Returns:
+            Output from the model of type :class:`~torch.Tensor`
+        """
+        out = self.features(x)
+        # out = out.view(out.size(0), -1)
+        out = self.classifier(out)
+        return out
 
     def get_hidden(self, x: torch.Tensor) -> torch.Tensor:
         """


### PR DESCRIPTION
Using the [recommended](https://pytorch.org/tutorials/beginner/basics/buildmodel_tutorial.html) `nn.Flatten()` method instead of changing the view wherever we need to flatten the tensor.