### PR TITLE
Add resnet18

### DIFF
--- a/amulet/models/__init__.py
+++ b/amulet/models/__init__.py
@@ -4,5 +4,6 @@ The module mlconf.models includes utilities to build sample models.
 
 from .vgg import VGG
 from .linear_net import LinearNet
+from .resnet import ResNet18
 
-__all__ = ["VGG", "LinearNet"]
+__all__ = ["VGG", "LinearNet", "ResNet18"]

--- a/amulet/models/resnet.py
+++ b/amulet/models/resnet.py
@@ -1,4 +1,5 @@
 """PyTorch ResNet"""
+
 import torch
 import torchvision
 import torch.nn as nn
@@ -16,7 +17,7 @@ class ResNet18(nn.Module):
     def __init__(self, num_classes: int = 10):
         super().__init__()
         self.features = torchvision.models.resnet18(pretrained=True)
-        self.features.fc = Identity()
+        self.features.fc = Identity()  # type: ignore[reportAttributeAccessIssue]
         self.classifier = nn.Linear(512, num_classes)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/amulet/models/resnet.py
+++ b/amulet/models/resnet.py
@@ -1,0 +1,49 @@
+"""PyTorch ResNet"""
+import torch
+import torchvision
+import torch.nn as nn
+
+
+class Identity(nn.Module):
+    def __init__(self):
+        super(Identity, self).__init__()
+
+    def forward(self, x):
+        return x
+
+
+class ResNet18(nn.Module):
+    def __init__(self, num_classes: int = 10):
+        super().__init__()
+        self.features = torchvision.models.resnet18(pretrained=True)
+        self.features.fc = Identity()
+        self.classifier = nn.Linear(512, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Runs the forward pass on the neural network.
+
+        Args:
+            x: :class:`~torch.Tensor`
+                Input data
+
+        Returns:
+            Output from the model of type :class:`~torch.Tensor`
+        """
+        x = self.features(x)
+        x = self.classifier(x)
+        x = torch.sigmoid(x)
+        return x
+
+    def get_hidden(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Gets the intermediate layer output from the model.
+
+        Args:
+            x: :class:`~torch.Tensor`
+                Input data to the model.
+
+        Returns:
+            Output from the model of type :class:`~torch.Tensor`.
+        """
+        return self.features(x)

--- a/amulet/utils/__pipeline.py
+++ b/amulet/utils/__pipeline.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 from torch.utils.data import random_split
 from sklearn.model_selection import train_test_split
 
-from ..models import VGG, LinearNet
+from ..models import VGG, LinearNet, ResNet18
 from ..datasets import (
     load_census,
     load_cifar10,
@@ -242,6 +242,8 @@ def initialize_model(
         model = VGG(
             num_classes, capacity_map[model_capacity]["vgg"], batch_norm=batch_norm
         )
+    elif model_arch == "resnet":
+        model = ResNet18(num_classes)
     elif model_arch == "linearnet":
         model = LinearNet(
             num_features,


### PR DESCRIPTION
Barebones pretrained resnet18. Used it for membership inference attacks. Since we will eventually remove models anyways, I did not add different sizes/complexities of this architecture. 