### PR TITLE
Change naming convention for consistency

### DIFF
--- a/amulet/attribute_inference/attacks/duddu_cikm_2022.py
+++ b/amulet/attribute_inference/attacks/duddu_cikm_2022.py
@@ -40,7 +40,7 @@ class DudduCIKM2022(AttributeInferenceAttack):
         super().__init__(target_model, x_train_adv, x_test, z_train_adv, device)
         self.batch_size = batch_size
 
-    def attack_predictions(self) -> dict[int, dict[str, np.ndarray]]:
+    def attack(self) -> dict[int, dict[str, np.ndarray]]:
         """
         Runs the attribute inference attack by training an attack model
         to predict the sensitive attributes of a model using the predictions

--- a/amulet/data_reconstruction/attacks/fredrikson_ccs_2015.py
+++ b/amulet/data_reconstruction/attacks/fredrikson_ccs_2015.py
@@ -92,7 +92,7 @@ class FredriksonCCS2015(DataReconstructionAttack):
         i = cost_x.index(min(cost_x))
         return current_x[i]
 
-    def get_reconstructed_data(self) -> list[torch.Tensor]:
+    def attack(self) -> list[torch.Tensor]:
         """
         Outputs the reconstructed data of different classes
 

--- a/amulet/evasion/attacks/projected_gradient_descent.py
+++ b/amulet/evasion/attacks/projected_gradient_descent.py
@@ -54,7 +54,7 @@ class EvasionPGD(EvasionAttack):
         self.iterations = iterations
         self.step_size = step_size
 
-    def run_evasion(self) -> DataLoader:
+    def attack(self) -> DataLoader:
         """
         Runs the evasion attack on the model.
 

--- a/amulet/evasion/defenses/projected_gradient_descent.py
+++ b/amulet/evasion/defenses/projected_gradient_descent.py
@@ -61,7 +61,7 @@ class AdversarialTrainingPGD(EvasionDefense):
         self.iterations = iterations
         self.step_size = step_size
 
-    def train_model(self) -> nn.Module:
+    def train_robust(self) -> nn.Module:
         """
         Adversarially trains the model.
 

--- a/amulet/membership_inference/attacks/lira.py
+++ b/amulet/membership_inference/attacks/lira.py
@@ -226,7 +226,7 @@ class LiRA(MembershipInferenceAttack):
         true_labels = np.array(true_labels)
         return -final_preds, true_labels
 
-    def run_membership_inference(self):
+    def attack(self):
         """
         Runs the membership inference attack.
         """

--- a/amulet/membership_inference/defenses/dp_sgd.py
+++ b/amulet/membership_inference/defenses/dp_sgd.py
@@ -58,7 +58,7 @@ class DPSGD(MembershipInferenceDefense):
             max_grad_norm=max_per_sample_grad_norm,
         )
 
-    def train_model(self) -> nn.Module:
+    def train_private(self) -> nn.Module:
         """
         Trains the model with differential privacy.
 

--- a/amulet/poisoning/attacks/badnets.py
+++ b/amulet/poisoning/attacks/badnets.py
@@ -64,7 +64,7 @@ class BadNets:
 
         return data_point
 
-    def poison_dataset(self, dataset, mode="train"):
+    def attack(self, dataset, mode="train"):
         """
         Poisons a proportion (pkeep) of the data points.
 

--- a/amulet/poisoning/defenses/outlier_removal.py
+++ b/amulet/poisoning/defenses/outlier_removal.py
@@ -116,7 +116,7 @@ class OutlierRemoval(PoisoningDefense):
 
         return np.mean(s, axis=1)
 
