### PR TITLE
Update data recon

### DIFF
--- a/amulet/data_reconstruction/attacks/fredrikson_ccs_2015.py
+++ b/amulet/data_reconstruction/attacks/fredrikson_ccs_2015.py
@@ -64,7 +64,7 @@ class FredriksonCCS2015(DataReconstructionAttack):
 
         self.target_model.to(self.device).eval()
 
-    def __invert_cost(self, input_x) -> torch.Tensor:
+    def __invert_cost(self, input_x: torch.Tensor) -> torch.Tensor:
         return 1 - self.target_model(input_x.requires_grad_(True))[0][self.target_label]
 
     def __model_invert(self) -> torch.Tensor:

--- a/amulet/data_reconstruction/attacks/fredrikson_ccs_2015.py
+++ b/amulet/data_reconstruction/attacks/fredrikson_ccs_2015.py
@@ -4,7 +4,6 @@ import torch
 import torch.nn as nn
 import numpy as np
 import torch.utils.data
-from torch.autograd import Variable
 
 from .data_reconstruction_attack import DataReconstructionAttack
 
@@ -65,17 +64,18 @@ class FredriksonCCS2015(DataReconstructionAttack):
 
         self.target_model.to(self.device).eval()
 
-    def __invert_cost(self, input_x):
+    def __invert_cost(self, input_x) -> torch.Tensor:
         return 1 - self.target_model(input_x.requires_grad_(True))[0][self.target_label]
 
-    def __model_invert(self):
+    def __model_invert(self) -> torch.Tensor:
         current_x = []
         cost_x = []
         current_x.append(
-            Variable(torch.from_numpy(np.zeros(self.input_size, dtype=np.uint8)))
-            .float()
-            .to(self.device)
+            torch.Tensor(
+                torch.from_numpy(np.zeros(self.input_size, dtype=np.float32))
+            ).to(self.device)
         )
+
         for i in range(self.alpha):
             cost_x.append(self.__invert_cost(current_x[i]).to(self.device))
             cost_x[i].backward()
@@ -92,7 +92,7 @@ class FredriksonCCS2015(DataReconstructionAttack):
         i = cost_x.index(min(cost_x))
         return current_x[i]
 
-    def get_reconstructed_data(self) -> list[torch.autograd.Variable]:
+    def get_reconstructed_data(self) -> list[torch.Tensor]:
         """
         Outputs the reconstructed data of different classes
 

--- a/amulet/data_reconstruction/metrics/__init__.py
+++ b/amulet/data_reconstruction/metrics/__init__.py
@@ -1,5 +1,5 @@
-from .attack_accuracy import reverse_mse
+from .similary_evaluation import evaluate_similarity
 
 __all__ = [
-    "reverse_mse",
+    "evaluate_similarity",
 ]

--- a/amulet/data_reconstruction/metrics/__init__.py
+++ b/amulet/data_reconstruction/metrics/__init__.py
@@ -1,4 +1,4 @@
-from .similary_evaluation import evaluate_similarity
+from .similarity_evaluation import evaluate_similarity
 
 __all__ = [
     "evaluate_similarity",

--- a/amulet/data_reconstruction/metrics/attack_accuracy.py
+++ b/amulet/data_reconstruction/metrics/attack_accuracy.py
@@ -2,7 +2,6 @@ import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
 import numpy as np
-from torch.autograd import Variable
 
 
 def __figure_mse(recover_fig, original_fig):
@@ -12,7 +11,7 @@ def __figure_mse(recover_fig, original_fig):
 
 def reverse_mse(
     original_dataset: DataLoader,
-    reverse_data: list[torch.autograd.Variable],
+    reverse_data: list[torch.Tensor],
     input_size: tuple[int, ...],
     output_size: int,
     device: str,
@@ -35,9 +34,9 @@ def reverse_mse(
         MSE Loss
     """
     class_avg = [
-        Variable(torch.from_numpy(np.zeros(input_size, dtype=np.uint8)))
-        .float()
-        .to(device)
+        torch.Tensor(torch.from_numpy(np.zeros(input_size, dtype=np.float32))).to(
+            device
+        )
         for _ in range(output_size)
     ]
     class_mse = [0 for _ in range(output_size)]

