### PR TITLE
CIFAR10 normalization to [0,1]

### DIFF
--- a/amulet/datasets/__image_datasets.py
+++ b/amulet/datasets/__image_datasets.py
@@ -51,20 +51,17 @@ def load_cifar10(
                 A dataset of images and labels used to build a DataLoader for
                 testing PyTorch models.
     """
-    mean, std = (0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010)
     if transform_train is None:
         transform_train = transforms.Compose(
             [
                 transforms.RandomCrop(32, padding=4),
                 transforms.RandomHorizontalFlip(),
                 transforms.ToTensor(),
-                transforms.Normalize(mean, std),
             ]
         )
     if transform_test is None:
-        transform_test = transforms.Compose(
-            [transforms.ToTensor(), transforms.Normalize(mean, std)]
-        )
+        transform_test = transforms.Compose([transforms.ToTensor()])
+
     train_set = datasets.CIFAR10(
         root=path, train=True, transform=transform_train, download=True
     )


### PR DESCRIPTION
Turns out it is already in the [0,1] range by default. There isn't a need for normalization. 