-    def train_model(
+    def train_robust(
         self,
         get_hidden: Callable[
             [nn.Module, DataLoader, str],

--- a/amulet/unauth_model_ownership/attacks/model_extraction.py
+++ b/amulet/unauth_model_ownership/attacks/model_extraction.py
@@ -56,7 +56,7 @@ class ModelExtraction:
         self.device = device
         self.epochs = epochs
 
-    def train_attack_model(self) -> nn.Module:
+    def attack(self) -> nn.Module:
         """
         Trains attack model by extracting the target model.
 

--- a/amulet/unauth_model_ownership/defenses/__init__.py
+++ b/amulet/unauth_model_ownership/defenses/__init__.py
@@ -1,4 +1,4 @@
-from .fingerprint import Fingerprinting
+from .fingerprint import DatasetInference
 from .watermark import WatermarkNN
 
-__all__ = ["Fingerprinting", "WatermarkNN"]
+__all__ = ["DatasetInference", "WatermarkNN"]

--- a/amulet/unauth_model_ownership/defenses/fingerprint.py
+++ b/amulet/unauth_model_ownership/defenses/fingerprint.py
@@ -10,7 +10,7 @@ from torch.utils.data import DataLoader
 from scipy.stats import ttest_ind
 
 
-class Fingerprinting:
+class DatasetInference:
     """
     Implementation of algorithm to fingerprint models based on the
     data they are trained with. Code taken from:
@@ -85,7 +85,7 @@ class Fingerprinting:
         self.regressor_embed = regressor_embed
         self.batch_size = batch_size
 
-    def dataset_inference(self):
+    def fingerprint(self):
         """
         Runs the Dataset Inference algorithm and returns a p-value for
         the target and suspect models.

--- a/examples/attack_pipelines/run_attribute_inference.py
+++ b/examples/attack_pipelines/run_attribute_inference.py
@@ -184,7 +184,7 @@ def main(args: argparse.Namespace) -> None:
         args.batch_size,
         args.device,
     )
-    predictions = attribute_inference.attack_predictions()
+    predictions = attribute_inference.attack()
 
     results = evaluate_attribute_inference(data.z_test, predictions)
 

--- a/examples/attack_pipelines/run_data_recon.py
+++ b/examples/attack_pipelines/run_data_recon.py
@@ -133,7 +133,7 @@ def main(args: argparse.Namespace) -> None:
         target_model, input_size, output_size, args.device, args.alpha
     )
 
-    reverse_data = data_recon.get_reconstructed_data()
+    reverse_data = data_recon.attack()
 
     results = evaluate_similarity(
         test_loader, reverse_data, input_size, output_size, args.device

--- a/examples/attack_pipelines/run_evasion.py
+++ b/examples/attack_pipelines/run_evasion.py
@@ -126,7 +126,7 @@ def main(args: argparse.Namespace) -> None:
     evasion = EvasionPGD(
         target_model, test_loader, args.device, args.batch_size, args.epsilon
     )
-    adversarial_test_loader = evasion.run_evasion()
+    adversarial_test_loader = evasion.attack()
     adv_accuracy = get_accuracy(target_model, adversarial_test_loader, args.device)
     log.info("Adversarial accuracy of target model: %s", adv_accuracy)
 

--- a/examples/attack_pipelines/run_membership_inference.py
+++ b/examples/attack_pipelines/run_membership_inference.py
@@ -169,7 +169,7 @@ def main(args: argparse.Namespace) -> None:
         args.exp_id,
     )
 
-    results = mem_inf.run_membership_inference()
+    results = mem_inf.attack()
 
     print(get_fixed_auc(results["lira_online_preds"], results["true_labels"]))
     print(get_fixed_auc(results["lira_offline_preds"], results["true_labels"]))

--- a/examples/attack_pipelines/run_model_extraction.py
+++ b/examples/attack_pipelines/run_model_extraction.py
@@ -173,7 +173,7 @@ def main(args: argparse.Namespace) -> None:
             args.device,
             args.epochs,
         )
-        attack_model = model_extraction.train_attack_model()
+        attack_model = model_extraction.attack()
 
         # Save model
         create_dir(attack_model_path, log)

--- a/examples/attack_pipelines/run_poisoning.py
+++ b/examples/attack_pipelines/run_poisoning.py
@@ -158,7 +158,7 @@ def main(args: argparse.Namespace) -> None:
             dataset_type,
         )
 
-        poisoned_test_set = poisoning.poison_dataset(data.test_set, mode="test")
+        poisoned_test_set = poisoning.attack(data.test_set, mode="test")
         poisoned_test_loader = DataLoader(
             dataset=poisoned_test_set, batch_size=args.batch_size, shuffle=False
         )
@@ -176,7 +176,7 @@ def main(args: argparse.Namespace) -> None:
             dataset_type,
         )
 
-        poisoned_train_set = poisoning.poison_dataset(data.train_set)
+        poisoned_train_set = poisoning.attack(data.train_set)
         poisoned_train_loader = DataLoader(
             dataset=poisoned_train_set, batch_size=args.batch_size, shuffle=False
         )
@@ -190,7 +190,7 @@ def main(args: argparse.Namespace) -> None:
             args.device,
         )
 
-        poisoned_test_set = poisoning.poison_dataset(data.test_set, mode="test")
+        poisoned_test_set = poisoning.attack(data.test_set, mode="test")
         poisoned_test_loader = DataLoader(
             dataset=poisoned_test_set, batch_size=args.batch_size, shuffle=False
         )

--- a/examples/defense_pipelines/run_adversarial_training.py
+++ b/examples/defense_pipelines/run_adversarial_training.py
@@ -142,7 +142,7 @@ def main(args: argparse.Namespace) -> None:
             args.epochs,
             args.epsilon,
         )
-        defended_model = adv_training.train_model()
+        defended_model = adv_training.train_robust()
 
         # Save model
         create_dir(defended_model_path, log)

--- a/examples/defense_pipelines/run_dp_sgd.py
+++ b/examples/defense_pipelines/run_dp_sgd.py
@@ -169,7 +169,7 @@ def main(args: argparse.Namespace) -> None:
             args.secure_rng,
             args.epochs,
         )
-        defended_model = dp_training.train_model()
+        defended_model = dp_training.train_private()
 
         # Save model
         create_dir(defended_model_path, log)

--- a/examples/defense_pipelines/run_fingerprint.py
+++ b/examples/defense_pipelines/run_fingerprint.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import torch
 from torch.utils.data import DataLoader
-from amulet.unauth_model_ownership.defenses import Fingerprinting
+from amulet.unauth_model_ownership.defenses import DatasetInference
 from amulet.utils import (
     load_data,
     initialize_model,
@@ -177,7 +177,7 @@ def main(args: argparse.Namespace) -> None:
     num_classes_map = {"cifar10": 10, "fmnist": 10, "census": 2, "lfw": 2}
     dataset_map = {"cifar10": "2D", "fmnist": "2D", "census": "1D", "lfw": "1D"}
 
-    fingerprinting = Fingerprinting(
+    dataset_inference = DatasetInference(
         target_model,
         suspect_model,
         train_loader,
@@ -194,7 +194,7 @@ def main(args: argparse.Namespace) -> None:
         args.regressor_embed,
         args.batch_size,
     )
-    results = fingerprinting.dataset_inference()
+    results = dataset_inference.fingerprint()
     log.info(results)
 
 

--- a/examples/defense_pipelines/run_outlier_removal.py
+++ b/examples/defense_pipelines/run_outlier_removal.py
@@ -142,7 +142,7 @@ def main(args: argparse.Namespace) -> None:
             batch_size=args.batch_size,
             percent=args.percent,
         )
-        defended_model = outlier_removal.train_model()
+        defended_model = outlier_removal.train_robust()
 
         # Save model
         create_dir(defended_model_path, log)

--- a/examples/defense_pipelines/run_watermark.py
+++ b/examples/defense_pipelines/run_watermark.py
@@ -146,7 +146,7 @@ def main(args: argparse.Namespace) -> None:
         defended_model = torch.load(defended_model_filename)
     else:
         log.info("Retraining Model with Watermarking")
-        wm_model = WatermarkNN(
+        wm_knn = WatermarkNN(
             target_model,
             criterion,
             optimizer,
@@ -158,7 +158,7 @@ def main(args: argparse.Namespace) -> None:
             args.epochs,
             args.batch_size,
         )
-        defended_model = wm_model.watermark()
+        defended_model = wm_knn.watermark()
 
         # Save model
         create_dir(defended_model_path, log)

--- a/examples/get_started.py
+++ b/examples/get_started.py
@@ -54,7 +54,7 @@ print("Test accuracy of target model: %s", test_accuracy_target)
 
 # Run Evasion
 evasion = EvasionPGD(target_model, test_loader, device, batch_size=256, epsilon=32)
-adversarial_test_loader = evasion.run_evasion()
+adversarial_test_loader = evasion.attack()
 adv_accuracy = get_accuracy(target_model, adversarial_test_loader, device)
 print("Adversarial accuracy of target model: %s", adv_accuracy)
 
@@ -68,12 +68,12 @@ adv_training = AdversarialTrainingPGD(
     epochs,
     epsilon=32,
 )
-defended_model = adv_training.train_model()
+defended_model = adv_training.train_robust()
 test_accuracy_defended = get_accuracy(defended_model, test_loader, device)
 print("Test accuracy of defended model: %s", test_accuracy_defended)
 
 # Run Evasion against defended model
 evasion = EvasionPGD(defended_model, test_loader, device, batch_size=256, epsilon=32)
-adversarial_test_loader = evasion.run_evasion()
+adversarial_test_loader = evasion.attack()
 adv_accuracy = get_accuracy(defended_model, adversarial_test_loader, device)
 print("Adversarial accuracy of defended model: %s", adv_accuracy)


### PR DESCRIPTION
When calling any attack, instead of a specific named function for each attack, we use the `<attack_type>.attack()` convention. 

For defenses, it made most sense to break it down into different things: 
1. Robustness (e.g. poisoning and evasion): `<defense_type>.train_robust()`
2. Privacy (e.g. DP): `<defense_type>.train_private()`
3. Fairness (e.g. discriminatory behavior): `<defense_type>.train_fair()`