--- a/amulet/data_reconstruction/metrics/similarity_evaluation.py
+++ b/amulet/data_reconstruction/metrics/similarity_evaluation.py
@@ -63,13 +63,23 @@ def evaluate_similarity(
         )
 
     all_class_avg_mse = 0
+    all_class_avg_ssim = 0
     per_class_ssim = {}
+    per_class_mse = {}
     for i in range(output_size):
         all_class_avg_mse = all_class_avg_mse + class_mse[i]
+        all_class_avg_ssim = all_class_avg_ssim + class_ssim[i]
+        per_class_mse[i] = class_mse[i]
         per_class_ssim[i] = class_ssim[i]
 
     mse = all_class_avg_mse / output_size
+    ssim = all_class_avg_ssim / output_size
 
-    results = {"mse": mse, "ssim": per_class_ssim}
+    results = {
+        "mean_mse": mse,
+        "class_mse": per_class_mse,
+        "mean_ssim": ssim,
+        "class_ssim": per_class_ssim,
+    }
 
     return results

--- a/amulet/data_reconstruction/metrics/similary_evaluation.py
+++ b/amulet/data_reconstruction/metrics/similary_evaluation.py
@@ -2,14 +2,15 @@ import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
 import numpy as np
+from skimage.metrics import structural_similarity
 
 
 def __figure_mse(recover_fig, original_fig):
     diff = nn.MSELoss()
