### PR TITLE
Add AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+CLAUDE.md
+
 *outputs*
 data/
 saved_models/


### PR DESCRIPTION
This is incomplete, and I'll let you populate it according to your preference to get it started.

My only restriction is that imo, `AGENTS.md` should only contain things that cannot be inferred easily from reading the code: external assumptions, design choices, available tools.

Also, I think we'd `AGENTS.md` and not `CLAUDE.md` because it's more generic, and just `ln -s AGENTS.md CLAUDE.md` if you want to use it with claude-code (which I do e.g.).