### PR TITLE
Update adversarial training code

### DIFF
--- a/amulet/evasion/attacks/projected_gradient_descent.py
+++ b/amulet/evasion/attacks/projected_gradient_descent.py
@@ -45,7 +45,7 @@ class EvasionPGD(EvasionAttack):
         test_loader: DataLoader,
         device: str,
         batch_size: int,
-        epsilon: int = 16,
+        epsilon: int = 0.1,
         iterations: int = 40,
         step_size: float = 0.02,
     ):
@@ -71,7 +71,7 @@ class EvasionPGD(EvasionAttack):
             x_pgd = projected_gradient_descent(
                 self.model,
                 x,
-                self.epsilon / 255,
+                self.epsilon,
                 self.step_size,
                 self.iterations,
                 np.inf,

--- a/amulet/evasion/attacks/projected_gradient_descent.py
+++ b/amulet/evasion/attacks/projected_gradient_descent.py
@@ -45,7 +45,7 @@ class EvasionPGD(EvasionAttack):
         test_loader: DataLoader,
         device: str,
         batch_size: int,
-        epsilon: int = 0.1,
+        epsilon: float = 0.1,
         iterations: int = 40,
         step_size: float = 0.02,
     ):

--- a/amulet/evasion/attacks/projected_gradient_descent.py
+++ b/amulet/evasion/attacks/projected_gradient_descent.py
@@ -47,7 +47,7 @@ class EvasionPGD(EvasionAttack):
         batch_size: int,
         epsilon: float = 0.1,
         iterations: int = 40,
-        step_size: float = 0.02,
+        step_size: float = 0.01,
     ):
         super().__init__(model, test_loader, device, batch_size)
         self.epsilon = epsilon

--- a/amulet/evasion/defenses/evasion_defense.py
+++ b/amulet/evasion/defenses/evasion_defense.py
@@ -1,7 +1,5 @@
 """Evasion Defense Base Class"""
 
-import copy
-
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
@@ -35,7 +33,7 @@ class EvasionDefense:
         device: str,
         epochs: int = 5,
     ):
-        self.model = copy.deepcopy(model)
+        self.model = model
         self.criterion = criterion
         self.optimizer = optimizer
         self.train_loader = train_loader

--- a/amulet/evasion/defenses/projected_gradient_descent.py
+++ b/amulet/evasion/defenses/projected_gradient_descent.py
@@ -54,7 +54,7 @@ class AdversarialTrainingPGD(EvasionDefense):
         epochs: int = 5,
         epsilon: float = 0.1,
         iterations: int = 40,
-        step_size: float = 0.02,
+        step_size: float = 0.01,
     ):
         super().__init__(model, criterion, optimizer, train_loader, device, epochs)
         self.epsilon = epsilon

--- a/amulet/evasion/defenses/projected_gradient_descent.py
+++ b/amulet/evasion/defenses/projected_gradient_descent.py
@@ -52,7 +52,7 @@ class AdversarialTrainingPGD(EvasionDefense):
         train_loader: DataLoader,
         device: str,
         epochs: int = 5,
-        epsilon: int = 0.1,
+        epsilon: float = 0.1,
         iterations: int = 40,
         step_size: float = 0.02,
     ):

--- a/amulet/evasion/defenses/projected_gradient_descent.py
+++ b/amulet/evasion/defenses/projected_gradient_descent.py
@@ -52,7 +52,7 @@ class AdversarialTrainingPGD(EvasionDefense):
         train_loader: DataLoader,
         device: str,
         epochs: int = 5,
-        epsilon: int = 16,
+        epsilon: int = 0.1,
         iterations: int = 40,
         step_size: float = 0.02,
     ):
@@ -70,33 +70,42 @@ class AdversarialTrainingPGD(EvasionDefense):
         """
         self.model.train()
         for epoch in range(self.epochs):
-            acc = 0
+            correct = 0
             total = 0
             for x, y in self.train_loader:
                 x, y = x.to(self.device), y.to(self.device)
+
+                self.optimizer.zero_grad()
+                output = self.model(x)
+                loss = self.criterion(output, y)
+                loss.backward()
+                self.optimizer.step()
+
+                _, predictions = torch.max(output, 1)
+                correct += predictions.eq(y).sum().item()
+                total += len(y)
+
                 x_pgd = projected_gradient_descent(
                     self.model,
                     x,
-                    self.epsilon / 255,
+                    self.epsilon,
                     self.step_size,
                     self.iterations,
                     np.inf,
                 )
-                x = torch.concat([x, x_pgd], dim=0)
-                y = torch.concat([y, y], dim=0)
 
                 self.optimizer.zero_grad()
-                output = self.model(x)
-                _, pred = torch.max(output, 1)
+                output = self.model(x_pgd)
                 loss = self.criterion(output, y)
-
                 loss.backward()
                 self.optimizer.step()
-                acc += pred.eq(y).sum().item()
+
+                _, predictions = torch.max(output, 1)
+                correct += predictions.eq(y).sum().item()
                 total += len(y)
 
             print(
-                f"Train Epoch: {epoch} Loss: {loss.item():.6f} Acc: {acc/total*100:.2f}"  # type: ignore[reportPossiblyUnboundVariable]
+                f"Train Epoch: {epoch} Loss: {loss.item():.6f} Acc: {correct/total*100:.2f}"  # type: ignore[reportPossiblyUnboundVariable]
             )
 
         return self.model

--- a/examples/attack_pipelines/run_evasion.py
+++ b/examples/attack_pipelines/run_evasion.py
@@ -62,7 +62,7 @@ def parse_args() -> argparse.Namespace:
         "--exp_id", type=int, default=0, help="Used as a random seed for experiments."
     )
     parser.add_argument(
-        "--epsilon", type=int, default=32, help="Controls amount of perturbations."
+        "--epsilon", type=float, default=0.01, help="Controls amount of perturbations."
     )
 
     return parser.parse_args()

--- a/examples/defense_pipelines/run_adversarial_training.py
+++ b/examples/defense_pipelines/run_adversarial_training.py
@@ -62,7 +62,7 @@ def parse_args() -> argparse.Namespace:
         "--exp_id", type=int, default=0, help="Used as a random seed for experiments."
     )
     parser.add_argument(
-        "--epsilon", type=int, default=32, help="Controls amount of perturbations."
+        "--epsilon", type=float, default=0.01, help="Controls amount of perturbations."
     )
 
     return parser.parse_args()


### PR DESCRIPTION
List of changes made: 
- Removed the division by 255 for epsilon. Directly setting an epsilon value seems more intuitive especially considering the data is now normalized to [0,1].
- For some reason concatenating the adversarial samples with the original data messed up the training. Each epoch now backpropogates on the original data and then the adversarial data. 
- No longer copying the model. The assumption is that the model will be trained from scratch anyway. 

I'm still testing this code on CelebA. It worked for CIFAR10, but I'm trying to find hyperparameters that work for Celeb,A which is a bit harder. 