-    return diff(recover_fig, original_fig)
+    return diff(recover_fig, original_fig).item()
 
 
-def reverse_mse(
+def evaluate_similarity(
     original_dataset: DataLoader,
     reverse_data: list[torch.Tensor],
     input_size: tuple[int, ...],
@@ -33,28 +34,43 @@ def reverse_mse(
     Returns:
         MSE Loss
     """
-    class_avg = [
+    class_total = [
         torch.Tensor(torch.from_numpy(np.zeros(input_size, dtype=np.float32))).to(
             device
         )
         for _ in range(output_size)
     ]
     class_mse = [0 for _ in range(output_size)]
+    class_ssim = [0 for _ in range(output_size)]
     class_count = [0 for _ in range(output_size)]
 
     for x, y in original_dataset:
         x, y = x.to(device), y.to(device)
-        class_avg[y] = class_avg[y] + x
+        class_total[y] = class_total[y] + x
         class_count[y] = class_count[y] + 1
 
     for i in range(output_size):
-        class_mse[i] = __figure_mse(class_avg[i] / class_count[i], (reverse_data[i]))
+        class_avg = class_total[i] / class_count[i]
+        class_avg = class_avg.squeeze()
+        reverse_data[i] = reverse_data[i].squeeze()
+        print(class_avg.shape)
+        print(reverse_data[i].shape)
+        class_mse[i] = __figure_mse(class_avg, reverse_data[i])
+        data_range = reverse_data[i].max() - reverse_data[i].min()
+        class_ssim[i] = structural_similarity(class_avg.detach().cpu().numpy(), reverse_data[i].detach().cpu().numpy(), data_range=data_range, channel_axis=0)
 
     all_class_avg_mse = 0
+    all_class_avg_ssim = 0
     for i in range(output_size):
         all_class_avg_mse = all_class_avg_mse + class_mse[i]
+        all_class_avg_ssim = all_class_avg_ssim + class_ssim[i]
 
-    accuracy = all_class_avg_mse / output_size
+    mse = all_class_avg_mse / output_size
+    ssim = all_class_avg_ssim / output_size
+
+    print(mse)
+    print(ssim)
+    exit()
 
     # PyRight thinks this is a float, it isn't.
-    return accuracy.item()  # type: ignore[reportAttributeAccessIssue]
+    return mse  # type: ignore[reportAttributeAccessIssue]

--- a/examples/attack_pipelines/run_data_recon.py
+++ b/examples/attack_pipelines/run_data_recon.py
@@ -135,10 +135,11 @@ def main(args: argparse.Namespace) -> None:
 
     reverse_data = data_recon.get_reconstructed_data()
 
-    mse_loss = evaluate_similarity(
+    results = evaluate_similarity(
         test_loader, reverse_data, input_size, output_size, args.device
     )
-    log.info(f"MSE Loss on test dataset: {mse_loss:.4f}")
+    log.info(f"MSE Loss on test dataset: {results['mse']:.4f}")
+    log.info(f"SSIMs on test dataset: {results['ssim']}")
 
 
 if __name__ == "__main__":

--- a/examples/attack_pipelines/run_data_recon.py
+++ b/examples/attack_pipelines/run_data_recon.py
@@ -138,8 +138,10 @@ def main(args: argparse.Namespace) -> None:
     results = evaluate_similarity(
         test_loader, reverse_data, input_size, output_size, args.device
     )
-    log.info(f"MSE Loss on test dataset: {results['mse']:.4f}")
-    log.info(f"SSIMs on test dataset: {results['ssim']}")
+    log.info(f"Average MSE Loss on test dataset: {results['mean_mse']:.4f}")
+    log.info(f"Per Class MSE Loss on test dataset: {results['class_mse']}")
+    log.info(f"Average SSIM Loss on test dataset: {results['mean_ssim']:.4f}")
+    log.info(f"SSIMs on test dataset: {results['class_ssim']}")
 
 
 if __name__ == "__main__":

--- a/examples/attack_pipelines/run_data_recon.py
+++ b/examples/attack_pipelines/run_data_recon.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import torch
 from torch.utils.data import DataLoader
 from amulet.data_reconstruction.attacks import FredriksonCCS2015
-from amulet.data_reconstruction.metrics import reverse_mse
+from amulet.data_reconstruction.metrics import evaluate_similarity
 from amulet.utils import (
     load_data,
     initialize_model,
@@ -135,7 +135,7 @@ def main(args: argparse.Namespace) -> None:
 
     reverse_data = data_recon.get_reconstructed_data()
 
-    mse_loss = reverse_mse(
+    mse_loss = evaluate_similarity(
         test_loader, reverse_data, input_size, output_size, args.device
     )
     log.info(f"MSE Loss on test dataset: {mse_loss:.4f}")

--- a/poetry.lock
+++ b/poetry.lock
@@ -601,6 +601,39 @@ files = [
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
+name = "imageio"
+version = "2.37.0"
+description = "Library for reading and writing a wide range of image, video, scientific, and volumetric data formats."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "imageio-2.37.0-py3-none-any.whl", hash = "sha256:11efa15b87bc7871b61590326b2d635439acc321cf7f8ce996f812543ce10eed"},
+    {file = "imageio-2.37.0.tar.gz", hash = "sha256:71b57b3669666272c818497aebba2b4c5f20d5b37c81720e5e1a56d59c492996"},
+]
+
+[package.dependencies]
+numpy = "*"
+pillow = ">=8.3.2"
+
+[package.extras]
+all-plugins = ["astropy", "av", "imageio-ffmpeg", "numpy (>2)", "pillow-heif", "psutil", "rawpy", "tifffile"]
+all-plugins-pypy = ["av", "imageio-ffmpeg", "pillow-heif", "psutil", "tifffile"]
+build = ["wheel"]
+dev = ["black", "flake8", "fsspec[github]", "pytest", "pytest-cov"]
+docs = ["numpydoc", "pydata-sphinx-theme", "sphinx (<6)"]
+ffmpeg = ["imageio-ffmpeg", "psutil"]
+fits = ["astropy"]
+full = ["astropy", "av", "black", "flake8", "fsspec[github]", "gdal", "imageio-ffmpeg", "itk", "numpy (>2)", "numpydoc", "pillow-heif", "psutil", "pydata-sphinx-theme", "pytest", "pytest-cov", "rawpy", "sphinx (<6)", "tifffile", "wheel"]
+gdal = ["gdal"]
+itk = ["itk"]
+linting = ["black", "flake8"]
+pillow-heif = ["pillow-heif"]
+pyav = ["av"]
+rawpy = ["numpy (>2)", "rawpy"]
+test = ["fsspec[github]", "pytest", "pytest-cov"]
+tifffile = ["tifffile"]
+
+[[package]]
 name = "intel-openmp"
 version = "2021.4.0"
 description = "Intel OpenMP* Runtime Library"
@@ -754,6 +787,25 @@ files = [
     {file = "kiwisolver-1.4.5-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:11d011a7574eb3b82bcc9c1a1d35c1d7075677fdd15de527d91b46bd35e935ee"},
     {file = "kiwisolver-1.4.5.tar.gz", hash = "sha256:e57e563a57fb22a142da34f38acc2fc1a5c864bc29ca1517a88abc963e60d6ec"},
 ]
+
+[[package]]
+name = "lazy-loader"
+version = "0.4"
+description = "Makes it easy to load subpackages and functions on demand."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "lazy_loader-0.4-py3-none-any.whl", hash = "sha256:342aa8e14d543a154047afb4ba8ef17f5563baad3fc610d7b15b213b0f119efc"},
+    {file = "lazy_loader-0.4.tar.gz", hash = "sha256:47c75182589b91a4e1a85a136c074285a5ad4d9f39c63e0d7fb76391c4574cd1"},
+]
+
+[package.dependencies]
+packaging = "*"
+
+[package.extras]
+dev = ["changelist (==0.5)"]
+lint = ["pre-commit (==3.7.0)"]
+test = ["pytest (>=7.4)", "pytest-cov (>=4.1)"]
 
 [[package]]
 name = "markupsafe"
@@ -1552,6 +1604,54 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "scikit-image"
+version = "0.25.1"
+description = "Image processing in Python"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "scikit_image-0.25.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:40763a3a089617e6f00f92d46b3475368b9783588a165c2aa854da95b66bb4ff"},
+    {file = "scikit_image-0.25.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:7c6b69f33e5512ee7fc53361b064430f146583f08dc75317667e81d5f8fcd0c6"},
+    {file = "scikit_image-0.25.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d9187347d115776ff0ddba3e5d2a04638d291b1a62e3c315d17b71eea351cde8"},
+    {file = "scikit_image-0.25.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdfca713979ad1873a4b55d94bb1eb4bc713f0c10165b261bf6f7e606f44a00c"},
+    {file = "scikit_image-0.25.1-cp310-cp310-win_amd64.whl", hash = "sha256:167fb146de80bb2a1493d1a760a9ac81644a8a5de254c3dd12a95d1b662d819c"},
+    {file = "scikit_image-0.25.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c1bde2d5f1dfb23b3c72ef9fcdb2dd5f42fa353e8bd606aea63590eba5e79565"},
+    {file = "scikit_image-0.25.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:5112d95cccaa45c434e57efc20c1f721ab439e516e2ed49709ddc2afb7c15c70"},
+    {file = "scikit_image-0.25.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0f5e313b028f5d7a9f3888ad825ddf4fb78913d7762891abb267b99244b4dd31"},
+    {file = "scikit_image-0.25.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39ad76aeff754048dabaff83db752aa0655dee425f006678d14485471bdb459d"},
+    {file = "scikit_image-0.25.1-cp311-cp311-win_amd64.whl", hash = "sha256:8dc8b06176c1a2316fa8bc539fd7e96155721628ae5cf51bc1a2c62cb9786581"},
+    {file = "scikit_image-0.25.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ebf83699d60134909647395a0bf07db3859646de7192b088e656deda6bc15e95"},
+    {file = "scikit_image-0.25.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:408086520eed036340e634ab7e4f648e00238f711bac61ab933efeb11464a238"},
+    {file = "scikit_image-0.25.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bd709faa87795869ccd21f32490c37989ca5846571495822f4b9430fb42c34c"},
+    {file = "scikit_image-0.25.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a6b15c0265c072a46ff4720784d756d8f8e5d63567639aa8451f6673994d6846"},
+    {file = "scikit_image-0.25.1-cp312-cp312-win_amd64.whl", hash = "sha256:a689a0d091e0bd97d7767309abdeb27c43be210d075abb34e71657add920c22b"},
+    {file = "scikit_image-0.25.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f070f899d6572a125ab106c4b26d1a5fb784dc60ba6dea45c7816f08c3a4fb4d"},
+    {file = "scikit_image-0.25.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:cc9538d8db7670878aa68ea79c0b1796b6c771085e8d50f5408ee617da3281b6"},
+    {file = "scikit_image-0.25.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:caa08d4fa851e1f421fcad8eac24d32f2810971dc61f1d72dc950ca9e9ec39b1"},
+    {file = "scikit_image-0.25.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9923aa898b7921fbcf503d32574d48ed937a7cff45ce8587be4868b39676e18"},
+    {file = "scikit_image-0.25.1-cp313-cp313-win_amd64.whl", hash = "sha256:6c7bba6773ab8c39ee8b1cbb17c7f98965bacdb8cd8da337942be6acc38fc562"},
+    {file = "scikit_image-0.25.1.tar.gz", hash = "sha256:d4ab30540d114d37c35fe5c837f89b94aaba2a7643afae8354aa353319e9bbbb"},
+]
+
+[package.dependencies]
+imageio = ">=2.33,<2.35.0 || >2.35.0"
+lazy-loader = ">=0.4"
+networkx = ">=3.0"
+numpy = ">=1.24"
+packaging = ">=21"
+pillow = ">=10.1"
+scipy = ">=1.11.2"
+tifffile = ">=2022.8.12"
+
+[package.extras]
+build = ["Cython (>=3.0.8)", "build (>=1.2.1)", "meson-python (>=0.16)", "ninja (>=1.11.1.1)", "numpy (>=2.0)", "pythran (>=0.16)", "setuptools (>=68)", "spin (==0.13)"]
+data = ["pooch (>=1.6.0)"]
+developer = ["ipython", "pre-commit", "tomli"]
+docs = ["PyWavelets (>=1.6)", "dask[array] (>=2022.9.2)", "intersphinx-registry (>=0.2411.14)", "ipykernel", "ipywidgets", "kaleido (==0.2.1)", "matplotlib (>=3.7)", "myst-parser", "numpydoc (>=1.7)", "pandas (>=2.0)", "plotly (>=5.20)", "pooch (>=1.6)", "pydata-sphinx-theme (>=0.16)", "pytest-doctestplus", "scikit-learn (>=1.2)", "seaborn (>=0.11)", "sphinx (>=8.0)", "sphinx-copybutton", "sphinx-gallery[parallel] (>=0.18)", "sphinx_design (>=0.5)", "tifffile (>=2022.8.12)"]
+optional = ["PyWavelets (>=1.6)", "SimpleITK", "astropy (>=5.0)", "cloudpickle (>=0.2.1)", "dask[array] (>=2021.1.0,!=2024.8.0)", "matplotlib (>=3.7)", "pooch (>=1.6.0)", "pyamg (>=5.2)", "scikit-learn (>=1.2)"]
+test = ["asv", "numpydoc (>=1.7)", "pooch (>=1.6.0)", "pytest (>=7.0)", "pytest-cov (>=2.11.0)", "pytest-doctestplus", "pytest-faulthandler", "pytest-localserver"]
+
+[[package]]
 name = "scikit-learn"
 version = "1.4.1.post1"
 description = "A set of python modules for machine learning and data mining"
@@ -1718,6 +1818,28 @@ files = [
     {file = "threadpoolctl-3.5.0-py3-none-any.whl", hash = "sha256:56c1e26c150397e58c4926da8eeee87533b1e32bef131bd4bf6a2f45f3185467"},
     {file = "threadpoolctl-3.5.0.tar.gz", hash = "sha256:082433502dd922bf738de0d8bcc4fdcbf0979ff44c42bd40f5af8a282f6fa107"},
 ]
+
+[[package]]
+name = "tifffile"
+version = "2025.1.10"
+description = "Read and write TIFF files"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "tifffile-2025.1.10-py3-none-any.whl", hash = "sha256:ed24cf4c99fb13b4f5fb29f8a0d5605e60558c950bccbdca2a6470732a27cfb3"},
+    {file = "tifffile-2025.1.10.tar.gz", hash = "sha256:baaf0a3b87bf7ec375fa1537503353f70497eabe1bdde590f2e41cc0346e612f"},
+]
+
+[package.dependencies]
+numpy = "*"
+
+[package.extras]
+all = ["defusedxml", "fsspec", "imagecodecs (>=2024.12.30)", "lxml", "matplotlib", "zarr (<3)"]
+codecs = ["imagecodecs (>=2024.12.30)"]
+plot = ["matplotlib"]
+test = ["cmapfile", "czifile", "dask", "defusedxml", "fsspec", "imagecodecs", "lfdfiles", "lxml", "ndtiff", "oiffile", "psdtags", "pytest", "roifile", "xarray", "zarr (<3)"]
+xml = ["defusedxml", "lxml"]
+zarr = ["fsspec", "zarr (<3)"]
 
 [[package]]
 name = "torch"
@@ -1926,4 +2048,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "aaa78f037c06f4dcec9f5bbed204a4654c92ec838e89d6d90683cb3666216ec0"
+content-hash = "0dbc30124b184b10c09defdf29951de13a04ffaa97d9734c271459c2e34223d9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ numpy                 = "1.26.4"
 opacus                = "1.4.1"
 pandas                = "2.2.1"
 scikit-learn          = "1.4.1.post1"
+scikit-image          = "0.25.1"
 scipy                 = "1.12.0"
 torch                 = {version = "^2.2.0", source = "pytorch-gpu-src"}
 torchvision           = {version = "^0.18.0", source = "pytorch-gpu-src"}


### PR DESCRIPTION
WIP. 

I've converted the use of `torch.autograd.Variable` to `torch.Tensor` instead since `Variable` is depracated. 

I'm using the [structural similarity function from scikit-learn](https://scikit-image.org/docs/0.24.x/api/skimage.metrics.html#skimage.metrics.structural_similarity), but I'm getting a really weird error from the library:

```
raceback (most recent call last):
  File "/home/a7waheed/amulet_github/examples/attack_pipelines/run_data_recon.py", line 146, in <module>
    main(args)
  File "/home/a7waheed/amulet_github/examples/attack_pipelines/run_data_recon.py", line 138, in main
    mse_loss = evaluate_similarity(
               ^^^^^^^^^^^^^^^^^^^^
  File "/home/a7waheed/amulet_github/amulet/data_reconstruction/metrics/similary_evaluation.py", line 60, in evaluate_similarity
    class_ssim[i] = structural_similarity(class_avg.detach().cpu().numpy(), reverse_data[i].detach().cpu().numpy(), data_range=data_range, channel_axis=0)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/a7waheed/amulet_github/.venv/lib/python3.11/site-packages/skimage/metrics/_structural_similarity.py", line 142, in structural_similarity
    ch_result = structural_similarity(im1[_at(ch)], im2[_at(ch)], **args)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/a7waheed/amulet_github/.venv/lib/python3.11/site-packages/skimage/metrics/_structural_similarity.py", line 263, in structural_similarity
    2 * ux * uy + C1,
    ~~~~~~~~~~~~^~~~
TypeError: Concatenation operation is not implemented for NumPy arrays, use np.concatenate() instead. Please do not rely on this error; it may not be given on all Python implementations.
```

Not really sure how to deal with this other than trying different library versions. Will spend some more time on this tomorrow. 

Fixes #32 