### PR TITLE
refactor: add AmuletModel base class, shared ML utilities, and modernize tooling

### DIFF
--- a/.geminiignore
+++ b/.geminiignore
@@ -1,0 +1,5 @@
+.venv/
+.ruff_cache/
+.pytest_cache/
+.git/
+node_modules/

--- a/.github/workflows/precommit-main.yaml
+++ b/.github/workflows/precommit-main.yaml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, "release/*"]
+    branches: [main, "release/*", "pr/*"]
 
 permissions: read-all
 

--- a/.github/workflows/precommit-main.yaml
+++ b/.github/workflows/precommit-main.yaml
@@ -1,7 +1,6 @@
-# Same as `code-quality-pr.yaml` but triggered on commit to main branch
-# and runs on all files (instead of only the changed ones)
+# CI for push to main and PRs: pre-commit on all files, then pytest.
 
-name: precommit-checks
+name: ci
 
 on:
   push:
@@ -17,18 +16,23 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
 
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: Install dependencies
         run: |
-          $HOME/.local/bin/uv sync
+          $HOME/.local/bin/uv sync --all-extras
           echo PATH="$PWD/.venv/bin:$PATH" >> $GITHUB_ENV
 
-      - name: Pre-commit on changed files
+      - name: Pre-commit on all files
         uses: pre-commit/action@v3.0.1
+
+      - name: Run pytest
+        run: uv run pytest tests/ -v

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 data/
 saved_models/
 logs/
+scripts/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -166,3 +167,12 @@ cython_debug/
 
 # VSCode Settings
 .vscode
+
+# macOS
+.DS_Store
+
+# AI Agent Specifics (symlinks to AGENT.md and local metadata)
+CLAUDE.md
+GEMINI.md
+.claude/
+.gemini

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,13 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD033": false,
+  "MD041": false,
+  "MD024": false,
+  "MD036": false,
+  "MD032": false,
+  "MD060": false,
+  "MD046": { "style": "fenced" },
+  "MD049": { "style": "asterisk" },
+  "MD050": { "style": "asterisk" }
+}

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,4 @@
+# Pre-existing issues in docs/ and examples/extending_amulet/ are addressed
+# in the docs overhaul PR (PR 6). Ignored here to keep PR 1 scoped.
+docs/
+examples/extending_amulet/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
 
   # python linting and formatting
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.7
+    rev: v0.11.0
     hooks:
       # Run the linter.
       - id: ruff
@@ -31,9 +31,16 @@ repos:
     hooks:
       - id: basedpyright
 
-  # yaml formatting
+  # yaml and markdown formatting
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1
     hooks:
       - id: prettier
-        types: [yaml]
+        files: \.(yaml|yml|md|markdown)$
+
+  # markdown linting
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.41.0
+    hooks:
+      - id: markdownlint
+        args: ["--config", ".markdownlint.json"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,102 @@
+# AGENTS.md
+
+This file provides guidance to AI agents when working with code in this repository.
+
+## Project Overview
+
+Amulet (`amuletml` on PyPI) is a PyTorch-based research library for evaluating **unintended interactions** among ML defenses and risks across security, privacy, and fairness.
+It builds on "SoK: Unintended Interactions among Machine Learning Defenses and Risks" (IEEE S&P 2024).
+The central use case is composing an attack from one risk with a defense designed for another risk and measuring how they interfere.
+
+Requires Python ~=3.11.0 and (for GPU) CUDA 11.8+ with PyTorch 2.2+.
+
+## Where to find things
+
+- **Dev setup, deps, lint/typecheck config:** [`pyproject.toml`](pyproject.toml) and [`.pre-commit-config.yaml`](.pre-commit-config.yaml)
+- **Risk modules:** `amulet/<risk>/` — each has `attacks/`, `defenses/`, and optionally `metrics/` subpackages
+  - Security: [`evasion/`](amulet/evasion/), [`poisoning/`](amulet/poisoning/), [`unauth_model_ownership/`](amulet/unauth_model_ownership/)
+  - Privacy: [`membership_inference/`](amulet/membership_inference/), [`attribute_inference/`](amulet/attribute_inference/), [`distribution_inference/`](amulet/distribution_inference/), [`data_reconstruction/`](amulet/data_reconstruction/)
+  - Fairness: [`discriminatory_behavior/`](amulet/discriminatory_behavior/)
+- **Shared training/eval utilities:** [`amulet/utils/`](amulet/utils/) — check here before implementing your own helpers. If a needed utility is missing, add it to `amulet/utils/` and submit a PR — functionality useful in one risk module is likely useful elsewhere.
+- **Dataset loaders:** [`amulet/datasets/`](amulet/datasets/)
+- **Model base class and architectures:** [`amulet/models/`](amulet/models/)
+- **Runnable pipelines:** [`examples/attack_pipelines/`](examples/attack_pipelines/) and [`examples/defense_pipelines/`](examples/defense_pipelines/)
+- **Extending Amulet (custom modules, metrics, risks):** [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) and [`examples/extending_amulet/`](examples/extending_amulet/)
+
+## Commands
+
+Dependency management is via `uv` (never `pip`/`conda`):
+
+```bash
+uv sync                     # install runtime deps, create .venv
+uv sync --all-extras        # include dev deps (ruff, basedpyright, pytest, pre-commit)
+uv add <pkg>                # add runtime dep
+uv add --dev <pkg>          # add dev dep
+uv lock                     # regenerate uv.lock after editing pyproject.toml
+```
+
+Lint / typecheck / format (run via pre-commit so configuration stays in sync with CI):
+
+```bash
+uv run pre-commit install          # one-time
+uv run pre-commit run --all-files  # ALWAYS use --all-files; omitting it only checks staged files
+uv run ruff check --fix .
+uv run ruff format .
+uv run basedpyright                # standard mode; venv is .venv (configured in pyproject.toml)
+```
+
+Tests live in `tests/` (`unit/` and `integration/`).
+Run examples as end-to-end smoke tests:
+
+```bash
+uv run python examples/get_started.py
+uv run python examples/attack_pipelines/run_evasion.py
+```
+
+## Non-obvious rules
+
+### API contract
+
+Attacks and defenses must not emit metrics.
+They return outputs (e.g. adversarial `DataLoader`, defended `nn.Module`) consumed by metrics in `amulet/utils/__metrics.py` or the risk's own `metrics/`.
+
+Each risk has an ABC base class in `amulet/<risk>/attacks/` and `amulet/<risk>/defenses/`.
+The standard entry-point methods are:
+
+| Role                           | Method                                             |
+| ------------------------------ | -------------------------------------------------- |
+| All attacks (except poisoning) | `attack()`                                         |
+| Poisoning attacks              | `poison_train(dataset)` and `poison_test(dataset)` |
+| Evasion + poisoning defenses   | `train_robust()`                                   |
+| Membership inference defense   | `train_private()`                                  |
+| Fairness defense               | `train_fair()`                                     |
+| Watermarking defense           | `watermark()`                                      |
+| Fingerprinting defense         | `fingerprint()`                                    |
+
+Some classes expose additional public helpers for experimentation — for example, `MembershipInferenceAttack` has `train_shadow_model()` / `prepare_shadow_models()` and `DistributionInferenceAttack` has `train_model_population()` / `prepare_model_populations()`.
+Check the base class before assuming `attack()` is the only callable.
+
+### Models
+
+Any model under `amulet/models/` must subclass `AmuletModel` ([`amulet/models/base.py`](amulet/models/base.py)) and implement `get_hidden(self, x) -> Tensor`.
+Several modules depend on intermediate activations; omitting `get_hidden` breaks them silently.
+
+`WatermarkNN` and `DatasetInference` have separate ABC base classes (`WatermarkDefense`, `FingerprintDefense`).
+There is no shared parent — this is intentional.
+
+### Datasets
+
+Loaders follow a 3-step fallback to ensure availability:
+
+1. **Processed local** (e.g. `celeba.npz`, `lfw_images.npz`)
+2. **Raw local** (e.g. `img_align_celeba/`, `lfw_home/`)
+3. **GDrive download** — IDs are hard-coded in [`amulet/datasets/__image_datasets.py`](amulet/datasets/__image_datasets.py) (similar to how PyTorch ships dataset URLs), so no configuration is needed.
+
+### Tooling
+
+- Keep the `ruff-pre-commit` hook rev in sync with `ruff==` in `pyproject.toml`. A mismatch silently skips rules.
+- `B903` (class-could-be-dataclass) is globally ignored. Base classes that provide shared state for subclasses are a valid pattern here.
+- Pandas stubs: use `# type: ignore[reportArgumentType]` for `columns=list[str]` and `# type: ignore[reportAttributeAccessIssue]` for `.isin()`. Do not use `cast()` — established repo convention.
+- Dependency versions are pinned exactly. `cleverhans`, `opacus`, and `captum` are sensitive to version drift. Do not loosen pins without a reason.
+- The package is published to PyPI as `amuletml`; the import name is `amulet`.
+- Docstrings use Google style: imperative summary line, `Args:` / `Returns:` / `Raises:` sections, no type repetition from the signature, no RST markup.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,3 @@
-
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge
@@ -18,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the overall
+- Focusing on what is best not just for us as individuals, but for the overall
   community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or advances of
+- The use of sexualized language or imagery, and sexual attention or advances of
   any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email address,
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
   without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -120,14 +119,14 @@ version 2.1, available at
 [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
 
 Community Impact Guidelines were inspired by
-[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
 
 For answers to common questions about this code of conduct, see the FAQ at
-[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
 [https://www.contributor-covenant.org/translations][translations].
 
 [homepage]: https://www.contributor-covenant.org
 [v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
-[Mozilla CoC]: https://github.com/mozilla/diversity
-[FAQ]: https://www.contributor-covenant.org/faq
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
 [translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ Amulet is a Python machine learning (ML) package to evaluate the susceptibility 
 Amulet builds upon prior work titled [“SoK: Unintended Interactions among Machine Learning Defenses and Risks”](https://arxiv.org/abs/2312.04542) which appears in IEEE Symposium on Security and Privacy 2024. The SoK covers only two interactions and identifies the design of a software library to evaluate unintended interactions as future work. Amulet addresses this gap by including eight different risks each covering their own attacks, defenses and metrics.
 
 Amulet is:
+
 - Comprehensive: Covers the most representative attacks/defenses/metrics for different risks.
 - Extensible: Easy to include additional risks, attacks, defenses, or metrics.
 - Consistent: Allows using different attacks/defenses/metrics with a consistent, easy-to-use API.
 - Applicable: Allows evaluating unintended interactions among defenses and attacks.
 
-
-Built to work with PyTorch, you can incorporate Amulet into your current ML pipeline to test how your model interacts with these state-of-the-art defenses and risks. Alternatively, you can use the example pipelines to bootstrap your pipeline.
+Built to work with PyTorch
+, you can incorporate Amulet into your current ML pipeline to test how your model interacts with these state-of-the-art defenses and risks. Alternatively, you can use the example pipelines to bootstrap your pipeline.
 
 ## Getting Started
 

--- a/amulet/attribute_inference/attacks/attribute_inference_attack.py
+++ b/amulet/attribute_inference/attacks/attribute_inference_attack.py
@@ -1,7 +1,7 @@
 """Attribute Inference Attack Base class"""
 
-import torch.nn as nn
 import numpy as np
+import torch.nn as nn
 
 
 class AttributeInferenceAttack:

--- a/amulet/attribute_inference/attacks/duddu_cikm_2022.py
+++ b/amulet/attribute_inference/attacks/duddu_cikm_2022.py
@@ -1,12 +1,12 @@
 """Implementation of attribute inference algorithm"""
 
-import torch.nn as nn
 import numpy as np
-from sklearn.neural_network import MLPClassifier
+import torch.nn as nn
 from sklearn.metrics import roc_curve
+from sklearn.neural_network import MLPClassifier
 
-from .attribute_inference_attack import AttributeInferenceAttack
 from ...utils import get_predictions_numpy
+from .attribute_inference_attack import AttributeInferenceAttack
 
 
 class DudduCIKM2022(AttributeInferenceAttack):

--- a/amulet/attribute_inference/metrics/attack_accuracy.py
+++ b/amulet/attribute_inference/metrics/attack_accuracy.py
@@ -1,7 +1,7 @@
 """Attack accuracy for attribute inference attacks"""
 
-from sklearn.metrics import roc_auc_score, balanced_accuracy_score
 import numpy as np
+from sklearn.metrics import balanced_accuracy_score, roc_auc_score
 
 
 def evaluate_attribute_inference(

--- a/amulet/data_reconstruction/attacks/fredrikson_ccs_2015.py
+++ b/amulet/data_reconstruction/attacks/fredrikson_ccs_2015.py
@@ -1,8 +1,8 @@
 """Implementation of Model Inversion Attack from CCS 2015 by Fredrikson et al."""
 
+import numpy as np
 import torch
 import torch.nn as nn
-import numpy as np
 import torch.utils.data
 
 from .data_reconstruction_attack import DataReconstructionAttack

--- a/amulet/data_reconstruction/metrics/similarity_evaluation.py
+++ b/amulet/data_reconstruction/metrics/similarity_evaluation.py
@@ -1,8 +1,8 @@
+import numpy as np
 import torch
 import torch.nn as nn
-from torch.utils.data import DataLoader
-import numpy as np
 from skimage.metrics import structural_similarity
+from torch.utils.data import DataLoader
 
 
 def __figure_mse(recover_fig, original_fig):

--- a/amulet/datasets/__data.py
+++ b/amulet/datasets/__data.py
@@ -1,5 +1,6 @@
 """Data Classes Implementation"""
 
+from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
@@ -7,8 +8,7 @@ import pandas as pd
 import torch
 import torchvision.transforms as transforms
 from torch.utils.data import Dataset
-from dataclasses import dataclass
-from torchvision.io import read_image, ImageReadMode
+from torchvision.io import ImageReadMode, read_image
 
 
 @dataclass

--- a/amulet/datasets/__image_datasets.py
+++ b/amulet/datasets/__image_datasets.py
@@ -5,14 +5,15 @@ computer vision applications.
 
 from pathlib import Path
 
-import torchvision.transforms as transforms
-import pandas as pd
 import numpy as np
+import pandas as pd
 import torch
-from torchvision import datasets
-from torch.utils.data import TensorDataset
-from .__data import AmuletDataset
+import torchvision.transforms as transforms
 from sklearn.model_selection import train_test_split
+from torch.utils.data import TensorDataset
+from torchvision import datasets
+
+from .__data import AmuletDataset
 
 
 def load_cifar10(
@@ -56,13 +57,11 @@ def load_cifar10(
     # This is important for compatibility with attack methods (e.g., PGD, MIA).
 
     if transform_train is None:
-        transform_train = transforms.Compose(
-            [
-                transforms.RandomCrop(32, padding=4),
-                transforms.RandomHorizontalFlip(),
-                transforms.ToTensor(),
-            ]
-        )
+        transform_train = transforms.Compose([
+            transforms.RandomCrop(32, padding=4),
+            transforms.RandomHorizontalFlip(),
+            transforms.ToTensor(),
+        ])
     if transform_test is None:
         transform_test = transforms.Compose([transforms.ToTensor()])
 
@@ -119,17 +118,15 @@ def load_cifar100(
     # This is important for compatibility with attack methods (e.g., PGD, MIA).
 
     if transform_train is None:
-        transform_train = transforms.Compose(
-            [
-                transforms.RandomCrop(32, padding=4),
-                transforms.RandomHorizontalFlip(),
-                transforms.ColorJitter(
-                    brightness=0.2, contrast=0.2, saturation=0.2, hue=0.1
-                ),
-                transforms.ToTensor(),
-                transforms.RandomErasing(p=0.2),
-            ]
-        )
+        transform_train = transforms.Compose([
+            transforms.RandomCrop(32, padding=4),
+            transforms.RandomHorizontalFlip(),
+            transforms.ColorJitter(
+                brightness=0.2, contrast=0.2, saturation=0.2, hue=0.1
+            ),
+            transforms.ToTensor(),
+            transforms.RandomErasing(p=0.2),
+        ])
 
     if transform_test is None:
         transform_test = transforms.Compose([transforms.ToTensor()])
@@ -190,26 +187,22 @@ def load_fmnist(
                 testing PyTorch models.
     """
     if transform_train is None:
-        transform_train = transforms.Compose(
-            [
-                transforms.RandomHorizontalFlip(),
-                transforms.RandomVerticalFlip(),
-                transforms.RandomRotation(15),
-                transforms.RandomCrop([28, 28]),
-                transforms.ToTensor(),
-            ]
-        )
+        transform_train = transforms.Compose([
+            transforms.RandomHorizontalFlip(),
+            transforms.RandomVerticalFlip(),
+            transforms.RandomRotation(15),
+            transforms.RandomCrop([28, 28]),
+            transforms.ToTensor(),
+        ])
 
     if transform_test is None:
-        transform_test = transforms.Compose(
-            [
-                transforms.RandomHorizontalFlip(),
-                transforms.RandomVerticalFlip(),
-                transforms.RandomRotation(15),
-                transforms.RandomCrop([28, 28]),
-                transforms.ToTensor(),
-            ]
-        )
+        transform_test = transforms.Compose([
+            transforms.RandomHorizontalFlip(),
+            transforms.RandomVerticalFlip(),
+            transforms.RandomRotation(15),
+            transforms.RandomCrop([28, 28]),
+            transforms.ToTensor(),
+        ])
 
     train_set = datasets.FashionMNIST(
         root=path, train=True, transform=transform_train, download=True
@@ -264,26 +257,22 @@ def load_mnist(
                 testing PyTorch models.
     """
     if transform_train is None:
-        transform_train = transforms.Compose(
-            [
-                transforms.RandomHorizontalFlip(),
-                transforms.RandomVerticalFlip(),
-                transforms.RandomRotation(15),
-                transforms.RandomCrop([28, 28]),
-                transforms.ToTensor(),
-            ]
-        )
+        transform_train = transforms.Compose([
+            transforms.RandomHorizontalFlip(),
+            transforms.RandomVerticalFlip(),
+            transforms.RandomRotation(15),
+            transforms.RandomCrop([28, 28]),
+            transforms.ToTensor(),
+        ])
 
     if transform_test is None:
-        transform_test = transforms.Compose(
-            [
-                transforms.RandomHorizontalFlip(),
-                transforms.RandomVerticalFlip(),
-                transforms.RandomRotation(15),
-                transforms.RandomCrop([28, 28]),
-                transforms.ToTensor(),
-            ]
-        )
+        transform_test = transforms.Compose([
+            transforms.RandomHorizontalFlip(),
+            transforms.RandomVerticalFlip(),
+            transforms.RandomRotation(15),
+            transforms.RandomCrop([28, 28]),
+            transforms.ToTensor(),
+        ])
 
     train_set = datasets.MNIST(
         root=path, train=True, transform=transform_train, download=True
@@ -355,7 +344,7 @@ def load_celeba(
 
     images_np = np.stack(images["pixels"].to_list())
     sensitive_attributes: list[str] = ["Male"]
-    attributes = df[[target_attribute] + sensitive_attributes]
+    attributes = df[[target_attribute, *sensitive_attributes]]
 
     images_train, images_test, attributes_train, attributes_test = train_test_split(
         images_np,

--- a/amulet/datasets/__init__.py
+++ b/amulet/datasets/__init__.py
@@ -3,24 +3,24 @@ The module mlconf.datasets includes utilities to load datasets,
 including methods to load and fetch popular reference datasets.
 """
 
+from .__data import AmuletDataset, CustomImageDataset
 from .__image_datasets import (
+    load_celeba,
     load_cifar10,
     load_cifar100,
     load_fmnist,
     load_mnist,
-    load_celeba,
 )
 from .__tabular_datasets import load_census, load_lfw
-from .__data import AmuletDataset, CustomImageDataset
 
 __all__ = [
+    "AmuletDataset",
+    "CustomImageDataset",
+    "load_celeba",
+    "load_census",
     "load_cifar10",
     "load_cifar100",
     "load_fmnist",
-    "load_mnist",
-    "load_census",
     "load_lfw",
-    "load_celeba",
-    "AmuletDataset",
-    "CustomImageDataset",
+    "load_mnist",
 ]

--- a/amulet/datasets/__tabular_datasets.py
+++ b/amulet/datasets/__tabular_datasets.py
@@ -244,7 +244,7 @@ def load_lfw(
         w = int(resize_by * w)
 
         imgs = np.zeros((len(names), h, w, 3), dtype=np.uint8)
-        for i, (name, num) in enumerate(zip(names, img_num, strict=False)):
+        for i, (name, num) in enumerate(zip(names, img_num, strict=True)):
             name = name.replace(" ", "_")
             img_path = (
                 path
@@ -276,7 +276,7 @@ def load_lfw(
             binary_attr = np.asarray(attributes["Male"])
             binary_attr = np.sign(binary_attr)
             binary_attr[binary_attr == -1] = 0
-            return dict(zip(range(len(binary_attr)), binary_attr, strict=False))
+            return dict(zip(range(len(binary_attr)), binary_attr, strict=True))
         else:
             raise ValueError(attribute)
 
@@ -295,7 +295,7 @@ def load_lfw(
             indices.append(i)
             labels.append(np.argmax(a))
 
-        return dict(zip(indices, labels, strict=False))
+        return dict(zip(indices, labels, strict=True))
 
     # Wrapper
     def _load_lfw_attr(attribute: str):

--- a/amulet/datasets/__tabular_datasets.py
+++ b/amulet/datasets/__tabular_datasets.py
@@ -7,16 +7,15 @@ import os
 from pathlib import Path
 from urllib.request import urlopen
 
+import numpy as np
 import pandas as pd
 import torch
-import numpy as np
-from torch.utils.data import TensorDataset
+from PIL import Image
 from sklearn.datasets import fetch_lfw_people
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import MinMaxScaler
-
+from torch.utils.data import TensorDataset
 from ucimlrepo import fetch_ucirepo
-from PIL import Image
 
 from .__data import AmuletDataset
 
@@ -100,7 +99,7 @@ def load_census(
         sex=lambda df: (df["sex"] == "Male").astype(int),
     )
     target = (adult_data["income"] == ">50K").astype(int)
-    to_drop = ["income", "fnlwgt"] + sensitive_attributes
+    to_drop = ["income", "fnlwgt", *sensitive_attributes]
     features = (
         adult_data.drop(columns=to_drop)
         .fillna("Unknown")
@@ -245,8 +244,7 @@ def load_lfw(
         w = int(resize_by * w)
 
         imgs = np.zeros((len(names), h, w, 3), dtype=np.uint8)
-        i = 0
-        for name, num in zip(names, img_num):
+        for i, (name, num) in enumerate(zip(names, img_num, strict=False)):
             name = name.replace(" ", "_")
             img_path = (
                 path
@@ -256,9 +254,7 @@ def load_lfw(
                 / f"{name}_{str(num).zfill(4)}.jpg"
             )
             img = Image.fromarray(np.array(Image.open(img_path))[slice_])
-            img = np.array(img.resize((w, h)))
-            imgs[i] = img
-            i += 1
+            imgs[i] = np.array(img.resize((w, h)))
 
         np.savez(images_path, imgs)
 
@@ -280,7 +276,7 @@ def load_lfw(
             binary_attr = np.asarray(attributes["Male"])
             binary_attr = np.sign(binary_attr)
             binary_attr[binary_attr == -1] = 0
-            return dict(zip(range(len(binary_attr)), binary_attr))
+            return dict(zip(range(len(binary_attr)), binary_attr, strict=False))
         else:
             raise ValueError(attribute)
 
@@ -299,7 +295,7 @@ def load_lfw(
             indices.append(i)
             labels.append(np.argmax(a))
 
-        return dict(zip(indices, labels))
+        return dict(zip(indices, labels, strict=False))
 
     # Wrapper
     def _load_lfw_attr(attribute: str):
@@ -314,13 +310,13 @@ def load_lfw(
         imgs = f["arr_0"].transpose(0, 3, 1, 2)
 
     target_labels = _load_lfw_attr(target)
-    target_indices = [x for x in target_labels.keys()]
+    target_indices = list(target_labels.keys())
 
     sensitive_attr_1 = _load_lfw_attr(attribute_1)
-    sens_1_indices = [x for x in sensitive_attr_1.keys()]
+    sens_1_indices = list(sensitive_attr_1.keys())
 
     sensitive_attr_2 = _load_lfw_attr(attribute_2)
-    sens_2_indices = [x for x in sensitive_attr_2.keys()]
+    sens_2_indices = list(sensitive_attr_2.keys())
 
     # Align and normalize data
     common_indices = np.intersect1d(target_indices, sens_1_indices)

--- a/amulet/discriminatory_behavior/defenses/adversarial_debiasing.py
+++ b/amulet/discriminatory_behavior/defenses/adversarial_debiasing.py
@@ -1,10 +1,10 @@
 """Adversarial Debiasing Implementation"""
 
+import numpy as np
 import torch
 import torch.nn as nn
-import numpy as np
-from torch.utils.data import DataLoader
 from sklearn import metrics
+from torch.utils.data import DataLoader
 
 from .discr_behavior_defense import DicriminatoryBehaviorDefense
 
@@ -21,7 +21,7 @@ class AdversaryModel(nn.Module):
     """
 
     def __init__(self, n_sensitive_attrs: int = 2, n_classes: int = 2):
-        super(AdversaryModel, self).__init__()
+        super().__init__()
         self.network = nn.Sequential(
             nn.Linear(n_classes, 32),
             nn.ReLU(),
@@ -200,7 +200,7 @@ class AdversarialDebiasing(DicriminatoryBehaviorDefense):
 
         auc_race = float(metrics.roc_auc_score(race_true, new_race_pred))
         auc_sex = float(metrics.roc_auc_score(sex_true, new_sex_pred))
-        print("AUC [race]: {}, [sex]: {}".format(auc_race, auc_sex))
+        print(f"AUC [race]: {auc_race}, [sex]: {auc_sex}")
         return auc_race, auc_sex
 
     def __pretrain_adversary(self):

--- a/amulet/discriminatory_behavior/metrics/discriminatory_behavior.py
+++ b/amulet/discriminatory_behavior/metrics/discriminatory_behavior.py
@@ -1,8 +1,8 @@
-import torch
 import numpy as np
+import torch
 import torch.nn as nn
-from torch.utils.data import DataLoader
 from sklearn.metrics import accuracy_score
+from torch.utils.data import DataLoader
 
 
 class DiscriminatoryBehavior:
@@ -54,8 +54,8 @@ class DiscriminatoryBehavior:
         p_joint_att_positive = np.mean((predictions == 1) * (attributes == 1))
         p_joint_att_negative = np.mean((predictions == 1) * (attributes == 0))
 
-        p_margin_att_positive = np.mean((attributes == 1))
-        p_margin_att_negative = np.mean((attributes == 0))
+        p_margin_att_positive = np.mean(attributes == 1)
+        p_margin_att_negative = np.mean(attributes == 0)
 
         p_condition_att_positive = p_joint_att_positive / (p_margin_att_positive + 1e-8)
         p_condition_att_negative = p_joint_att_negative / (p_margin_att_negative + 1e-8)

--- a/amulet/distribution_inference/attacks/distribution_inference.py
+++ b/amulet/distribution_inference/attacks/distribution_inference.py
@@ -1,11 +1,12 @@
-import sys
-import torch
 import argparse
+import sys
+
 import numpy as np
 import pandas as pd
-from tqdm import tqdm
-from torch.utils.data import TensorDataset, ConcatDataset, DataLoader
+import torch
 from sklearn.model_selection import StratifiedShuffleSplit
+from torch.utils.data import ConcatDataset, DataLoader, TensorDataset
+from tqdm import tqdm
 
 
 def filter(df, condition, ratio, verbose=True):
@@ -15,7 +16,7 @@ def filter(df, condition, ratio, verbose=True):
     current_ratio = len(qualify) / (len(qualify) + len(notqualify))
     # If current ratio less than desired ratio, subsample from non-ratio
     if verbose:
-        print("Changing ratio from %.2f to %.2f" % (current_ratio, ratio))
+        print(f"Changing ratio from {current_ratio:.2f} to {ratio:.2f}")
     if current_ratio <= ratio:
         np.random.shuffle(notqualify)
         if ratio < 1:
@@ -90,10 +91,12 @@ def get_filter(df, filter_prop, split, ratio, dataset_name, is_test):
 
             def lambda_fn(x):
                 return x["sex"] == 1
+
         elif filter_prop == "race":
 
             def lambda_fn(x):
                 return x["race"] == 1
+
         else:
             print("Incorrect filter prop")
             sys.exit()
@@ -125,10 +128,12 @@ def get_filter(df, filter_prop, split, ratio, dataset_name, is_test):
 
             def lambda_fn(x):
                 return x["sex"] == 1
+
         elif filter_prop == "race":
 
             def lambda_fn(x):
                 return x["race"] == 1
+
         else:
             print("Incorrect filter prop")
             sys.exit()
@@ -515,8 +520,9 @@ class DistributionInference:
         preds /= np.max(preds, 0)
 
         preds = np.mean(preds, 1)
-        gt = np.concatenate(
-            (np.zeros(preds_first.shape[0]), np.ones(preds_second.shape[0]))
-        )
+        gt = np.concatenate((
+            np.zeros(preds_first.shape[0]),
+            np.ones(preds_second.shape[0]),
+        ))
         acc = 100 * np.mean((preds >= 0.5) == gt)
         return acc

--- a/amulet/evasion/attacks/projected_gradient_descent.py
+++ b/amulet/evasion/attacks/projected_gradient_descent.py
@@ -1,12 +1,12 @@
 """Evasion using Projected Gradient Descent implementation"""
 
-import torch
 import numpy as np
-from torch.nn import Module
-from torch.utils.data import DataLoader, TensorDataset
+import torch
 from cleverhans.torch.attacks.projected_gradient_descent import (
     projected_gradient_descent,
 )
+from torch.nn import Module
+from torch.utils.data import DataLoader, TensorDataset
 
 from .evasion_attack import EvasionAttack
 

--- a/amulet/evasion/defenses/projected_gradient_descent.py
+++ b/amulet/evasion/defenses/projected_gradient_descent.py
@@ -1,13 +1,13 @@
 """Adversarial Training implementation"""
 
+import numpy as np
 import torch
 import torch.nn as nn
-import numpy as np
-from torch.utils.data import DataLoader
-from torch.optim import Optimizer
 from cleverhans.torch.attacks.projected_gradient_descent import (
     projected_gradient_descent,
 )
+from torch.optim import Optimizer
+from torch.utils.data import DataLoader
 
 from .evasion_defense import EvasionDefense
 
@@ -112,7 +112,7 @@ class AdversarialTrainingPGD(EvasionDefense):
                 total += len(y)
 
             print(
-                f"Train Epoch: {epoch} Loss: {loss.item():.6f} Acc: {correct/total*100:.2f}"  # type: ignore[reportPossiblyUnboundVariable]
+                f"Train Epoch: {epoch} Loss: {loss.item():.6f} Acc: {correct / total * 100:.2f}"  # type: ignore[reportPossiblyUnboundVariable]
             )
 
         return self.model

--- a/amulet/membership_inference/attacks/lira.py
+++ b/amulet/membership_inference/attacks/lira.py
@@ -2,13 +2,15 @@
 
 import copy
 from pathlib import Path
+
+import numpy as np
+import scipy.stats
 import torch
 import torch.nn as nn
-import scipy.stats
-import numpy as np
+from torch.utils.data import DataLoader, Dataset
 from tqdm import tqdm
-from torch.utils.data import Dataset, DataLoader
-from .membership_inference_attack import MembershipInferenceAttack, InferenceModel
+
+from .membership_inference_attack import InferenceModel, MembershipInferenceAttack
 
 
 class LiRA(MembershipInferenceAttack):
@@ -150,7 +152,7 @@ class LiRA(MembershipInferenceAttack):
             Scores numpy array of shape (num_models, num_samples, num_trials).
         """
         pred_logits = copy.deepcopy(pred_logits)  # avoid modifying input
-        num_models, num_samples, num_trials, num_classes = pred_logits.shape
+        num_models, num_samples, num_trials, _num_classes = pred_logits.shape
         eps = 1e-45
 
         scores = np.zeros((num_models, num_samples, num_trials), dtype=np.float64)
@@ -241,7 +243,7 @@ class LiRA(MembershipInferenceAttack):
         final_preds = []
         true_labels = []
 
-        for ans, sc in zip(target_in_out_labels, target_scores):
+        for ans, sc in zip(target_in_out_labels, target_scores, strict=False):
             pr_in = -scipy.stats.norm.logpdf(sc, mean_in, std_in + 1e-30)
             pr_out = -scipy.stats.norm.logpdf(sc, mean_out, std_out + 1e-30)
             score = pr_in - pr_out
@@ -290,15 +292,12 @@ class LiRA(MembershipInferenceAttack):
 
         mean_out = np.median(dat_out, axis=1)
 
-        if fix_variance:
-            std_out = np.std(dat_out)
-        else:
-            std_out = np.std(dat_out, axis=1)
+        std_out = np.std(dat_out) if fix_variance else np.std(dat_out, axis=1)
 
         final_preds = []
         true_labels = []
 
-        for ans, sc in zip(target_in_out_labels, target_scores):
+        for ans, sc in zip(target_in_out_labels, target_scores, strict=False):
             score = scipy.stats.norm.logpdf(sc, mean_out, std_out + 1e-30)
             final_preds.extend(score.mean(axis=1))
             true_labels.extend(ans)

--- a/amulet/membership_inference/attacks/lira.py
+++ b/amulet/membership_inference/attacks/lira.py
@@ -243,7 +243,7 @@ class LiRA(MembershipInferenceAttack):
         final_preds = []
         true_labels = []
 
-        for ans, sc in zip(target_in_out_labels, target_scores, strict=False):
+        for ans, sc in zip(target_in_out_labels, target_scores, strict=True):
             pr_in = -scipy.stats.norm.logpdf(sc, mean_in, std_in + 1e-30)
             pr_out = -scipy.stats.norm.logpdf(sc, mean_out, std_out + 1e-30)
             score = pr_in - pr_out
@@ -297,7 +297,7 @@ class LiRA(MembershipInferenceAttack):
         final_preds = []
         true_labels = []
 
-        for ans, sc in zip(target_in_out_labels, target_scores, strict=False):
+        for ans, sc in zip(target_in_out_labels, target_scores, strict=True):
             score = scipy.stats.norm.logpdf(sc, mean_out, std_out + 1e-30)
             final_preds.extend(score.mean(axis=1))
             true_labels.extend(ans)

--- a/amulet/membership_inference/attacks/membership_inference_attack.py
+++ b/amulet/membership_inference/attacks/membership_inference_attack.py
@@ -4,10 +4,11 @@ import os
 import random
 from pathlib import Path
 
+import numpy as np
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader, Dataset, Subset
-import numpy as np
+
 from ...utils import initialize_model
 
 
@@ -135,7 +136,7 @@ class MembershipInferenceAttack:
             epoch_loss = train_loss / total
             epoch_acc = 100.0 * correct / total
             print(
-                f"Epoch {epoch+1}/{self.epochs} — Loss: {epoch_loss:.4f} — Acc: {epoch_acc:.2f}%"
+                f"Epoch {epoch + 1}/{self.epochs} — Loss: {epoch_loss:.4f} — Acc: {epoch_acc:.2f}%"
             )
             scheduler.step()
 
@@ -240,9 +241,9 @@ class InferenceModel(nn.Module):
         resume_checkpoint = (
             self.models_dir / f"{self.dataset}_shadow_{shadow_id}_{exp_id}.pth"
         )
-        assert os.path.isfile(
-            resume_checkpoint
-        ), f"Checkpoint not found at {resume_checkpoint}"
+        assert os.path.isfile(resume_checkpoint), (
+            f"Checkpoint not found at {resume_checkpoint}"
+        )
         checkpoint = torch.load(resume_checkpoint)
 
         self.model = initialize_model(

--- a/amulet/membership_inference/defenses/dp_sgd.py
+++ b/amulet/membership_inference/defenses/dp_sgd.py
@@ -2,8 +2,8 @@
 
 import torch
 import torch.nn as nn
-from torch.utils.data import DataLoader
 from opacus import PrivacyEngine
+from torch.utils.data import DataLoader
 
 from .membership_inference_defense import MembershipInferenceDefense
 
@@ -83,7 +83,7 @@ class DPSGD(MembershipInferenceDefense):
                 total += len(target)
                 if batch_idx % 2000 == 0:
                     print(
-                        f"Train Epoch: {epoch} Loss: {loss.item():.6f} Acc: {acc/total*100:.2f}"
+                        f"Train Epoch: {epoch} Loss: {loss.item():.6f} Acc: {acc / total * 100:.2f}"
                     )
             epsilon = self.privacy_engine.accountant.get_epsilon(delta=self.delta)
             print(

--- a/amulet/membership_inference/metrics/compute_mi_metrics.py
+++ b/amulet/membership_inference/metrics/compute_mi_metrics.py
@@ -33,10 +33,7 @@ def compute_mi_metrics(
 
     # Find the TPR at or just below the given FPR threshold
     valid_indices = np.where(fpr <= fpr_threshold)[0]
-    if len(valid_indices) == 0:
-        tpr_at_fpr = 0.0
-    else:
-        tpr_at_fpr = tpr[valid_indices[-1]]
+    tpr_at_fpr = 0.0 if len(valid_indices) == 0 else tpr[valid_indices[-1]]
 
     return {
         "auc": float(auc_score),

--- a/amulet/models/__init__.py
+++ b/amulet/models/__init__.py
@@ -1,10 +1,11 @@
 """
-The module mlconf.models includes utilities to build sample models.
+The module amulet.models includes utilities to build sample models.
 """
 
-from .vgg import VGG
+from .base import AmuletModel
+from .cnn import SimpleCNN
 from .linear_net import LinearNet
 from .resnet import ResNet
-from .cnn import SimpleCNN
+from .vgg import VGG
 
-__all__ = ["VGG", "LinearNet", "ResNet", "SimpleCNN"]
+__all__ = ["VGG", "AmuletModel", "LinearNet", "ResNet", "SimpleCNN"]

--- a/amulet/models/base.py
+++ b/amulet/models/base.py
@@ -1,0 +1,18 @@
+"""Shared base class for Amulet models."""
+
+import torch
+import torch.nn as nn
+
+
+class AmuletModel(nn.Module):
+    """Base class for models in `amulet/models/`.
+
+    Amulet pipelines (e.g. `get_intermediate_features`, `OutlierRemoval`) rely on
+    models exposing a `get_hidden` method that returns intermediate-layer activations.
+    Subclasses must override both `forward` and `get_hidden`; the default
+    `get_hidden` here mirrors `nn.Module.forward` and raises `NotImplementedError`
+    so the contract is enforced at runtime without an abstract-method metaclass.
+    """
+
+    def get_hidden(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError(f"{type(self).__name__} must implement `get_hidden`.")

--- a/amulet/models/cnn.py
+++ b/amulet/models/cnn.py
@@ -1,8 +1,10 @@
 import torch
 import torch.nn as nn
 
+from .base import AmuletModel
 
-class SimpleCNN(nn.Module):
+
+class SimpleCNN(AmuletModel):
     """
     Parameterized CNN for MNIST, similar to the one used in the BadNets paper.
 
@@ -18,8 +20,8 @@ class SimpleCNN(nn.Module):
 
     def __init__(
         self,
-        conv_channels_kernel: list[tuple[int, int]] = [(20, 5), (50, 5)],
-        fc_layers: list[int] = [500],
+        conv_channels_kernel: list[tuple[int, int]] | None = None,
+        fc_layers: list[int] | None = None,
         num_classes: int = 10,
         input_channels: int = 1,
     ):
@@ -37,6 +39,11 @@ class SimpleCNN(nn.Module):
         """
         super().__init__()
 
+        if conv_channels_kernel is None:
+            conv_channels_kernel = [(20, 5), (50, 5)]
+        if fc_layers is None:
+            fc_layers = [500]
+
         layers = []
         in_channels = input_channels
 
@@ -52,7 +59,8 @@ class SimpleCNN(nn.Module):
 
         self.features = nn.Sequential(*layers)
 
-        # Calculate flattened feature size after convs
+        # Calculate flattened feature size after convs.
+        # Hardcoded for 28x28 inputs (MNIST/FMNIST); does not generalize to other resolutions.
         spatial_size = 28
         for _ in conv_channels_kernel:
             spatial_size = spatial_size // 2  # Each MaxPool halves spatial size
@@ -60,7 +68,7 @@ class SimpleCNN(nn.Module):
         feature_dim = in_channels * (spatial_size**2)
 
         # Fully connected layers
-        fc_layers_full = [feature_dim] + fc_layers
+        fc_layers_full = [feature_dim, *fc_layers]
         fc_modules = []
         for i in range(len(fc_layers)):
             fc_modules.append(nn.Linear(fc_layers_full[i], fc_layers_full[i + 1]))

--- a/amulet/models/linear_net.py
+++ b/amulet/models/linear_net.py
@@ -3,8 +3,10 @@
 import torch
 import torch.nn as nn
 
+from .base import AmuletModel
 
-class LinearNet(nn.Module):
+
+class LinearNet(AmuletModel):
     """
     Builds a dense neural network for a multiclass image classification task.
 
@@ -22,10 +24,12 @@ class LinearNet(nn.Module):
         self,
         num_features: int,
         num_classes: int,
-        hidden_layer_sizes: list[int] = [128, 256, 128],
+        hidden_layer_sizes: list[int] | None = None,
         batch_norm: bool = True,
     ):
         super().__init__()
+        if hidden_layer_sizes is None:
+            hidden_layer_sizes = [128, 256, 128]
         self.num_features = num_features
         self.num_classes = num_classes
         self.batch_norm = batch_norm
@@ -53,11 +57,11 @@ class LinearNet(nn.Module):
         Runs the forward pass on the neural network.
 
         Args:
-            x: :class:`~torch.Tensor`
+            x: torch.Tensor
                 Input data
 
         Returns:
-            Output from the model of type :class:`~torch.Tensor`
+            Output from the model of type torch.Tensor
         """
         hidden_out = self.features(x)
         return self.classifier(hidden_out)
@@ -67,10 +71,10 @@ class LinearNet(nn.Module):
         Gets the intermediate layer output from the model.
 
         Args:
-            x: :class:`~torch.Tensor`
+            x: torch.Tensor
                 Input data to the model.
 
         Returns:
-            Output from the model of type :class:`~torch.Tensor`.
+            Output from the model of type torch.Tensor.
         """
         return self.features(x)

--- a/amulet/models/resnet.py
+++ b/amulet/models/resnet.py
@@ -1,10 +1,10 @@
 """PyTorch ResNet"""
 
-from typing import Callable
+from collections.abc import Callable
 
 import torch
-import torchvision
 import torch.nn as nn
+import torchvision
 from torchvision.models import (
     ResNet18_Weights,
     ResNet34_Weights,
@@ -14,16 +14,18 @@ from torchvision.models import (
 )
 from torchvision.models._api import WeightsEnum
 
+from .base import AmuletModel
+
 
 class Identity(nn.Module):
     def __init__(self):
-        super(Identity, self).__init__()
+        super().__init__()
 
     def forward(self, x):
         return x
 
 
-class ResNet(nn.Module):
+class ResNet(AmuletModel):
     def __init__(
         self,
         size: str = "resnet18",
@@ -47,10 +49,7 @@ class ResNet(nn.Module):
             "resnet152": ResNet152_Weights,
         }
 
-        if pretrained:
-            weights = self.weights_map[size]
-        else:
-            weights = None
+        weights = self.weights_map[size] if pretrained else None
 
         self.features = self.model_map[size](weights=weights)
         if replace_first:
@@ -59,7 +58,7 @@ class ResNet(nn.Module):
             )
             self.features.maxpool = nn.Identity()  # Remove aggressive downsampling
 
-        self.features.fc = Identity()  # type: ignore[reportAttributeAccessIssue]
+        self.features.fc = Identity()
 
         if size in ["resnet18", "resnet34"]:
             self.classifier = nn.Linear(512, num_classes)
@@ -80,11 +79,11 @@ class ResNet(nn.Module):
         Runs the forward pass on the neural network.
 
         Args:
-            x: :class:`~torch.Tensor`
+            x: torch.Tensor
                 Input data
 
         Returns:
-            Output from the model of type :class:`~torch.Tensor`
+            Output from the model of type torch.Tensor
         """
         x = self.features(x)
         x = self.classifier(x)
@@ -95,10 +94,10 @@ class ResNet(nn.Module):
         Gets the intermediate layer output from the model.
 
         Args:
-            x: :class:`~torch.Tensor`
+            x: torch.Tensor
                 Input data to the model.
 
         Returns:
-            Output from the model of type :class:`~torch.Tensor`.
+            Output from the model of type torch.Tensor.
         """
         return self.features(x)

--- a/amulet/models/vgg.py
+++ b/amulet/models/vgg.py
@@ -3,8 +3,10 @@
 import torch
 import torch.nn as nn
 
+from .base import AmuletModel
 
-class VGG(nn.Module):
+
+class VGG(AmuletModel):
     """
     Builds a VGG network. Code taken from
     https://github.com/kuangliu/pytorch-cifar/blob/master/models/vgg.py
@@ -22,24 +24,26 @@ class VGG(nn.Module):
     def __init__(
         self,
         num_classes: int = 10,
-        layer_config: list[int | str] = [
-            64,
-            "M",
-            128,
-            "M",
-            256,
-            256,
-            "M",
-            512,
-            512,
-            "M",
-            512,
-            512,
-            "M",
-        ],
+        layer_config: list[int | str] | None = None,
         batch_norm: bool = True,
     ) -> None:
         super().__init__()
+        if layer_config is None:
+            layer_config = [
+                64,
+                "M",
+                128,
+                "M",
+                256,
+                256,
+                "M",
+                512,
+                512,
+                "M",
+                512,
+                512,
+                "M",
+            ]
         self.batch_norm = batch_norm
         self.classifier = nn.Linear(512, num_classes)
         self.features = self._make_layers(layer_config)
@@ -74,11 +78,11 @@ class VGG(nn.Module):
         Runs the forward pass on the neural network.
 
         Args:
-            x: :class:`~torch.Tensor`
+            x: torch.Tensor
                 Input data
 
         Returns:
-            Output from the model of type :class:`~torch.Tensor`
+            Output from the model of type torch.Tensor
         """
         out = self.features(x)
         out = self.classifier(out)
@@ -89,10 +93,10 @@ class VGG(nn.Module):
         Gets the intermediate layer output from the model.
 
         Args:
-            x: :class:`~torch.Tensor`
+            x: torch.Tensor
                 Input data to the model.
 
         Returns:
-            Output from the model of type :class:`~torch.Tensor`.
+            Output from the model of type torch.Tensor.
         """
         return self.features(x)

--- a/amulet/poisoning/defenses/outlier_removal.py
+++ b/amulet/poisoning/defenses/outlier_removal.py
@@ -1,14 +1,14 @@
 """Outlier Removal implementation"""
 
-from typing import Callable
+from collections.abc import Callable
 
-import torch
-import torch.nn as nn
 import numpy as np
 import pandas as pd
+import torch
+import torch.nn as nn
 from torch.utils.data import DataLoader, TensorDataset
 
-from ...utils import train_classifier, get_intermediate_features
+from ...utils import get_intermediate_features, train_classifier
 from .poisoning_defense import PoisoningDefense
 
 
@@ -139,13 +139,11 @@ class OutlierRemoval(PoisoningDefense):
         normalized_scores = (shapley_scores - min(shapley_scores)) / (
             max(shapley_scores) - min(shapley_scores)
         )
-        df = pd.Series(
-            {
-                "Scores": np.array(normalized_scores),
-                "train_inputs": train_inputs,
-                "train_targets": train_targets,
-            }
-        )
+        df = pd.Series({
+            "Scores": np.array(normalized_scores),
+            "train_inputs": train_inputs,
+            "train_targets": train_targets,
+        })
 
         print("Retraining Model")
         # Remove a percentage of data records

--- a/amulet/unauth_model_ownership/attacks/model_extraction.py
+++ b/amulet/unauth_model_ownership/attacks/model_extraction.py
@@ -1,10 +1,10 @@
 """Model Extraction implementation"""
 
 import torch
-import torch.nn.functional as F
 import torch.nn as nn
-from torch.utils.data import DataLoader
+import torch.nn.functional as F
 from torch.optim import Optimizer
+from torch.utils.data import DataLoader
 
 
 class ModelExtraction:
@@ -121,7 +121,7 @@ class ModelExtraction:
             acc = 100.0 * correct / total
 
             print(
-                f"Epoch {epoch+1}/{self.epochs} | Loss: {avg_loss:.4f} | Acc: {acc:.2f}%"
+                f"Epoch {epoch + 1}/{self.epochs} | Loss: {avg_loss:.4f} | Acc: {acc:.2f}%"
             )
 
         return self.attack_model

--- a/amulet/unauth_model_ownership/defenses/fingerprint.py
+++ b/amulet/unauth_model_ownership/defenses/fingerprint.py
@@ -4,10 +4,10 @@ import time
 
 import torch
 import torch.nn as nn
-from tqdm.auto import tqdm
+from scipy.stats import ttest_ind
 from torch.nn import Module
 from torch.utils.data import DataLoader
-from scipy.stats import ttest_ind
+from tqdm.auto import tqdm
 
 
 class DatasetInference:
@@ -142,7 +142,7 @@ class DatasetInference:
                 loss = -1 * ((2 * y - 1) * (outputs.squeeze(-1))).mean()
                 loss.backward()
                 optimizer.step()
-                pbar.set_description("loss {}".format(loss.item()))
+                pbar.set_description(f"loss {loss.item()}")
 
         outputs_tr = {}
         outputs_te = {}
@@ -190,7 +190,7 @@ class DatasetInference:
         ).pvalue  # type: ignore[reportAttributeAccessIssue] https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.ttest_ind.html
         if pval < 0:
             raise Exception(f"p-value={pval}")
-        print(f"p-value = {pval} \t| Mean difference = {m1-m2}")
+        print(f"p-value = {pval} \t| Mean difference = {m1 - m2}")
 
         return pval, m1 - m2
 
@@ -206,12 +206,11 @@ class DatasetInference:
         ex_skipped = 0
         for i, batch in enumerate(loader):
             if (
-                self.regressor_embed == 1
-            ):  ##We need an extra set of `distinct images for training the confidence regressor
-                if ex_skipped < num_images:
-                    y = batch[1]
-                    ex_skipped += y.shape[0]
-                    continue
+                self.regressor_embed == 1 and ex_skipped < num_images
+            ):  # We need an extra set of distinct images for training the confidence regressor
+                y = batch[1]
+                ex_skipped += y.shape[0]
+                continue
             for j, distance in enumerate(["linf", "l2", "l1"]):
                 temp_list = []
                 for target_i in range(self.num_classes):
@@ -300,7 +299,7 @@ class DatasetInference:
             delta[remaining] = delta_r.detach()
 
         print(
-            f"Number of steps = {t+1} | Failed to convert = {(model(X+delta).max(1)[1]!=target).sum().item()} | Time taken = {time.time() - start}"
+            f"Number of steps = {t + 1} | Failed to convert = {(model(X + delta).max(1)[1] != target).sum().item()} | Time taken = {time.time() - start}"
         )
         if is_training:
             model.train()

--- a/amulet/unauth_model_ownership/defenses/watermark.py
+++ b/amulet/unauth_model_ownership/defenses/watermark.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-import torch
 import numpy as np
+import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader, TensorDataset
 from torchvision import transforms
@@ -83,18 +83,14 @@ class WatermarkNN:
             )
         else:
             if gray:
-                transform_wm = transforms.Compose(
-                    [
-                        transforms.CenterCrop((shape, shape)),
-                        transforms.Grayscale(num_output_channels=1),
-                    ]
-                )
+                transform_wm = transforms.Compose([
+                    transforms.CenterCrop((shape, shape)),
+                    transforms.Grayscale(num_output_channels=1),
+                ])
             else:
-                transform_wm = transforms.Compose(
-                    [
-                        transforms.CenterCrop((shape, shape)),
-                    ]
-                )
+                transform_wm = transforms.Compose([
+                    transforms.CenterCrop((shape, shape)),
+                ])
 
             labels_file = wm_path / "labels.csv"
             img_path = wm_path / "images"
@@ -114,11 +110,10 @@ class WatermarkNN:
         Return:
             Model with watermark embedded
         """
-        self.target_model
         criterion = torch.nn.CrossEntropyLoss()
         optimizer = torch.optim.Adam(self.target_model.parameters(), lr=1e-3)
         wm_inputs, wm_labels = [], []
-        for wm_idx, (wm_input, wm_label) in enumerate(self.wm_loader):
+        for _wm_idx, (wm_input, wm_label) in enumerate(self.wm_loader):
             wm_input, wm_label = wm_input.to(self.device), wm_label.to(self.device)
             wm_inputs.append(wm_input)
             wm_labels.append(wm_label)
@@ -150,7 +145,7 @@ class WatermarkNN:
                 total += len(target)
                 if batch_idx % 2000 == 0:
                     print(
-                        f"Train Epoch: {epoch} Loss: {loss.item():.6f} Acc: {acc/total*100:.2f}"
+                        f"Train Epoch: {epoch} Loss: {loss.item():.6f} Acc: {acc / total * 100:.2f}"
                     )
                     self.verify(self.target_model)
                     self.target_model.train()
@@ -184,9 +179,6 @@ class WatermarkNN:
 
         watermark_accuracy = correct / total
 
-        print("Watermark Accuracy: {:.2f}".format(watermark_accuracy))
+        print(f"Watermark Accuracy: {watermark_accuracy:.2f}")
 
-        if watermark_accuracy > threshold:
-            return True
-        else:
-            return False
+        return watermark_accuracy > threshold

--- a/amulet/utils/__base.py
+++ b/amulet/utils/__base.py
@@ -2,10 +2,16 @@
 Utilities to train and provide white-box access to models.
 """
 
+import logging
+from collections.abc import Callable
+from pathlib import Path
+
+import numpy as np
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader, TensorDataset
-import numpy as np
+
+from ..models import AmuletModel
 
 
 def train_classifier(
@@ -19,28 +25,20 @@ def train_classifier(
     early_stopping_patience: int = 25,
 ) -> nn.Module:
     """
-    Trains a classifier.
+    Train a classifier.
 
     Args:
-        model: :class:`~torch.nn.Module`
-            Model to be trained.
-        data_loader: :class:'~torch.utils.data.DataLoader`
-            Data used to train the model.
-        criterion: :class:`~torch.nn.Module`
-            Loss function for training model.
-        optimizer: :class:`~torch.optim.Optimizer`
-            Optimizer for training model.
-        epochs: int
-            Determines number of iterations over training data.
-        device: str
-            Device used to train model. Example: "cuda:0".
-        scheduler: :class:`~torch.optim.lr_scheduler._LRScheduler`
-            LR scheduler.
-        early_stopping_patience: int
-            Stop if no accuracy improvement after this many epochs.
+        model: Model to be trained.
+        data_loader: Data used to train the model.
+        criterion: Loss function for training model.
+        optimizer: Optimizer for training model.
+        epochs: Number of iterations over training data.
+        device: Device used to train model. Example: "cuda:0".
+        scheduler: LR scheduler.
+        early_stopping_patience: Stop if no accuracy improvement after this many epochs.
 
     Returns:
-        Trained model of type :class:`~torch.nn.Module`.
+        Trained model.
     """
     model.train()
     best_acc = 0.0
@@ -88,24 +86,68 @@ def train_classifier(
     return model
 
 
+def load_or_train(
+    path: Path,
+    init_fn: Callable[[], nn.Module],
+    train_fn: Callable[[nn.Module], nn.Module],
+    log: logging.Logger | None = None,
+    description: str = "model",
+) -> nn.Module:
+    """
+    Load a model checkpoint if it exists, otherwise train and save one.
+
+    Collapses the standard `if checkpoint.exists(): load else train+save` block
+    that every example pipeline reimplements. The caller supplies two closures:
+    `init_fn` returns a freshly initialised model, and `train_fn` trains it.
+    On a cache miss, `init_fn` is invoked, the result is trained via `train_fn`,
+    and its state_dict is saved to `path` (parent directories created as needed).
+    On a cache hit, `init_fn` is invoked and its state_dict is loaded from `path`.
+
+    Args:
+        path: Checkpoint file path. Parent directories are created on save.
+        init_fn: Zero-argument callable returning a fresh `nn.Module` already on
+            the target device.
+        train_fn: Callable that takes the freshly initialised model and returns
+            the trained model. Responsible for optimizer, loaders, and epochs.
+        log: Optional logger for progress messages.
+        description: Short noun phrase describing the model, used in log lines
+            (e.g. "target model", "defended model", "shadow model").
+
+    Returns:
+        The loaded or newly trained model.
+    """
+    if path.exists():
+        if log:
+            log.info("Loading %s from %s", description, path)
+        model = init_fn()
+        model.load_state_dict(torch.load(path, weights_only=True))
+        return model
+
+    if log:
+        log.info("Training %s", description)
+    model = init_fn()
+    model = train_fn(model)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(model.state_dict(), path)
+    if log:
+        log.info("Saved %s to %s", description, path)
+    return model
+
+
 def get_predictions_numpy(
     input_data: np.ndarray, model: nn.Module, batch_size: int, device: str
 ) -> np.ndarray:
     """
-    Helper function to get predictions from a model from a numpy array and return them as a numpy array.
+    Get predictions from a model for numpy input and return as a numpy array.
 
     Args:
-        input_data: :class:`~np.ndarray`
-            The input for the model.
-        model: :class:`nn.Module`
-            Get predictions from this model.
-        batch_size: int
-            Batch size for the data loader.
-        device: str
-            Device used for computation.
+        input_data: The input for the model.
+        model: Model to get predictions from.
+        batch_size: Batch size for the data loader.
+        device: Device used for computation.
 
     Returns:
-        Predictions of type :class:`~np.ndarray`.
+        Model predictions as a numpy array.
     """
     dataloader = DataLoader(
         dataset=TensorDataset(torch.from_numpy(input_data).type(torch.float32)),
@@ -125,28 +167,18 @@ def get_predictions_numpy(
 
 
 def get_intermediate_features(
-    model: nn.Module, data_loader: DataLoader, device: str
+    model: AmuletModel, data_loader: DataLoader, device: str
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
-    Gets the intermediate layer output of a model.
+    Get intermediate layer outputs, labels, and inputs from a model.
 
     Args:
-        model: :class:`~torch.nn.Module`
-            Model to get intermediate layer outputs from.
-            Assumes model has a .get_hidden() function.
-            See sample models in src.models.
-        data_loader: :class:'~torch.utils.data.DataLoader
-            Input data to the model.
-        device: str
-            Device used for inference. Example: "cuda:0".
+        model: Amulet model to get intermediate outputs from.
+        data_loader: Input data to the model.
+        device: Device used for inference. Example: "cuda:0".
 
     Returns:
-        A tuple containing:
-            The intermediate layer output of the model of type :class:`~torch.Tensor`.
-
-            The labels of type :class:`~torch.Tensor`.
-
-            The inputs of type :class:`~torch.Tensor`.
+        Tuple of (intermediate features, labels, inputs) as numpy arrays.
     """
     model.eval()
     features = []
@@ -155,14 +187,14 @@ def get_intermediate_features(
     with torch.no_grad():
         for x, y in data_loader:
             x, y = x.to(device), y.to(device)
-            feature = model.get_hidden(x).data.cpu().numpy()  # type: ignore[misc]
+            feature = model.get_hidden(x).data.cpu().numpy()
 
             features.append(feature)
             targets.append(y.data.cpu().numpy())
             inputs.append(x.data.cpu().numpy())
 
-    features = np.concatenate(np.array(features, dtype=object))
-    targets = np.concatenate(np.array(targets, dtype=object))
-    inputs = np.concatenate(np.array(inputs, dtype=object))
+    features = np.concatenate(features, axis=0)
+    targets = np.concatenate(targets, axis=0)
+    inputs = np.concatenate(inputs, axis=0)
 
     return features, targets, inputs

--- a/amulet/utils/__init__.py
+++ b/amulet/utils/__init__.py
@@ -1,23 +1,29 @@
 """
-The module mlconf.utils contains utilities
+The module amulet.utils contains utilities
 for model training and evaluation.
 """
 
+from .__base import (
+    get_intermediate_features,
+    get_predictions_numpy,
+    load_or_train,
+    train_classifier,
+)
 from .__metrics import (
     get_accuracy,
+    get_fidelity,
 )
-
-from .__base import train_classifier, get_intermediate_features, get_predictions_numpy
-
-from .__pipeline import load_data, stratified_split, create_dir, initialize_model
+from .__pipeline import create_dir, initialize_model, load_data, stratified_split
 
 __all__ = [
-    "train_classifier",
-    "get_accuracy",
-    "get_predictions_numpy",
-    "get_intermediate_features",
-    "load_data",
-    "stratified_split",
     "create_dir",
+    "get_accuracy",
+    "get_fidelity",
+    "get_intermediate_features",
+    "get_predictions_numpy",
     "initialize_model",
+    "load_data",
+    "load_or_train",
+    "stratified_split",
+    "train_classifier",
 ]

--- a/amulet/utils/__meta_classifiers.py
+++ b/amulet/utils/__meta_classifiers.py
@@ -1,0 +1,126 @@
+"""Neural architectures for meta-inference (Inference about models)."""
+
+import torch
+import torch.nn as nn
+
+
+class PermInvModel(nn.Module):
+    """
+    Permutation Invariant Model (PIM) for processing model parameters.
+
+    Processes layers of a model (weights and biases) while maintaining
+    invariance to the permutation of neurons within those layers. Each
+    neuron is processed through a mini-network, and the results are
+    aggregated using sum-pooling.
+
+    Attributes:
+        layer_shapes: List of (N_neurons, Dim_per_neuron) for each layer.
+        inside_dims: Hidden dimensions for the mini-networks.
+        dropout: Dropout rate for regularization.
+        n_classes: Number of output classes for the meta-classifier.
+    """
+
+    def __init__(
+        self,
+        layer_shapes: list[tuple[int, int]],
+        inside_dims: list[int] | None = None,
+        dropout: float = 0.5,
+        n_classes: int = 1,
+    ):
+        super().__init__()
+        self.layer_shapes = layer_shapes
+        self.inside_dims = inside_dims or [64, 8]
+        self.dropout = dropout
+
+        self.mini_nets = nn.ModuleList()
+        prev_rep_size = 0
+
+        for _n_neurons, dim in layer_shapes:
+            # Each neuron sees its own weights (dim) + sum-pooled representation
+            # from the previous layer (prev_rep_size).
+            input_dim = dim + prev_rep_size
+            self.mini_nets.append(self._make_mini_net(input_dim))
+            # The next layer will see H as context (pooled)
+            prev_rep_size = self.inside_dims[-1]
+
+        # Final classifier to combine aggregated representations from all layers
+        self.rho = nn.Linear(len(layer_shapes) * self.inside_dims[-1], n_classes)
+
+    def _make_mini_net(self, input_dim: int) -> nn.Sequential:
+        layers = [nn.Linear(input_dim, self.inside_dims[0]), nn.ReLU()]
+        for i in range(1, len(self.inside_dims)):
+            layers.append(nn.Linear(self.inside_dims[i - 1], self.inside_dims[i]))
+            layers.append(nn.ReLU())
+        layers.append(nn.Dropout(self.dropout))
+        return nn.Sequential(*layers)
+
+    def forward(self, layer_params_list: list[torch.Tensor]) -> torch.Tensor:
+        """
+        Forward pass for the PIM.
+
+        Args:
+            layer_params_list: List of tensors, one per layer,
+                               each with shape [Batch, N_neurons, Dim].
+
+        Returns:
+            Logits for the meta-classification decision.
+        """
+        reps = []
+        for_prev = None
+
+        for _i, (param, net) in enumerate(
+            zip(layer_params_list, self.mini_nets, strict=False)
+        ):
+            # param shape: [Batch, N_neurons, Dim]
+            if param.size(1) != self.layer_shapes[_i][0]:
+                raise ValueError(
+                    f"Layer {_i} expects {self.layer_shapes[_i][0]} neurons, "
+                    f"got {param.size(1)}"
+                )
+
+            if for_prev is not None:
+                # for_prev is [Batch, 1, H] (sum-pooled context from previous layer)
+                # Repeat for each neuron in the current layer
+                prev_rep = for_prev.repeat(1, param.size(1), 1)
+                param_eff = torch.cat([param, prev_rep], dim=-1)
+            else:
+                param_eff = param
+
+            # Flatten batch and neuron dims for the mini-net
+            batch_size, n_neurons, dim_eff = param_eff.shape
+            pp = net(param_eff.view(batch_size * n_neurons, dim_eff))
+            pp = pp.view(batch_size, n_neurons, -1)  # [Batch, N_neurons, H]
+
+            # Sum-pool across the neuron dimension (Invariance step!)
+            processed = torch.sum(pp, dim=1)  # [Batch, H]
+            reps.append(processed)
+
+            # Pass aggregated representation as context for the next layer
+            # This maintains invariance because 'processed' is already pooled.
+            for_prev = processed.view(batch_size, 1, -1)  # [Batch, 1, H]
+
+        combined = torch.cat(reps, dim=1)  # [Batch, Layers * H]
+        return self.rho(combined)
+
+
+def meta_collate_fn(batch: list[tuple[list[torch.Tensor], int]]):
+    """
+    Custom collate function for model-as-data batches.
+
+    Args:
+        batch: List of (layer_params, label) tuples.
+               layer_params is a list of [N_neurons, Dim] tensors.
+
+    Returns:
+        Tuple of (batched_layer_params, labels).
+        batched_layer_params is a list of [Batch, N_neurons, Dim] tensors.
+    """
+    labels = torch.tensor([item[1] for item in batch])
+    num_layers = len(batch[0][0])
+    batched_params = []
+
+    for i in range(num_layers):
+        layer_batch = torch.stack([item[0][i] for item in batch])
+        batched_params.append(layer_batch)
+
+    return batched_params, labels

--- a/amulet/utils/__meta_classifiers.py
+++ b/amulet/utils/__meta_classifiers.py
@@ -69,7 +69,7 @@ class PermInvModel(nn.Module):
         for_prev = None
 
         for _i, (param, net) in enumerate(
-            zip(layer_params_list, self.mini_nets, strict=False)
+            zip(layer_params_list, self.mini_nets, strict=True)
         ):
             # param shape: [Batch, N_neurons, Dim]
             if param.size(1) != self.layer_shapes[_i][0]:

--- a/amulet/utils/__metrics.py
+++ b/amulet/utils/__metrics.py
@@ -13,25 +13,22 @@ def get_accuracy(
     device: str,
 ) -> float:
     """
-    Calculates the classification accuracy of a model.
+    Calculate classification accuracy of a model.
 
     Args:
-        model: :class:`~nn.Module`
-            The model to evaluate.
-        data_loader: :class:'~torch.utils.data.DataLoader
-            Input data to the model.
-        device: str
-            Device used for inference. Example: "cuda:0".
+        model: The model to evaluate.
+        data_loader: Input data to the model.
+        device: Device used for inference. Example: "cuda:0".
 
     Returns:
-        The accuracy of the model.
+        Accuracy as a percentage.
     """
     model.eval()
     correct = 0
     total = 0
     with torch.no_grad():
-        for tuple in data_loader:
-            x, y = tuple[0].to(device), tuple[1].to(device)
+        for batch in data_loader:
+            x, y = batch[0].to(device), batch[1].to(device)
             outputs = model(x)
             _, predictions = torch.max(outputs.data, 1)
             total += y.size(0)
@@ -47,20 +44,16 @@ def get_fidelity(
     device: str,
 ) -> float:
     """
-    Calculates the agreement in predictions (fidelity) of two models.
+    Calculate prediction agreement (fidelity) between two models.
 
     Args:
-        model: :class:`~nn.Module`
-            One of the models to compare.
-        model: :class:`~nn.Module`
-            One of the models to compare.
-        data_loader: :class:'~torch.utils.data.DataLoader
-            Input data to the models.
-        device: str
-            Device used for inference. Example: "cuda:0".
+        model_1: First model to compare.
+        model_2: Second model to compare.
+        data_loader: Input data to the models.
+        device: Device used for inference. Example: "cuda:0".
 
     Returns:
-        The agreement (fidelity) between two models.
+        Fidelity as a percentage.
     """
     model_1.eval()
     model_2.eval()

--- a/amulet/utils/__pipeline.py
+++ b/amulet/utils/__pipeline.py
@@ -2,28 +2,25 @@
 Utilities to help build an ML pipeline.
 """
 
-import sys
 import logging
 from pathlib import Path
 from typing import TypedDict
 
 import torch
-import torch.nn as nn
-from torch.utils.data import random_split, Dataset, Subset
-
 from sklearn.model_selection import train_test_split
+from torch.utils.data import Dataset, Subset, random_split
 
-from ..models import VGG, LinearNet, ResNet, SimpleCNN
 from ..datasets import (
+    AmuletDataset,
+    load_celeba,
     load_census,
     load_cifar10,
     load_cifar100,
     load_fmnist,
-    load_mnist,
     load_lfw,
-    load_celeba,
-    AmuletDataset,
+    load_mnist,
 )
+from ..models import VGG, AmuletModel, LinearNet, ResNet, SimpleCNN
 
 
 def load_data(
@@ -35,19 +32,18 @@ def load_data(
     celeba_target: str = "Smiling",
 ) -> AmuletDataset:
     """
-    Loads data given the dataset and the training size.
+    Load data given the dataset name and training size.
 
     Args:
-        root: :class:~`pathlib.Path` or str
-            Root directory of pipeline
-        dataset: str
-            Name of the dataset.
-        training_size: float
-            Proportion of training data to use.
-        log: :class:~`logging.Logger`
-            Logging facility.
-        exp_id: int
-            Used as a random seed.
+        root: Root directory of the pipeline.
+        dataset: Name of the dataset. Options: "cifar10", "cifar100", "fmnist", "mnist", "census", "lfw", "celeba".
+        training_size: Proportion of training data to use.
+        log: Logging facility.
+        exp_id: Used as a random seed.
+        celeba_target: Target attribute for CelebA. Example: "Smiling".
+
+    Returns:
+        Loaded dataset as an AmuletDataset.
     """
 
     if isinstance(root, str):
@@ -72,13 +68,7 @@ def load_data(
             root / "data" / "celeba", random_seed=exp_id, target_attribute=celeba_target
         )
     else:
-        if log:
-            log.info(
-                "Line 42, mlconf.utils._pipeline.py: Incorrect dataset configuration"
-            )
-        else:
-            print("Line 44, mlconf.utils._pipeline.py: Incorrect dataset configuration")
-        sys.exit()
+        raise ValueError(f"Unknown dataset: {dataset!r}")
 
     if training_size < 1.0:
         if data.x_train is not None:
@@ -93,11 +83,11 @@ def load_data(
         new_train_size = int(training_size * len(data.train_set))  # type: ignore[reportAttributeAccessIssue]
         generator = torch.Generator().manual_seed(exp_id)
         train_set, _ = random_split(
-            data.train_set,  # type: ignore[reportAttributeAccessIssue]
+            data.train_set,
             [new_train_size, len(data.train_set) - new_train_size],  # type: ignore[reportAttributeAccessIssue]
             generator=generator,
         )
-        data.train_set = train_set  # type: ignore[reportAttributeAccessIssue]
+        data.train_set = train_set
 
     return data
 
@@ -106,7 +96,7 @@ def stratified_split(
     dataset: Dataset,
     split_ratio: float,
     seed: int = 42,
-) -> tuple[Dataset, Dataset]:
+) -> tuple[Subset, Subset]:
     """
     Split a dataset into two stratified subsets.
 
@@ -134,16 +124,14 @@ def stratified_split(
 
 def create_dir(path: Path | str, log: logging.Logger | None = None) -> Path:
     """
-    Create directory using provided path.
+    Create directory at the provided path.
 
     Args:
-        path: :class:~`pathlib.Path` or str
-            Directory to be created.
-        log: :class:~`logging.Logger` or None
-            Logging facility.
+        path: Directory to be created.
+        log: Logging facility.
 
     Returns:
-        Path to the created directory.
+        Resolved path to the created directory.
     """
     if isinstance(path, str):
         path = Path(path)
@@ -295,7 +283,7 @@ def initialize_model(
     batch_norm: bool = True,
     model_conf: CapacityMap = DEFAULT_CAPACITY_MAP,
     resnet_replace_first: bool = True,
-) -> nn.Module:
+) -> AmuletModel:
     """
     Creates a model using the provided configuration.
 
@@ -318,8 +306,8 @@ def initialize_model(
             Whether to replace the first conv layer of ResNet with a smaller filter. Defaults to True.
 
     Returns:
-        nn.Module
-            Initialized PyTorch model instance.
+        AmuletModel
+            Initialized PyTorch model instance with a `get_hidden` method.
     """
     if model_capacity not in model_conf:
         raise KeyError(f"Capacity '{model_capacity}' not found in model_conf")
@@ -367,10 +355,5 @@ def initialize_model(
         else:
             print(msg)
         raise ValueError(msg)
-
-    # if log:
-    #     log.info("Model initialized: %s", model)
-    # else:
-    #     print(f"Model initialized: {model}")
 
     return model

--- a/amulet/utils/__weight_extraction.py
+++ b/amulet/utils/__weight_extraction.py
@@ -1,0 +1,46 @@
+"""Utilities to extract model parameters as features for meta-inference."""
+
+from typing import cast
+
+import torch
+import torch.nn as nn
+
+
+def get_layer_parameters(model: nn.Module) -> list[torch.Tensor]:
+    """
+    Extract weights and biases from Linear and Conv2d layers.
+
+    Captures the parameters of the model and formats them as a list of tensors,
+    where each tensor represents one layer. The output is formatted to support
+    permutation-invariant processing (one row per neuron/channel).
+
+    Args:
+        model: Model to extract parameters from.
+
+    Returns:
+        List of tensors, one per layer, with shape [N_neurons, Dim_per_neuron].
+    """
+    features = []
+    # Unwrap DataParallel/DistributedDataParallel if present
+    base_model = cast(nn.Module, model.module if hasattr(model, "module") else model)
+
+    for _, module in base_model.named_modules():
+        if isinstance(module, (nn.Linear, nn.Conv2d)):
+            # Weight shape for Linear: [out_features, in_features]
+            # Weight shape for Conv2d: [out_channels, in_channels, k_h, k_w]
+            w = module.weight.data.detach().cpu()
+
+            if isinstance(module, nn.Conv2d):
+                # Flatten Conv kernels: [out, in*k*k]
+                w = w.view(w.size(0), -1)
+
+            # Append bias if it exists: [out, feat] -> [out, feat + 1]
+            if module.bias is not None:
+                b = module.bias.data.detach().cpu().unsqueeze(1)
+                layer_feat = torch.cat([w, b], dim=1)
+            else:
+                layer_feat = w
+
+            features.append(layer_feat)
+
+    return features

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,16 +11,18 @@ Each issue should include a title and a description of the error you are facing.
 ### Feature Requests
 
 Since this is a growing package, we welcome new feature requests! However, remember that you may need to write the code for a feature yourself. Depending on the type of feature you want, there are slightly different requirements. Some examples are:
+
 - **Requesting a utility for an ML Pipeline.**
-If this is an easy fix and we feel this would be helpful to many users facing the same issue, we would love to work with you on this to make it happen!
+  If this is an easy fix and we feel this would be helpful to many users facing the same issue, we would love to work with you on this to make it happen!
 - **Adding a new risk or defense.**
-Are you a researcher who has discovered a new risk or way to defend against known risks? We welcome your contributions! However, in most cases, we only include state-of-the-art risks or defenses in our package. The package aims to allow other users to test their models against known risks or defenses or enable researchers to test their techniques against the current state-of-the-art. Thus, having a peer-reviewed paper to justify adding a new risk or defense would be nice.
+  Are you a researcher who has discovered a new risk or way to defend against known risks? We welcome your contributions! However, in most cases, we only include state-of-the-art risks or defenses in our package. The package aims to allow other users to test their models against known risks or defenses or enable researchers to test their techniques against the current state-of-the-art. Thus, having a peer-reviewed paper to justify adding a new risk or defense would be nice.
 
 ## Contributing Code
 
 For new functionalities that help with an ML pipeline, please submit an issue, and we can work together to find the best way to incorporate the utility. For a module comprising a new risk or defense, we strongly urge you to follow the same coding conventions as the rest of the package. Please follow the tutorial below to add a new module.
 
 **For all contributions:**
+
 - **Submit an issue describing the contribution**.
 - **Fork or clone the library.**
 - **Create a new branch for your contribution.**
@@ -56,6 +58,7 @@ To install all dev dependencies:
 #### Using uv
 
 When you add or modify dependencies in `pyproject.toml`:
+
 - Run `uv lock` to update the lock file
 - Run `uv sync` to install the updated dependencies
 
@@ -85,18 +88,22 @@ def load_<name_of_dataset> (
 	return_x_y: Optional[boolean] # flag used to return NumPy arrays, if applicable
 ) -> sklearn.utils.Bunch
 ```
+
 Note that the output is a [`sklearn.utils.Bunch`](https://scikit-learn.org/stable/modules/generated/sklearn.utils.Bunch.html) object, a dictionary-like object of the format:
+
 ```python
 {
 	train_set: torch.utils.data.TensorDataset,
 	test_set: torch.utils.data.TensorDataset
 }
 ```
+
 Please follow these steps to add a new function to load a dataset:
+
 1. Write a function that will download the dataset, preprocess it, and split it into train and test sets (see function template above). Example code: [`amulet/datasets/_tabular_datasets.py:load_census()`](https://github.com/ssg-research/amulet/blob/main/amulet/datasets/_tabular_datasets.py#L21). Please ensure the following when:
-    * **Downloading**: Ensure download location is passed as a parameter. Example code: [`amulet/datasets/_tabular_datasets.py:L72-81`](https://github.com/ssg-research/amulet/blob/main/amulet/datasets/_tabular_datasets.py#L72-L81).
-    * **Preprocessing**: Ensure the data types are correct, engineer features, etc. Example code: [`amulet/datasets/_tabular_datasets.py:L83-91`](https://github.com/ssg-research/amulet/blob/main/amulet/datasets/_tabular_datasets.py#L83-L91).
-    * **Splitting**: Ensure any randomized splitting uses a random seed. Example code: [`amulet/datasets/_tabular_datasets.py:L94-99`](https://github.com/ssg-research/amulet/blob/main/amulet/datasets/_tabular_datasets.py#L94-L99).
+   - **Downloading**: Ensure download location is passed as a parameter. Example code: [`amulet/datasets/_tabular_datasets.py:L72-81`](https://github.com/ssg-research/amulet/blob/main/amulet/datasets/_tabular_datasets.py#L72-L81).
+   - **Preprocessing**: Ensure the data types are correct, engineer features, etc. Example code: [`amulet/datasets/_tabular_datasets.py:L83-91`](https://github.com/ssg-research/amulet/blob/main/amulet/datasets/_tabular_datasets.py#L83-L91).
+   - **Splitting**: Ensure any randomized splitting uses a random seed. Example code: [`amulet/datasets/_tabular_datasets.py:L94-99`](https://github.com/ssg-research/amulet/blob/main/amulet/datasets/_tabular_datasets.py#L94-L99).
 2. Add this function into the appropriate file: `amulet/datasets/_tabular_datasets.py` for 1-dimensional datasets and `amulet/datasets/_image_datasets.py` for 2-dimensional datasets.
 3. Import your function in [`amulet/datasets/__init__.py`](https://github.com/ssg-research/amulet/blob/main/amulet/datasets/__init__.py).
 4. Add the appropriate if condition in [`amulet/utils/_pipeline.py/load_data()`](https://github.com/ssg-research/amulet/blob/main/amulet/utils/_pipeline.py).
@@ -104,6 +111,7 @@ Please follow these steps to add a new function to load a dataset:
 ### Adding a model architecture
 
 Please follow these steps to add a new model architecture to Amulet:
+
 1. Create a file in `amulet/models/` that defines a model as a `nn.Module` subclass.
 2. We recommend including a `get_hidden()` function in the model since some modules use it. This function outputs the model's hidden layer activations. Example code: [`amulet/models/vgg.py:L65-76`](https://github.com/ssg-research/amulet/blob/main/amulet/models/vgg.py#L65-L76).
 3. Import the new model into `amulet/models/__init__.py`. For example, `from model_file import model_name`.
@@ -116,15 +124,16 @@ The first step is to decide which risk the new module interacts with. For detail
 ### Adding an attack or a defense
 
 The general template of an attack or defense:
+
 - Inputs:
-    - Target Model
-    - Hyperparameters (include reasonable default values)
-    - Other attributes or methods required by the class
+  - Target Model
+  - Hyperparameters (include reasonable default values)
+  - Other attributes or methods required by the class
 - Main Algorithm:
-    - Code logic to run the attack or defense
+  - Code logic to run the attack or defense
 - Outputs:
-    - Output of the attack OR
-    - Defended model
+  - Output of the attack OR
+  - Defended model
 
 Please refer to the Module Templates (link TBD) for an idea of the outputs for our existing modules. This ensures that new attacks or defenses can be compared to old ones using the same code. **If introducing a new metric, please make two separate contributions for the metric and the new attack or defense.**
 
@@ -137,36 +146,42 @@ There is no set template for metrics. Please include in-code documentation about
 ### Steps
 
 Once a rough template has been sketched out, please follow these steps for adding code:
+
 1. Create a file in the appropriate directory as follows:
 
-    `amulet/<risk>/<defense/attack/metric>/new_module.py`
+   `amulet/<risk>/<defense/attack/metric>/new_module.py`
 
-    For example, if your module is a new defense for evasion, create the file as follows:
+   For example, if your module is a new defense for evasion, create the file as follows:
 
-    `amulet/evasion/defense/new_module.py`
+   `amulet/evasion/defense/new_module.py`
+
 2. Create a class. We follow a convention for all our attacks and defenses:
-    1. Create a subclass using the Base class for the attack/defense you want to add. For example, to add a new evasion attack, you can use the following code:
-        ```python
 
-        from .evasion import Evasion
-        class newEvasionAttack(Evasion):
-            def __init__(
-                model,
-                test_loader,
-                device,
-                batch_size,
-                param1,
-                param2
-            ):
-                super().__init__(model, test_loader, device, batch_size)
-                self.param1 = param1
-                self.param2 = param2
-        ```
-    2. The `__init__()` method should have most of the parameters required to run the technique. This allows users to use functions like `__getattr__()` to log the parameters while running the technique. Optional parameters may go in other methods.
-    3. Where possible, use the utils available in the package.
-    4. If your module uses hyperparameters, please recommend a reasonable default value.
-    5. Add docstrings to the class and methods, including the recommended range for specific hyperparameters for your technique. Please use the modules we have written as a reference for formatting these.
-    6. We follow the convention of prefixing the method with an underscore for private attributes and methods in the class.
+   1. Create a subclass using the Base class for the attack/defense you want to add. For example, to add a new evasion attack, you can use the following code:
+
+      ```python
+
+      from .evasion import Evasion
+      class newEvasionAttack(Evasion):
+          def __init__(
+              model,
+              test_loader,
+              device,
+              batch_size,
+              param1,
+              param2
+          ):
+              super().__init__(model, test_loader, device, batch_size)
+              self.param1 = param1
+              self.param2 = param2
+      ```
+
+   2. The `__init__()` method should have most of the parameters required to run the technique. This allows users to use functions like `__getattr__()` to log the parameters while running the technique. Optional parameters may go in other methods.
+   3. Where possible, use the utils available in the package.
+   4. If your module uses hyperparameters, please recommend a reasonable default value.
+   5. Add docstrings to the class and methods, including the recommended range for specific hyperparameters for your technique. Please use the modules we have written as a reference for formatting these.
+   6. We follow the convention of prefixing the method with an underscore for private attributes and methods in the class.
+
 3. Please include the code to download any files or data the module requires.
 4. Add an example script in `<TBD>` to show how to use your technique. Please look at the existing examples to understand how to use them.
 5. Run PyLint on your code using the pylintrc file in the repo to validate the code style.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,36 +1,46 @@
-
 # Features
 
 We provide a high-level list of features below.
 
 ## Datasets
+
 Amulet provides the following for computer vision tasks:
+
 - [CIFAR10](https://pytorch.org/vision/main/generated/torchvision.datasets.CIFAR10.html).
 - [FashionMNIST](https://pytorch.org/vision/stable/generated/torchvision.datasets.FashionMNIST.html).
 - [CelebA](https://mmlab.ie.cuhk.edu.hk/projects/CelebA.html). Or download the [CSV version](https://drive.google.com/file/d/1KTaJraB9Koa4h5EVTJQ3y2Dig_vgE5MZ/view?usp=sharing).
 
 Amulet pre-processes and provides the following datasets to test for privacy-related concerns:
+
 - [Census Income Dataset](https://archive.ics.uci.edu/dataset/20/census+income).
 - [Labeled Faces in the Wild (LFW)](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.fetch_lfw_people.html).
+
 ## Models
+
 Amulet provides the following models:
+
 - [VGG](https://viso.ai/deep-learning/vgg-very-deep-convolutional-networks/): for computer vision tasks.
 - LinearNet: A dense neural network tuned for multiclass classification on the FashionMNIST dataset.
 
 ## Risks
+
 Amulet provides attacks, defenses, and evaluation metrics for the following risks:
+
 ### Security
+
 - Evasion
 - Poisoning
 - Unauthorized Model Ownership
 
 ### Privacy
+
 - Membership Inference
 - Attribute Inference
 - Distribution Inference
 - Data Reconstruction
 
 ### Fairness
+
 - Discriminatory Behavior
 
 Please check the [Module Guide](https://github.com/ssg-research/amulet/blob/main/docs/MODULE_GUIDE.md) for more details.
@@ -38,7 +48,9 @@ Please check the [Module Guide](https://github.com/ssg-research/amulet/blob/main
 # Data Loading
 
 ## Data Class
+
 All Amulet datasets are returned as an AmuletDataset, which contains the following attributes:
+
 ```python
 train_set: torch.utils.data.Dataset
 test_set: torch.utils.data.Dataset
@@ -51,10 +63,13 @@ y_test: np.ndarray | None = None
 z_train: np.ndarray | None = None
 z_test: np.ndarray | None = None
 ```
+
 Every dataset will have the `train_set`, `test_set`, `num_features`, and `num_classes` attributes. For datasets that are loaded manually and processed by Amulet (such as LFW and Census Income Dataset), the individual feature and labels arrays will also be set `[x_train, x_test, y_train, y_test]`, as well as the arrays to store sensitive attributes `[z_train, z_test]`.
 
 ## Accessing Datasets
+
 For easy access, Amulet provides the following function to load any dataset as part of a pipeline:
+
 ```python
 def load_data(
     root: Path | str,
@@ -64,7 +79,9 @@ def load_data(
     exp_id: int = 0,
 ) -> AmuletDataset:
 ```
+
 Where:
+
 - `root`: the root directory to store datasets.
 - `dataset`: one of `['cifar10', 'fminst', 'census', 'lfw']`.
 - `training_size`: used to reduce the size of the training data, useful to test the impact of dataset size on models.
@@ -72,13 +89,14 @@ Where:
 - `exp_id`: for random seeding, if needed.
 
 Amulet provides the following functions to load datasets:
+
 - ```python
     def load_cifar10(
         path: str | Path = Path("./data/cifar10"),
         transform_train: transforms.Compose | None = None,
         transform_test: transforms.Compose | None = None,
     ) -> AmuletDataset:
-   ```
+  ```
 
 - ```python
     def load_fmnist(
@@ -86,7 +104,7 @@ Amulet provides the following functions to load datasets:
         transform_train: transforms.Compose | None = None,
         transform_test: transforms.Compose | None = None,
     ) -> AmuletDataset:
-   ```
+  ```
 - ```python
     def load_census(
         path: str | Path = Path("./data/census"),
@@ -107,10 +125,13 @@ Amulet provides the following functions to load datasets:
   ```
 
 # Creating Models
+
 Any PyTorch model of type `torch.nn.Module` can be used with Amulet. For some modules, it is helpful to have a `get_hidden(self, x: torch.Tensor) -> torch.Tensor` method that returns the intermediate layer output from the model, please see [this example](https://github.com/ssg-research/amulet/blob/main/amulet/models/vgg.py#L106).
 
 ## Accessing pre-configured model architectures
+
 To use the models configured for running experiments using Amulet, the following function can be used:
+
 ```python
 def initialize_model(
     model_arch: str,
@@ -121,7 +142,9 @@ def initialize_model(
     batch_norm: bool = True,
 ) -> nn.Module:
 ```
+
 Where:
+
 - `model_arch`: one of `['vgg', 'linearnet']`. Each model is optimized for a specific dataset that Amulet provides.
 - `model_capacity`: one of `['m1', 'm2', 'm3', 'm4]`. Configures the size and complexity of the model.
 - `num_features`: Size of the input for the model in the case of simple dense neural networks.
@@ -130,4 +153,5 @@ Where:
 - `batch_norm`: Used to control whether batch normalization is used. True by default.
 
 # Risks
+
 Amulet provides attacks, defenses, and metrics for each risk. **TBD.**

--- a/docs/module_guide/1_INTRO.md
+++ b/docs/module_guide/1_INTRO.md
@@ -1,11 +1,13 @@
 # Introduction
 
-Each risk in Amulet represents either an *attack*, a *defense*, or a *metric*.
+Each risk in Amulet represents either an _attack_, a _defense_, or a _metric_.
 To see the list of the risks and the features, please see the [Getting Started guide](https://github.com/ssg-research/amulet/blob/main/docs/GETTING_STARTED.md).
 
 ## Design Overview
+
 Most attacks and defenses are designed such that they take the target model, and some additional information (such as data, hyperparameters, configuration, etc.) as input, run an algorithm, and output a result.
 This result can then be passed onto the respective metrics modules to evaluate the attack or defense. A brief pipeline would look something like:
+
 ```python
 data = load_data()
 

--- a/docs/module_guide/2_EVASION.md
+++ b/docs/module_guide/2_EVASION.md
@@ -1,12 +1,15 @@
 # Evasion
+
 Amulet implements the Projected Gradient Descent (PGD) algorithm from [cleverhans](https://github.com/cleverhans-lab/cleverhans) to generate adversarial examples.
 PGD is used for the evasion attack and the adversarial training defense.
 
 ## Attack:
+
 To run an evasion attack, use `amulet.evasion.attacks.EvasionPGD`.
 This module returns a data loader containing the adversarial examples.
 
 The following code snippet shows a brief example:
+
 ```python
 import sys
 import torch
@@ -63,10 +66,12 @@ adversarial_accuracy = get_accuracy(target_model, adversarial_test_loader, devic
 ```
 
 ## Defense:
+
 To run the adversarial training algorithm use `amulet.evasion.defenses.AdversarialTrainingPGD`.
 This module trains a model using adversarial training.
 
 The following code snippet shows a brief example:
+
 ```python
 import sys
 import torch
@@ -127,4 +132,5 @@ test_accuracy_defended = get_accuracy(defended_model, test_loader, device)
 ```
 
 ## Metrics
+
 Accuracy (`amulet.utils.get_accuracy`) is currently the only metric implemeneted for evasion attacks.

--- a/docs/module_guide/3_POISONING.md
+++ b/docs/module_guide/3_POISONING.md
@@ -1,8 +1,10 @@
 # Data Poisoning
+
 Amulet implements [BadNets](https://github.com/Kooscii/BadNets) to poison a model.
 To defend against these attacks, Amulet implements outlier removal using [Shapely Values](https://github.com/AI-secure/KNN-shapley).
 
 ## Attack
+
 To run a data poisoning attack, use `amulet.poisoning.attacks.BadNets`.
 This attack returns a poisoned dataset to train a model.
 
@@ -112,9 +114,10 @@ print(
 ```
 
 ## Defense
+
 To run the outlier removal algorithm, use `amulet.poisoning.defenses`.
 Note that this is not a published defense, however, the KNN Shapley algorithm is published and used to calculate the value of each data point.
-Please see: [Ruoxi et. al., *Efficient task-specific data valuation for nearest neighbor algorithms*, ACM VLDB, 2019](https://dl.acm.org/doi/10.14778/3342263.3342637)
+Please see: [Ruoxi et. al., _Efficient task-specific data valuation for nearest neighbor algorithms_, ACM VLDB, 2019](https://dl.acm.org/doi/10.14778/3342263.3342637)
 
 ```python
 import sys
@@ -185,4 +188,5 @@ print(f'Test accuracy of model with outliers removed: {test_accuracy_outlier_rem
 ```
 
 ## Metrics
+
 Accuracy (`amulet.utils.get_accuracy`) is currently the only metric implemeneted for data poisoning.

--- a/docs/module_guide/4_UNAUTHORIZED_MODEL_OWNERSHIP.md
+++ b/docs/module_guide/4_UNAUTHORIZED_MODEL_OWNERSHIP.md
@@ -1,14 +1,17 @@
 # Unauthorized Model Ownership
+
 These risks are related to an adversary being able to "steal" a model, such that the stolen (surrogate) model has the same behavior and characteristics as the target model.
-Amulet implements the model stealing attack from [ML-Doctor](https://github.com/liuyugeng/ML-Doctor/blob/main/doctor/modsteal.py), which is based on the following work: [Tramer et. al. *Stealing Machine Learning Models
-via Prediction APIs*, USENIX Security, 2016](https://www.usenix.org/system/files/conference/usenixsecurity16/sec16_paper_tramer.pdf).
+Amulet implements the model stealing attack from [ML-Doctor](https://github.com/liuyugeng/ML-Doctor/blob/main/doctor/modsteal.py), which is based on the following work: [Tramer et. al. _Stealing Machine Learning Models
+via Prediction APIs_, USENIX Security, 2016](https://www.usenix.org/system/files/conference/usenixsecurity16/sec16_paper_tramer.pdf).
 The best known class of defenses for such attacks is Watermarking or Fingerprinting.
 Amulet implements the [Dataset Inference algorithm from cleverhans](https://github.com/cleverhans-lab/dataset-inference/tree/main) as a fingerprinting mechanism.
 For watermarking, Amulet implements the [WatermarkNN algorithm](https://github.com/adiyoss/WatermarkNN), however, this is currently a work in progress.
 
 ## Attack
+
 To run a model extraction attack, use `amulet.unauth_model_ownership.attacks.ModelExtraction`.
 This attack trains a surrogate model using the original target model.
+
 ```python
 import sys
 import torch
@@ -93,9 +96,11 @@ attack_model = model_extraction.train_attack_model()
 ```
 
 ## Defense
+
 ### Fingerprinting
+
 To fingerprint a target model, use `amulet.unauth_model_ownership.defenses.Fingerprinting`.
-Note that unlike other modules, a *suspect* model is required to run fingerprinting, as it outputs whether the suspect model was stolen or not.
+Note that unlike other modules, a _suspect_ model is required to run fingerprinting, as it outputs whether the suspect model was stolen or not.
 This could be a surrogate model using the attack above, or a separately trained model.
 
 ```python
@@ -188,6 +193,7 @@ results = fingerprinting.dataset_inference()
 ```
 
 ### Watermarking
+
 To watermark a target model, use `amulet.unauth_model_ownership.defenses.WatermarkNN`. The trigger set consists of 100 random images from the ImageNet test set and is available [here](https://github.com/ssg-research/amulet/tree/verify-watermark/miscellaneous/trigger_set).
 
 ```python
@@ -256,20 +262,25 @@ defended_model = wm_model.watermark()
 ```
 
 ## Metrics
+
 ### Model Extraction
+
 Amulet provides a set of metrics to evaluate surrogate models. Use `amulet.unauth_model_ownership.metrics.evaluate_extraction`, which takes as input:
+
 - The target model.
 - The surrogate model.
 - The test data loader.
 - Device to run the predictions on.
 
 And outputs a dictionary containing:
+
 - `target_accuracy`: Test accuracy of the target model.
 - `stolen_accuracy`: Test accuracy of the stolen model.
 - `fidelity`: Agreement between target and stolen model.
 - `correct_fidelity`: Accuracy conditioned on fidelity, i.e., when the models agree, how often are they also correct?
 
 ### Fingerprinting / Watermarking
+
 Amulet currently does not provide metrics to evaluate fingerprinting or watermarking.
 The modules output a boolean value for each model classifiying it as either "stolen" or "independently trained".
 Thus, evaluating these modules requires a pipeline to train multiple surrogate models and independently trained models to evaluate the module.

--- a/docs/module_guide/5_MEMBERSHIP_INFERENCE.md
+++ b/docs/module_guide/5_MEMBERSHIP_INFERENCE.md
@@ -1,8 +1,10 @@
 # Membership Inference
+
 Amulet implements the [Likelihood Ratio Attack (LiRA)](https://openreview.net/pdf?id=inPTplK-O6V), with the implementation taken from the [Canary in Coalmine](https://github.com/YuxinWenRick/canary-in-a-coalmine) codebase.
 To defend against these attacks, Amulet implements differentially private training using DP-SGD.
 
 ## Attack
+
 To run a membership inference attack, use `amulet.membership_inference.attacks.LiRA`.
 This attack classifies each data point as `in` or `out`.
 
@@ -104,6 +106,7 @@ print(compute_mi_metrics(results['lira_offline_preds'], results['true_labels']))
 ```
 
 ## Defense
+
 To train a model using DP-SGD, use `amulet.membership_inference.defenses.DPSGD`.
 Note that the current implementation of DP-SGD does not work with batch normalization.
 
@@ -179,6 +182,7 @@ print(f'Test accuracy of defended model: {test_accuracy_defended}')
 ```
 
 ## Metrics
+
 Amulet implements the fixed AUC method recommended by [LiRA](https://openreview.net/pdf?id=inPTplK-O6V).
 Use `amulet.membership_inference.metrics.compute_mi_metrics`.
 This function takes as input the in/out labels and compares them with the true labels.

--- a/docs/module_guide/6_ATTRIBUTE_INFERENCE.md
+++ b/docs/module_guide/6_ATTRIBUTE_INFERENCE.md
@@ -1,9 +1,11 @@
 # Attribute Inference
+
 Amulet implements the attribute inference attack from the work [Inferring Sensitive Attributes from Model Explanations](https://github.com/vasishtduddu/AttInfExplanations) by Duddu et. al. published at ACM CIKM 2022.
 
 ## Attack
+
 To run an attribute inference attack, use `amulet.attribute_inference.attacks.DudduCIKM2022`.
-This attack predicts the sensitive attributes for a dataset, for example, it could predict whether the data point was a *male* or *female* even when the training data did not use this attribute directly.
+This attack predicts the sensitive attributes for a dataset, for example, it could predict whether the data point was a _male_ or _female_ even when the training data did not use this attribute directly.
 Attribute inference only works for datasets that have sensitive attributes.
 Amulet provides the LFW and Census datasets for such use cases.
 
@@ -106,9 +108,11 @@ print(results)
 ```
 
 ## Defense
+
 Amulet does not currently implement any direct defenses for attribute inference.
 [DP-SGD](https://github.com/ssg-research/amulet/blob/main/docs/module_guide/5_MEMBERSHIP_INFERENCE.md#defense) may be used as a general privacy preserving mechanism.
 
 ## Metrics
+
 Use `amulet.attribute_inference.metrics.evaluate_attribute_inference` to evaluate attribute inference attacks.
 This calculates the balanced accuracy and the auc score for the predictions.

--- a/docs/module_guide/7_DISTRIBUTION_INFERENCE.md
+++ b/docs/module_guide/7_DISTRIBUTION_INFERENCE.md
@@ -1,13 +1,18 @@
 # Distribution Inference
+
 Amulet implements the distribution inference attack from the work [Dissecting Distribution Inference](https://github.com/iamgroot42/dissecting_dist_inf) by Suri et. al. published at IEEE SaTML 2023.
 
 ## Attack
+
 <!-- To run an distribution inference attack, use `amulet.distribution_inference.attacks.SuriSATML2023`. -->
+
 This attack is a work in progress and will be made available in a future update.
 
 ## Defense
+
 Amulet does not currently implement any direct defenses for distribution inference.
 [DP-SGD](https://github.com/ssg-research/amulet/blob/main/docs/module_guide/5_MEMBERSHIP_INFERENCE.md#defense) may be used as a general privacy preserving mechanism.
 
 ## Metrics
+
 Evaluation for distribution inference is currently a work in progress.

--- a/docs/module_guide/8_DATA_RECONSTRUCTION.md
+++ b/docs/module_guide/8_DATA_RECONSTRUCTION.md
@@ -1,8 +1,10 @@
 # Data Reconstruction
+
 Amulet implements the data reconstruction attack from the [ML-Doctor library](https://github.com/liuyugeng/ML-Doctor/blob/main/doctor/modinv.py) which is based off of the work [Model Inversion Attacks that Exploit Confidence Information
 and Basic Countermeasures](https://rist.tech.cornell.edu/papers/mi-ccs.pdf) by Fredrikson et. al. published at ACM CCS 2015.
 
 ## Attack
+
 To run a data reconstruction attack, use `amulet.data_reconstruction.attacks.FredriksonCCS2015`.
 
 ```python
@@ -67,10 +69,12 @@ print(f'Reverse MSE: {mse_loss}')
 ```
 
 ## Defense
+
 Amulet does not currently implement any direct defenses for data reconstruction.
 [DP-SGD](https://github.com/ssg-research/amulet/blob/main/docs/module_guide/5_MEMBERSHIP_INFERENCE.md#defense) may be used as a general privacy preserving mechanism.
 
 ## Metrics
+
 To evaluate data reconstruction attacks, use `amulet.data_reconstruction.metrics.reverse_mse`.
-This function calculates the *average* data point in each class, and finds the class-wise MSE between the reconstructed (reverse) data point and the average.
+This function calculates the _average_ data point in each class, and finds the class-wise MSE between the reconstructed (reverse) data point and the average.
 This class-wise MSE is then averaged over all classes.

--- a/docs/module_guide/9_DISCRIMINATORY_BEHAVIOR.md
+++ b/docs/module_guide/9_DISCRIMINATORY_BEHAVIOR.md
@@ -1,11 +1,14 @@
 # Discriminatory Behavior
+
 This module focuses on evaluating a model for bias and fairness.
 While there is currently no specific attack that increases bias in a model, Amulet does implement an [adversarial debiasing method](https://xebia.com/blog/towards-fairness-in-ml-with-adversarial-networks/) to decrease bias in a model.
 
 This module only works with datasets that have sensitive attributes, such as Census and LFW.
 
 ## Defense
+
 To run the adversarial debiasing module, use `amulet.discriminatory_behavior.defenses.AdversarialDebiasing`. This module uses adversarial training to ensure that the model outputs are independent of the sensitive attributes in the data.
+
 ```python
 import sys
 import torch
@@ -130,6 +133,7 @@ for attribute, metrics in metrics_labelled.items():
 ```
 
 ## Metrics
+
 Unlike other metrics, Amulet implements a class to measure discriminatory behavior.
 Please use `amulet.discriminatory_behavior.metrics.DiscriminatoryBehavior` to evaluate a model's risk for discriminatory behavior.
 The example above demonstrates how to use this class.

--- a/examples/attack_pipelines/run_attribute_inference.py
+++ b/examples/attack_pipelines/run_attribute_inference.py
@@ -5,19 +5,20 @@ import argparse
 import logging
 from pathlib import Path
 
-import torch
 import numpy as np
+import torch
+from sklearn.model_selection import train_test_split
 from torch.utils.data import DataLoader, TensorDataset
+
 from amulet.attribute_inference.attacks import DudduCIKM2022
 from amulet.attribute_inference.metrics import evaluate_attribute_inference
 from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
     create_dir,
     get_accuracy,
+    initialize_model,
+    load_data,
+    train_classifier,
 )
-from sklearn.model_selection import train_test_split
 
 
 def parse_args() -> argparse.Namespace:
@@ -53,9 +54,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default=torch.device(
-            "cuda:{0}".format(0) if torch.cuda.is_available() else "cpu"
-        ),
+        default=torch.device(f"cuda:{0}" if torch.cuda.is_available() else "cpu"),
         help="Device on which to run PyTorch",
     )
     parser.add_argument(
@@ -137,7 +136,7 @@ def main(args: argparse.Namespace) -> None:
 
     # Set up filename and directories to save/load models
     models_path = root_dir / "saved_models"
-    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size*100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
+    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size * 100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
 
     # Train or Load Target Model
     target_model_path = (

--- a/examples/attack_pipelines/run_data_recon.py
+++ b/examples/attack_pipelines/run_data_recon.py
@@ -7,14 +7,15 @@ from pathlib import Path
 
 import torch
 from torch.utils.data import DataLoader
+
 from amulet.data_reconstruction.attacks import FredriksonCCS2015
 from amulet.data_reconstruction.metrics import evaluate_similarity
 from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
     create_dir,
     get_accuracy,
+    initialize_model,
+    load_data,
+    train_classifier,
 )
 
 
@@ -51,9 +52,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default=torch.device(
-            "cuda:{0}".format(0) if torch.cuda.is_available() else "cpu"
-        ),
+        default=torch.device(f"cuda:{0}" if torch.cuda.is_available() else "cpu"),
         help="Device on which to run PyTorch",
     )
     parser.add_argument(
@@ -94,7 +93,7 @@ def main(args: argparse.Namespace) -> None:
 
     # Set up filename and directories to save/load models
     models_path = root_dir / "saved_models"
-    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size*100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
+    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size * 100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
     target_model_path = models_path / "target"
     target_model_filename = target_model_path / filename
 
@@ -126,7 +125,7 @@ def main(args: argparse.Namespace) -> None:
     # Run Data Reconstruction attack
     log.info("Running Data Reconstruction Attack")
 
-    input_size = (1,) + tuple(data.test_set[0][0].shape)
+    input_size = (1, *tuple(data.test_set[0][0].shape))
     num_classes_dict = {"cifar10": 10, "fmnist": 10, "census": 2, "lfw": 2, "celeba": 2}
     output_size = num_classes_dict[args.dataset]
     data_recon = FredriksonCCS2015(

--- a/examples/attack_pipelines/run_distribution_inference.py
+++ b/examples/attack_pipelines/run_distribution_inference.py
@@ -6,9 +6,10 @@ import logging
 from pathlib import Path
 
 import torch
+
 from amulet.distribution_inference.attacks import DistributionInference
-from amulet.utils import load_data, train_classifier, create_dir, get_accuracy
 from amulet.models.linear_net import LinearNet
+from amulet.utils import create_dir, get_accuracy, load_data, train_classifier
 
 
 def parse_args() -> argparse.Namespace:
@@ -44,9 +45,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default=torch.device(
-            "cuda:{0}".format(0) if torch.cuda.is_available() else "cpu"
-        ),
+        default=torch.device(f"cuda:{0}" if torch.cuda.is_available() else "cpu"),
         help="Device on which to run PyTorch",
     )
     parser.add_argument(
@@ -156,7 +155,7 @@ def main(args: argparse.Namespace) -> None:
         test_loader_1,
         test_loader_2,
     )
-    print("Accuracy: {:.2f}".format(accuracy))
+    print(f"Accuracy: {accuracy:.2f}")
 
 
 if __name__ == "__main__":

--- a/examples/attack_pipelines/run_evasion.py
+++ b/examples/attack_pipelines/run_evasion.py
@@ -7,13 +7,14 @@ from pathlib import Path
 
 import torch
 from torch.utils.data import DataLoader
+
 from amulet.evasion.attacks import EvasionPGD
 from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
     create_dir,
     get_accuracy,
+    initialize_model,
+    load_data,
+    train_classifier,
 )
 
 
@@ -53,9 +54,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default=torch.device(
-            "cuda:{0}".format(0) if torch.cuda.is_available() else "cpu"
-        ),
+        default=torch.device(f"cuda:{0}" if torch.cuda.is_available() else "cpu"),
         help="Device on which to run PyTorch",
     )
     parser.add_argument(
@@ -93,7 +92,7 @@ def main(args: argparse.Namespace) -> None:
 
     # Set up filename and directories to save/load models
     models_path = root_dir / "saved_models"
-    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size*100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
+    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size * 100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
     target_model_path = models_path / "target"
     target_model_filename = target_model_path / filename
 

--- a/examples/attack_pipelines/run_membership_inference.py
+++ b/examples/attack_pipelines/run_membership_inference.py
@@ -3,19 +3,20 @@ import sys
 sys.path.append("../../")
 import argparse
 import logging
-import numpy as np
 from pathlib import Path
 
+import numpy as np
 import torch
 from torch.utils.data import DataLoader, Subset
+
 from amulet.membership_inference.attacks import LiRA
 from amulet.membership_inference.metrics import compute_mi_metrics
 from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
     create_dir,
     get_accuracy,
+    initialize_model,
+    load_data,
+    train_classifier,
 )
 
 
@@ -55,9 +56,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default=torch.device(
-            "cuda:{0}".format(0) if torch.cuda.is_available() else "cpu"
-        ),
+        default=torch.device(f"cuda:{0}" if torch.cuda.is_available() else "cpu"),
         help="Device on which to run PyTorch",
     )
     parser.add_argument(
@@ -113,7 +112,7 @@ def main(args: argparse.Namespace) -> None:
 
     # Set up filename and directories to save/load models
     models_path = root_dir / "saved_models"
-    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size*100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
+    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size * 100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
     target_model_path = models_path / "target"
     target_model_filename = target_model_path / filename
 

--- a/examples/attack_pipelines/run_model_extraction.py
+++ b/examples/attack_pipelines/run_model_extraction.py
@@ -7,14 +7,15 @@ from pathlib import Path
 
 import torch
 from torch.utils.data import DataLoader, random_split
+
 from amulet.unauth_model_ownership.attacks import ModelExtraction
 from amulet.unauth_model_ownership.metrics import evaluate_extraction
 from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
     create_dir,
     get_accuracy,
+    initialize_model,
+    load_data,
+    train_classifier,
 )
 
 
@@ -54,9 +55,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default=torch.device(
-            "cuda:{0}".format(0) if torch.cuda.is_available() else "cpu"
-        ),
+        default=torch.device(f"cuda:{0}" if torch.cuda.is_available() else "cpu"),
         help="Device on which to run PyTorch",
     )
     parser.add_argument(
@@ -109,7 +108,7 @@ def main(args: argparse.Namespace) -> None:
 
     # Set up filename and directories to save/load models
     models_path = root_dir / "saved_models"
-    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size*100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
+    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size * 100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
 
     # Train or Load Target Model
     target_model_path = (

--- a/examples/attack_pipelines/run_poisoning.py
+++ b/examples/attack_pipelines/run_poisoning.py
@@ -7,13 +7,14 @@ from pathlib import Path
 
 import torch
 from torch.utils.data import DataLoader
+
 from amulet.poisoning.attacks import BadNets
 from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
     create_dir,
     get_accuracy,
+    initialize_model,
+    load_data,
+    train_classifier,
 )
 
 
@@ -53,9 +54,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default=torch.device(
-            "cuda:{0}".format(0) if torch.cuda.is_available() else "cpu"
-        ),
+        default=torch.device(f"cuda:{0}" if torch.cuda.is_available() else "cpu"),
         help="Device on which to run PyTorch",
     )
     parser.add_argument(
@@ -102,7 +101,7 @@ def main(args: argparse.Namespace) -> None:
 
     # Set up filename and directories to save/load models
     models_path = root_dir / "saved_models"
-    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size*100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
+    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size * 100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
 
     # Train or Load Target Model
     target_model_path = models_path / "target"
@@ -142,10 +141,7 @@ def main(args: argparse.Namespace) -> None:
     )
     poisoned_model_filename = poisoned_model_path / filename
 
-    if args.dataset in ["census", "lfw"]:
-        dataset_type = "tabular"
-    else:
-        dataset_type = "image"
+    dataset_type = "tabular" if args.dataset in ["census", "lfw"] else "image"
 
     if poisoned_model_filename.exists():
         log.info("Attack model loaded from %s", poisoned_model_filename)

--- a/examples/defense_pipelines/run_adversarial_debiasing.py
+++ b/examples/defense_pipelines/run_adversarial_debiasing.py
@@ -7,14 +7,15 @@ from pathlib import Path
 
 import torch
 from torch.utils.data import DataLoader, TensorDataset
+
 from amulet.discriminatory_behavior.defenses import AdversarialDebiasing
 from amulet.discriminatory_behavior.metrics import DiscriminatoryBehavior
 from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
     create_dir,
     get_accuracy,
+    initialize_model,
+    load_data,
+    train_classifier,
 )
 
 
@@ -51,9 +52,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default=torch.device(
-            "cuda:{0}".format(0) if torch.cuda.is_available() else "cpu"
-        ),
+        default=torch.device(f"cuda:{0}" if torch.cuda.is_available() else "cpu"),
         help="Device on which to run PyTorch",
     )
     parser.add_argument(
@@ -113,7 +112,7 @@ def main(args: argparse.Namespace) -> None:
 
     # Set up filename and directories to save/load models
     models_path = root_dir / "saved_models"
-    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size*100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
+    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size * 100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
     target_model_path = models_path / "target"
     target_model_filename = target_model_path / filename
 
@@ -148,7 +147,7 @@ def main(args: argparse.Namespace) -> None:
     )
     all_metrics = discr_behavior_target.evaluate_subgroup_metrics()
 
-    for attribute, metrics in all_metrics.items():
+    for _attribute, metrics in all_metrics.items():
         for metric, value in metrics.items():
             print(f"{metric}: {value}")
 

--- a/examples/defense_pipelines/run_adversarial_training.py
+++ b/examples/defense_pipelines/run_adversarial_training.py
@@ -7,13 +7,14 @@ from pathlib import Path
 
 import torch
 from torch.utils.data import DataLoader
+
 from amulet.evasion.defenses import AdversarialTrainingPGD
 from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
     create_dir,
     get_accuracy,
+    initialize_model,
+    load_data,
+    train_classifier,
 )
 
 
@@ -53,9 +54,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default=torch.device(
-            "cuda:{0}".format(0) if torch.cuda.is_available() else "cpu"
-        ),
+        default=torch.device(f"cuda:{0}" if torch.cuda.is_available() else "cpu"),
         help="Device on which to run PyTorch",
     )
     parser.add_argument(
@@ -93,7 +92,7 @@ def main(args: argparse.Namespace) -> None:
 
     # Set up filename and directories to save/load models
     models_path = root_dir / "saved_models"
-    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size*100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
+    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size * 100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
     target_model_path = models_path / "target"
     target_model_filename = target_model_path / filename
 

--- a/examples/defense_pipelines/run_dp_sgd.py
+++ b/examples/defense_pipelines/run_dp_sgd.py
@@ -7,13 +7,14 @@ from pathlib import Path
 
 import torch
 from torch.utils.data import DataLoader
+
 from amulet.membership_inference.defenses import DPSGD
 from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
     create_dir,
     get_accuracy,
+    initialize_model,
+    load_data,
+    train_classifier,
 )
 
 
@@ -53,9 +54,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default=torch.device(
-            "cuda:{0}".format(0) if torch.cuda.is_available() else "cpu"
-        ),
+        default=torch.device(f"cuda:{0}" if torch.cuda.is_available() else "cpu"),
         help="Device on which to run PyTorch",
     )
     parser.add_argument(
@@ -110,7 +109,7 @@ def main(args: argparse.Namespace) -> None:
 
     # Set up filename and directories to save/load models
     models_path = root_dir / "saved_models"
-    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size*100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
+    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size * 100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
     target_model_path = models_path / "target"
     target_model_filename = target_model_path / filename
 

--- a/examples/defense_pipelines/run_fingerprint.py
+++ b/examples/defense_pipelines/run_fingerprint.py
@@ -7,13 +7,14 @@ from pathlib import Path
 
 import torch
 from torch.utils.data import DataLoader
+
 from amulet.unauth_model_ownership.defenses import DatasetInference
 from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
     create_dir,
     get_accuracy,
+    initialize_model,
+    load_data,
+    train_classifier,
 )
 
 
@@ -53,9 +54,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default=torch.device(
-            "cuda:{0}".format(0) if torch.cuda.is_available() else "cpu"
-        ),
+        default=torch.device(f"cuda:{0}" if torch.cuda.is_available() else "cpu"),
         help="Device on which to run PyTorch",
     )
     parser.add_argument(
@@ -120,7 +119,7 @@ def main(args: argparse.Namespace) -> None:
 
     # Set up filename and directories to save/load models
     models_path = root_dir / "saved_models"
-    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size*100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
+    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size * 100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
     target_model_path = models_path / "target"
     target_model_filename = target_model_path / filename
 

--- a/examples/defense_pipelines/run_outlier_removal.py
+++ b/examples/defense_pipelines/run_outlier_removal.py
@@ -7,13 +7,14 @@ from pathlib import Path
 
 import torch
 from torch.utils.data import DataLoader
+
 from amulet.poisoning.defenses import OutlierRemoval
 from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
     create_dir,
     get_accuracy,
+    initialize_model,
+    load_data,
+    train_classifier,
 )
 
 
@@ -53,9 +54,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default=torch.device(
-            "cuda:{0}".format(0) if torch.cuda.is_available() else "cpu"
-        ),
+        default=torch.device(f"cuda:{0}" if torch.cuda.is_available() else "cpu"),
         help="Device on which to run PyTorch",
     )
     parser.add_argument(
@@ -93,7 +92,7 @@ def main(args: argparse.Namespace) -> None:
 
     # Set up filename and directories to save/load models
     models_path = root_dir / "saved_models"
-    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size*100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
+    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size * 100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
 
     # Train or Load Target Model
     target_model_path = models_path / "target"

--- a/examples/defense_pipelines/run_watermark.py
+++ b/examples/defense_pipelines/run_watermark.py
@@ -7,13 +7,14 @@ from pathlib import Path
 
 import torch
 from torch.utils.data import DataLoader
+
 from amulet.unauth_model_ownership.defenses import WatermarkNN
 from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
     create_dir,
     get_accuracy,
+    initialize_model,
+    load_data,
+    train_classifier,
 )
 
 
@@ -71,9 +72,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default=torch.device(
-            "cuda:{0}".format(0) if torch.cuda.is_available() else "cpu"
-        ),
+        default=torch.device(f"cuda:{0}" if torch.cuda.is_available() else "cpu"),
         help="Device on which to run PyTorch",
     )
     parser.add_argument(
@@ -108,7 +107,7 @@ def main(args: argparse.Namespace) -> None:
 
     # Set up filename and directories to save/load models
     models_path = root_dir / "saved_models"
-    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size*100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
+    filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size * 100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
     target_model_path = models_path / "target"
     target_model_filename = target_model_path / filename
 

--- a/examples/get_started.py
+++ b/examples/get_started.py
@@ -9,13 +9,14 @@ from pathlib import Path
 
 import torch
 from torch.utils.data import DataLoader
+
 from amulet.evasion.attacks import EvasionPGD
 from amulet.evasion.defenses import AdversarialTrainingPGD
 from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
     get_accuracy,
+    initialize_model,
+    load_data,
+    train_classifier,
 )
 
 # Set up constants

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "scikit-learn==1.4.1.post1",
     "scikit-image==0.25.1",
     "scipy==1.12.0",
-    "torch>=2.2.0",
+    "torch>=2.3.0",
     "torchvision>=0.18.0",
     "tqdm==4.66.2",
     "ucimlrepo==0.0.3",
@@ -34,6 +34,7 @@ dev = [
     "pre-commit==3.7.1",
     "basedpyright==1.12.5",
     "pytest==8.3.2",
+    "pytest-timeout==2.3.1",
     "ruff==0.11.0",
 ]
 
@@ -48,9 +49,33 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["amulet"]
 
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+preview = true
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "C4", "SIM", "RUF"]
+ignore = ["E501", "B903"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+docstring-code-format = true
+
 [tool.basedpyright]
 venvPath = "."
 venv = ".venv"
 typeCheckingMode = "standard"
 deprecateTypingAliases = true
 reportDeprecated = true
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: integration tests that train tiny models (slow)",
+    "gpu: tests that require a CUDA-capable GPU",
+]
+addopts = "--strict-markers"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,79 @@
+import pytest
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+
+
+class TinyMLP(nn.Module):
+    """Tiny 2-layer MLP used across tests; defined at module scope so it's picklable."""
+
+    def __init__(self, num_features: int = 4, num_classes: int = 2):
+        super().__init__()
+        self.layers = nn.Sequential(
+            nn.Linear(num_features, 8),
+            nn.ReLU(),
+            nn.Linear(8, num_classes),
+        )
+
+    def forward(self, x):
+        return self.layers(x)
+
+    def get_hidden(self, x):
+        """Return the intermediate features before the final layer."""
+        return self.layers[:-1](x)
+
+
+@pytest.fixture(
+    params=[
+        "cpu",
+        pytest.param("cuda", marks=pytest.mark.gpu),
+    ]
+)
+def device(request: pytest.FixtureRequest) -> str:
+    """Parametrized device fixture. CUDA variant is skipped when no GPU is available."""
+    if request.param == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    return request.param  # type: ignore[return-value]
+
+
+@pytest.fixture
+def cpu_device() -> str:
+    """CPU-only device fixture for unit tests."""
+    return "cpu"
+
+
+@pytest.fixture
+def tiny_classifier_factory():
+    """Factory fixture that returns fresh, independently-initialized TinyMLP instances.
+
+    Use when a test needs multiple distinct models (e.g. distribution inference,
+    where reusing the same instance would destroy the distinguishing signal).
+    """
+
+    def _make(seed: int | None = None, device: str = "cpu") -> TinyMLP:
+        if seed is not None:
+            torch.manual_seed(seed)
+        return TinyMLP().to(device)
+
+    return _make
+
+
+@pytest.fixture
+def tiny_classifier(tiny_classifier_factory, device):
+    """Single TinyMLP instance seeded for reproducibility, on the test device."""
+    return tiny_classifier_factory(seed=42, device=device)
+
+
+@pytest.fixture
+def tiny_dataset():
+    """Fixture for a synthetic dataset (N=64, num_features=4) with binary labels in [0, 1]."""
+    torch.manual_seed(42)
+    x = torch.rand(64, 4)
+    y = torch.randint(0, 2, (64,))
+    return TensorDataset(x, y)
+
+
+@pytest.fixture
+def tiny_loader(tiny_dataset):
+    """Fixture for a DataLoader with batch_size=8."""
+    return DataLoader(tiny_dataset, batch_size=8, shuffle=False)

--- a/tests/unit/test_dataset_dataclass.py
+++ b/tests/unit/test_dataset_dataclass.py
@@ -1,0 +1,54 @@
+import numpy as np
+import torch
+from torch.utils.data import TensorDataset
+
+from amulet.datasets.__data import AmuletDataset
+
+
+def _make_datasets() -> tuple[TensorDataset, TensorDataset]:
+    return (
+        TensorDataset(torch.randn(10, 1), torch.zeros(10)),
+        TensorDataset(torch.randn(5, 1), torch.zeros(5)),
+    )
+
+
+def test_amulet_dataset_required_fields():
+    train, test = _make_datasets()
+    data = AmuletDataset(
+        train_set=train,
+        test_set=test,
+        num_features=1,
+        num_classes=2,
+    )
+    assert data.train_set is train
+    assert data.test_set is test
+    assert data.num_features == 1
+    assert data.num_classes == 2
+
+
+def test_amulet_dataset_optional_arrays_default_none():
+    train, test = _make_datasets()
+    data = AmuletDataset(train_set=train, test_set=test, num_features=1, num_classes=2)
+    assert data.x_train is None
+    assert data.x_test is None
+    assert data.y_train is None
+    assert data.y_test is None
+    assert data.z_train is None
+    assert data.z_test is None
+
+
+def test_amulet_dataset_with_optional_arrays():
+    train, test = _make_datasets()
+    x_train = np.array([[1], [2]])
+    z_train = np.array([0, 1])
+    data = AmuletDataset(
+        train_set=train,
+        test_set=test,
+        num_features=1,
+        num_classes=2,
+        x_train=x_train,
+        z_train=z_train,
+    )
+    assert data.x_train is not None and np.array_equal(data.x_train, x_train)
+    assert data.z_train is not None and np.array_equal(data.z_train, z_train)
+    assert data.x_test is None

--- a/tests/unit/test_dataset_dataclass.py
+++ b/tests/unit/test_dataset_dataclass.py
@@ -1,19 +1,22 @@
 import numpy as np
+import pytest
 import torch
 from torch.utils.data import TensorDataset
 
 from amulet.datasets.__data import AmuletDataset
 
 
-def _make_datasets() -> tuple[TensorDataset, TensorDataset]:
+@pytest.fixture
+def datasets() -> tuple[TensorDataset, TensorDataset]:
+    """Train/test TensorDataset pair sized 10 and 5 over a single feature."""
     return (
         TensorDataset(torch.randn(10, 1), torch.zeros(10)),
         TensorDataset(torch.randn(5, 1), torch.zeros(5)),
     )
 
 
-def test_amulet_dataset_required_fields():
-    train, test = _make_datasets()
+def test_amulet_dataset_required_fields(datasets):
+    train, test = datasets
     data = AmuletDataset(
         train_set=train,
         test_set=test,
@@ -26,8 +29,8 @@ def test_amulet_dataset_required_fields():
     assert data.num_classes == 2
 
 
-def test_amulet_dataset_optional_arrays_default_none():
-    train, test = _make_datasets()
+def test_amulet_dataset_optional_arrays_default_none(datasets):
+    train, test = datasets
     data = AmuletDataset(train_set=train, test_set=test, num_features=1, num_classes=2)
     assert data.x_train is None
     assert data.x_test is None
@@ -37,8 +40,8 @@ def test_amulet_dataset_optional_arrays_default_none():
     assert data.z_test is None
 
 
-def test_amulet_dataset_with_optional_arrays():
-    train, test = _make_datasets()
+def test_amulet_dataset_with_optional_arrays(datasets):
+    train, test = datasets
     x_train = np.array([[1], [2]])
     z_train = np.array([0, 1])
     data = AmuletDataset(

--- a/tests/unit/test_meta_classifiers.py
+++ b/tests/unit/test_meta_classifiers.py
@@ -1,0 +1,108 @@
+import pytest
+import torch
+
+from amulet.utils.__meta_classifiers import PermInvModel, meta_collate_fn
+
+
+def test_permutation_invariance():
+    # Arrange
+    # 2 layers: Layer1 (8 neurons, 4+1 dims), Layer2 (2 neurons, 8*H + 8+1 dims)
+    # Actually PIM init calculates input_dim = dim + prev_N * H
+    # Let's use simple dimensions.
+    layer_shapes = [(8, 5), (2, 9)]
+    model = PermInvModel(layer_shapes=layer_shapes, inside_dims=[16, 8])
+    model.eval()
+
+    # Create random weights for 1 sample
+    # layer_params_list: List of [Batch=1, N_neurons, Dim]
+    p1 = torch.randn(1, 8, 5)
+    p2 = torch.randn(1, 2, 9)
+    input_orig = [p1, p2]
+
+    # Shuffle neurons in Layer 1
+    perm = torch.randperm(8)
+    p1_shuffled = p1[:, perm, :]
+    input_shuffled = [p1_shuffled, p2]  # Only layer 1 is shuffled
+
+    # Act
+    with torch.no_grad():
+        out_orig = model(input_orig)
+        out_shuffled = model(input_shuffled)
+
+    # Assert
+    assert torch.allclose(out_orig, out_shuffled, atol=1e-6)
+
+
+def test_meta_collate_fn():
+    # Arrange
+    # 2 models in batch. Each has 2 layers.
+    m1_l1 = torch.randn(8, 4)
+    m1_l2 = torch.randn(2, 8)
+    m2_l1 = torch.randn(8, 4)
+    m2_l2 = torch.randn(2, 8)
+
+    batch = [([m1_l1, m1_l2], 0), ([m2_l1, m2_l2], 1)]
+
+    # Act
+    batched_params, labels = meta_collate_fn(batch)
+
+    # Assert
+    assert labels.tolist() == [0, 1]
+    assert len(batched_params) == 2
+    # Layer 1: [Batch=2, N=8, D=4]
+    assert batched_params[0].shape == (2, 8, 4)
+    # Layer 2: [Batch=2, N=2, D=8]
+    assert batched_params[1].shape == (2, 2, 8)
+    # Check data content
+    assert torch.equal(batched_params[0][0], m1_l1)
+    assert torch.equal(batched_params[1][1], m2_l2)
+
+
+def test_pim_batched_forward():
+    # Arrange
+    layer_shapes = [(8, 4), (2, 8)]
+    model = PermInvModel(layer_shapes=layer_shapes, inside_dims=[16, 4])
+
+    # Batch of 3 models
+    p1 = torch.randn(3, 8, 4)
+    p2 = torch.randn(3, 2, 8)
+
+    # Act
+    out = model([p1, p2])
+
+    # Assert
+    assert out.shape == (3, 1)
+
+
+def test_pim_invalid_input_mismatch():
+    # Arrange
+    model = PermInvModel(layer_shapes=[(8, 4)])
+    # Input has 10 neurons instead of 8
+    p1 = torch.randn(1, 10, 4)
+
+    # Act & Assert
+    with pytest.raises(
+        ValueError, match="expects 8 neurons"
+    ):  # Specific ValueError from forward guard
+        model([p1])
+
+
+def test_pim_conv2d_invariance():
+    # Arrange: Simulate a Conv2d layer [out=4, in=3, k=3, k=3] -> 4 "neurons", 27 features
+    layer_shapes = [(4, 27)]
+    model = PermInvModel(layer_shapes=layer_shapes)
+    model.eval()
+
+    p1 = torch.randn(1, 4, 27)
+
+    # Permute the "neurons" (output channels)
+    perm = torch.randperm(4)
+    p1_shuffled = p1[:, perm, :]
+
+    # Act
+    with torch.no_grad():
+        out_orig = model([p1])
+        out_shuffled = model([p1_shuffled])
+
+    # Assert
+    assert torch.allclose(out_orig, out_shuffled, atol=1e-6)

--- a/tests/unit/test_metrics_shared.py
+++ b/tests/unit/test_metrics_shared.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader, TensorDataset
@@ -9,9 +10,9 @@ from amulet.utils.__metrics import get_accuracy, get_fidelity
 
 
 class MockModel(nn.Module):
-    """A mock model that returns fixed predictions based on class index."""
+    """Mock model that emits one-hot logits from a fixed prediction tensor."""
 
-    def __init__(self, predictions):
+    def __init__(self, predictions: torch.Tensor):
         super().__init__()
         self.predictions = predictions
 
@@ -22,63 +23,6 @@ class MockModel(nn.Module):
         for i in range(batch_size):
             logits[i, self.predictions[i]] = 1.0
         return logits
-
-
-def test_get_accuracy_identity(cpu_device):
-    # Arrange: model always correct
-    labels = torch.tensor([0, 1, 2, 3])
-    model = MockModel(labels)
-    dataset = TensorDataset(torch.randn(4, 1), labels)
-    loader = DataLoader(dataset, batch_size=4)
-
-    # Act
-    acc = get_accuracy(model, loader, cpu_device)
-
-    # Assert
-    assert acc == 100.0
-
-
-def test_get_accuracy_zero(cpu_device):
-    # Arrange: model always wrong
-    labels = torch.tensor([0, 0])
-    model = MockModel(torch.tensor([1, 1]))
-    dataset = TensorDataset(torch.randn(2, 1), labels)
-    loader = DataLoader(dataset, batch_size=2)
-
-    # Act
-    acc = get_accuracy(model, loader, cpu_device)
-
-    # Assert
-    assert acc == 0.0
-
-
-def test_get_fidelity_perfect(cpu_device):
-    # Arrange: two models agree perfectly
-    preds = torch.tensor([0, 1, 0, 1])
-    m1 = MockModel(preds)
-    m2 = MockModel(preds)
-    dataset = TensorDataset(torch.randn(4, 1), torch.zeros(4))
-    loader = DataLoader(dataset, batch_size=4)
-
-    # Act
-    fid = get_fidelity(m1, m2, loader, cpu_device)
-
-    # Assert
-    assert fid == 100.0
-
-
-def test_get_fidelity_zero(cpu_device):
-    # Arrange: two models never agree
-    m1 = MockModel(torch.tensor([0, 0]))
-    m2 = MockModel(torch.tensor([1, 1]))
-    dataset = TensorDataset(torch.randn(2, 1), torch.zeros(2))
-    loader = DataLoader(dataset, batch_size=2)
-
-    # Act
-    fid = get_fidelity(m1, m2, loader, cpu_device)
-
-    # Assert
-    assert fid == 0.0
 
 
 class _HiddenMLP(AmuletModel):
@@ -96,7 +40,88 @@ class _HiddenMLP(AmuletModel):
         return self.body(x)
 
 
-def test_get_intermediate_features_shapes_and_dtype(cpu_device):
+@pytest.fixture
+def mock_model_factory():
+    """Factory fixture returning MockModel instances for caller-supplied predictions."""
+
+    def _make(predictions: torch.Tensor) -> MockModel:
+        return MockModel(predictions)
+
+    return _make
+
+
+@pytest.fixture
+def hidden_mlp_factory():
+    """Factory fixture returning _HiddenMLP instances for caller-supplied dimensions."""
+
+    def _make(
+        num_features: int = 4, hidden: int = 6, num_classes: int = 3
+    ) -> _HiddenMLP:
+        return _HiddenMLP(
+            num_features=num_features, hidden=hidden, num_classes=num_classes
+        )
+
+    return _make
+
+
+def test_get_accuracy_identity(cpu_device, mock_model_factory):
+    # Arrange: model always correct
+    labels = torch.tensor([0, 1, 2, 3])
+    model = mock_model_factory(labels)
+    dataset = TensorDataset(torch.randn(4, 1), labels)
+    loader = DataLoader(dataset, batch_size=4)
+
+    # Act
+    acc = get_accuracy(model, loader, cpu_device)
+
+    # Assert
+    assert acc == 100.0
+
+
+def test_get_accuracy_zero(cpu_device, mock_model_factory):
+    # Arrange: model always wrong
+    labels = torch.tensor([0, 0])
+    model = mock_model_factory(torch.tensor([1, 1]))
+    dataset = TensorDataset(torch.randn(2, 1), labels)
+    loader = DataLoader(dataset, batch_size=2)
+
+    # Act
+    acc = get_accuracy(model, loader, cpu_device)
+
+    # Assert
+    assert acc == 0.0
+
+
+def test_get_fidelity_perfect(cpu_device, mock_model_factory):
+    # Arrange: two models agree perfectly
+    preds = torch.tensor([0, 1, 0, 1])
+    m1 = mock_model_factory(preds)
+    m2 = mock_model_factory(preds)
+    dataset = TensorDataset(torch.randn(4, 1), torch.zeros(4))
+    loader = DataLoader(dataset, batch_size=4)
+
+    # Act
+    fid = get_fidelity(m1, m2, loader, cpu_device)
+
+    # Assert
+    assert fid == 100.0
+
+
+def test_get_fidelity_zero(cpu_device, mock_model_factory):
+    # Arrange: two models never agree
+    m1 = mock_model_factory(torch.tensor([0, 0]))
+    m2 = mock_model_factory(torch.tensor([1, 1]))
+    dataset = TensorDataset(torch.randn(2, 1), torch.zeros(2))
+    loader = DataLoader(dataset, batch_size=2)
+
+    # Act
+    fid = get_fidelity(m1, m2, loader, cpu_device)
+
+    # Assert
+    assert fid == 0.0
+
+
+def test_get_intermediate_features_shapes_and_dtype(cpu_device, hidden_mlp_factory):
     # Arrange: uneven batches (last batch smaller) to exercise concat over axis 0
     num_samples = 10
     num_features = 4
@@ -104,7 +129,7 @@ def test_get_intermediate_features_shapes_and_dtype(cpu_device):
     x = torch.randn(num_samples, num_features)
     y = torch.randint(0, 3, (num_samples,))
     loader = DataLoader(TensorDataset(x, y), batch_size=4, shuffle=False)
-    model = _HiddenMLP(num_features=num_features, hidden=hidden)
+    model = hidden_mlp_factory(num_features=num_features, hidden=hidden)
 
     # Act
     features, targets, inputs = get_intermediate_features(model, loader, cpu_device)

--- a/tests/unit/test_metrics_shared.py
+++ b/tests/unit/test_metrics_shared.py
@@ -1,0 +1,120 @@
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from amulet.models import AmuletModel
+from amulet.utils.__base import get_intermediate_features
+from amulet.utils.__metrics import get_accuracy, get_fidelity
+
+
+class MockModel(nn.Module):
+    """A mock model that returns fixed predictions based on class index."""
+
+    def __init__(self, predictions):
+        super().__init__()
+        self.predictions = predictions
+
+    def forward(self, x):
+        batch_size = x.size(0)
+        num_classes = 10
+        logits = torch.zeros(batch_size, num_classes)
+        for i in range(batch_size):
+            logits[i, self.predictions[i]] = 1.0
+        return logits
+
+
+def test_get_accuracy_identity(cpu_device):
+    # Arrange: model always correct
+    labels = torch.tensor([0, 1, 2, 3])
+    model = MockModel(labels)
+    dataset = TensorDataset(torch.randn(4, 1), labels)
+    loader = DataLoader(dataset, batch_size=4)
+
+    # Act
+    acc = get_accuracy(model, loader, cpu_device)
+
+    # Assert
+    assert acc == 100.0
+
+
+def test_get_accuracy_zero(cpu_device):
+    # Arrange: model always wrong
+    labels = torch.tensor([0, 0])
+    model = MockModel(torch.tensor([1, 1]))
+    dataset = TensorDataset(torch.randn(2, 1), labels)
+    loader = DataLoader(dataset, batch_size=2)
+
+    # Act
+    acc = get_accuracy(model, loader, cpu_device)
+
+    # Assert
+    assert acc == 0.0
+
+
+def test_get_fidelity_perfect(cpu_device):
+    # Arrange: two models agree perfectly
+    preds = torch.tensor([0, 1, 0, 1])
+    m1 = MockModel(preds)
+    m2 = MockModel(preds)
+    dataset = TensorDataset(torch.randn(4, 1), torch.zeros(4))
+    loader = DataLoader(dataset, batch_size=4)
+
+    # Act
+    fid = get_fidelity(m1, m2, loader, cpu_device)
+
+    # Assert
+    assert fid == 100.0
+
+
+def test_get_fidelity_zero(cpu_device):
+    # Arrange: two models never agree
+    m1 = MockModel(torch.tensor([0, 0]))
+    m2 = MockModel(torch.tensor([1, 1]))
+    dataset = TensorDataset(torch.randn(2, 1), torch.zeros(2))
+    loader = DataLoader(dataset, batch_size=2)
+
+    # Act
+    fid = get_fidelity(m1, m2, loader, cpu_device)
+
+    # Assert
+    assert fid == 0.0
+
+
+class _HiddenMLP(AmuletModel):
+    """2-layer MLP exposing get_hidden for intermediate-feature extraction."""
+
+    def __init__(self, num_features: int = 4, hidden: int = 6, num_classes: int = 3):
+        super().__init__()
+        self.body = nn.Sequential(nn.Linear(num_features, hidden), nn.ReLU())
+        self.head = nn.Linear(hidden, num_classes)
+
+    def forward(self, x):
+        return self.head(self.body(x))
+
+    def get_hidden(self, x):
+        return self.body(x)
+
+
+def test_get_intermediate_features_shapes_and_dtype(cpu_device):
+    # Arrange: uneven batches (last batch smaller) to exercise concat over axis 0
+    num_samples = 10
+    num_features = 4
+    hidden = 6
+    x = torch.randn(num_samples, num_features)
+    y = torch.randint(0, 3, (num_samples,))
+    loader = DataLoader(TensorDataset(x, y), batch_size=4, shuffle=False)
+    model = _HiddenMLP(num_features=num_features, hidden=hidden)
+
+    # Act
+    features, targets, inputs = get_intermediate_features(model, loader, cpu_device)
+
+    # Assert: shapes line up and rows are stacked, not object-wrapped
+    assert features.shape == (num_samples, hidden)
+    assert targets.shape == (num_samples,)
+    assert inputs.shape == (num_samples, num_features)
+    assert features.dtype == np.float32
+    assert inputs.dtype == np.float32
+    # Inputs round-trip through the loader unchanged.
+    np.testing.assert_allclose(inputs, x.numpy())
+    np.testing.assert_array_equal(targets, y.numpy())

--- a/tests/unit/test_pipeline_createdir.py
+++ b/tests/unit/test_pipeline_createdir.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from amulet.utils.__pipeline import create_dir
+
+
+def test_create_dir_new(tmp_path):
+    # Arrange
+    target = tmp_path / "new_dir"
+    assert not target.exists()
+
+    # Act
+    resolved = create_dir(target)
+
+    # Assert
+    assert resolved == target.resolve()
+    assert target.exists()
+    assert target.is_dir()
+
+
+def test_create_dir_exists(tmp_path):
+    # Arrange
+    target = tmp_path / "existing_dir"
+    target.mkdir()
+    assert target.exists()
+
+    # Act
+    resolved = create_dir(target)
+
+    # Assert
+    assert resolved == target.resolve()
+    assert target.exists()
+
+
+def test_create_dir_str_path(tmp_path):
+    # Arrange
+    target_str = str(tmp_path / "str_dir")
+
+    # Act
+    resolved = create_dir(target_str)
+
+    # Assert
+    assert isinstance(resolved, Path)
+    assert resolved.exists()
+    assert str(resolved) == str(Path(target_str).resolve())

--- a/tests/unit/test_pipeline_init.py
+++ b/tests/unit/test_pipeline_init.py
@@ -1,0 +1,58 @@
+import pytest
+import torch
+
+from amulet.models import VGG, AmuletModel, LinearNet, ResNet, SimpleCNN
+from amulet.utils.__pipeline import initialize_model
+
+
+def _input_for(arch: str, num_features: int) -> torch.Tensor:
+    """Return a forward-compatible input tensor for each architecture."""
+    if arch == "linearnet":
+        return torch.randn(1, num_features)
+    if arch == "cnn":
+        # SimpleCNN is hard-coded to 28x28 single-channel input.
+        return torch.randn(1, 1, 28, 28)
+    # VGG and ResNet: 3-channel 32x32 (VGG has 5 MaxPools, ResNet uses replace_first).
+    return torch.randn(1, 3, 32, 32)
+
+
+@pytest.mark.parametrize(
+    "arch, expected_class",
+    [
+        ("vgg", VGG),
+        ("resnet", ResNet),
+        ("linearnet", LinearNet),
+        ("cnn", SimpleCNN),
+    ],
+)
+@pytest.mark.parametrize("capacity", ["m1", "m2", "m3", "m4"])
+def test_initialize_model_variants(arch, expected_class, capacity):
+    num_features = 10
+    num_classes = 2
+
+    model = initialize_model(arch, capacity, num_features, num_classes)
+
+    assert isinstance(model, expected_class)
+    assert isinstance(model, AmuletModel)
+
+    # eval() bypasses batch-norm's "batch size > 1" training-mode check
+    # so the forward pass works with a single-sample probe input.
+    model.eval()
+    x = _input_for(arch, num_features)
+    with torch.no_grad():
+        out = model(x)
+        hidden = model.get_hidden(x)
+
+    assert out.shape == (1, num_classes)
+    assert isinstance(hidden, torch.Tensor)
+    assert hidden.shape[0] == 1
+
+
+def test_initialize_model_invalid_arch():
+    with pytest.raises(ValueError, match="Incorrect model architecture"):
+        initialize_model("invalid", "m1", 10, 2)
+
+
+def test_initialize_model_invalid_capacity():
+    with pytest.raises(KeyError, match="not found in model_conf"):
+        initialize_model("vgg", "invalid", 10, 2)

--- a/tests/unit/test_pipeline_split.py
+++ b/tests/unit/test_pipeline_split.py
@@ -1,0 +1,59 @@
+import torch
+from torch.utils.data import TensorDataset
+
+from amulet.utils.__pipeline import stratified_split
+
+
+def test_stratified_split_union_equality():
+    # Arrange
+    x = torch.randn(20, 1)
+    y = torch.tensor([0] * 10 + [1] * 10)
+    dataset = TensorDataset(x, y)
+    split_ratio = 0.5
+
+    # Act
+    split1, split2 = stratified_split(dataset, split_ratio, seed=42)
+
+    # Assert
+    assert len(split1) + len(split2) == len(dataset)
+    assert len(split1) == 10
+    assert len(split2) == 10
+
+    # Check that indices are disjoint and cover the whole range
+    indices1 = set(split1.indices)
+    indices2 = set(split2.indices)
+    assert indices1.isdisjoint(indices2)
+    assert indices1.union(indices2) == set(range(20))
+
+
+def test_stratified_split_proportions():
+    # Arrange: 100 samples, 80 class 0, 20 class 1
+    y = torch.tensor([0] * 80 + [1] * 20)
+    x = torch.randn(100, 1)
+    dataset = TensorDataset(x, y)
+    split_ratio = 0.25  # 25 samples in split1, 75 in split2
+
+    # Act
+    split1, _ = stratified_split(dataset, split_ratio, seed=42)
+
+    # Assert
+    # In split1 (size 25), we expect 25% of each class: 80*0.25=20 (class 0), 20*0.25=5 (class 1)
+    y1 = torch.tensor([split1[i][1] for i in range(len(split1))])
+    assert (y1 == 0).sum().item() == 20
+    assert (y1 == 1).sum().item() == 5
+
+
+def test_stratified_split_determinism():
+    # Arrange
+    x = torch.randn(20, 1)
+    y = torch.tensor([0] * 10 + [1] * 10)
+    dataset = TensorDataset(x, y)
+
+    # Act
+    s1_a, _ = stratified_split(dataset, 0.5, seed=42)
+    s1_b, _ = stratified_split(dataset, 0.5, seed=42)
+    s1_c, _ = stratified_split(dataset, 0.5, seed=123)
+
+    # Assert
+    assert s1_a.indices == s1_b.indices
+    assert s1_a.indices != s1_c.indices

--- a/tests/unit/test_weight_extraction.py
+++ b/tests/unit/test_weight_extraction.py
@@ -1,0 +1,109 @@
+import pytest
+import torch
+import torch.nn as nn
+
+from amulet.utils.__weight_extraction import get_layer_parameters
+
+
+def test_extract_linear_with_bias():
+    # Arrange
+    model = nn.Linear(4, 8)
+
+    # Act
+    params = get_layer_parameters(model)
+
+    # Assert
+    assert len(params) == 1
+    # [out_features, in_features + 1] -> [8, 5]
+    assert params[0].shape == (8, 5)
+    # Check bias is in the last column
+    assert torch.equal(params[0][:, -1], model.bias.data)
+
+
+def test_extract_linear_no_bias():
+    # Arrange
+    model = nn.Linear(4, 8, bias=False)
+
+    # Act
+    params = get_layer_parameters(model)
+
+    # Assert
+    assert len(params) == 1
+    # [out_features, in_features] -> [8, 4]
+    assert params[0].shape == (8, 4)
+
+
+def test_extract_conv2d_with_bias():
+    # Arrange: [out=2, in=3, k=3, k=3]
+    model = nn.Conv2d(3, 2, kernel_size=3)
+
+    # Act
+    params = get_layer_parameters(model)
+
+    # Assert
+    assert len(params) == 1
+    # [out, in*k*k + 1] -> [2, 3*3*3 + 1] -> [2, 28]
+    assert params[0].shape == (2, 28)
+
+
+def test_extract_mixed_and_ignore_layers():
+    # Arrange
+    class MixedModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = nn.Conv2d(3, 16, 3)
+            self.bn = nn.BatchNorm2d(16)
+            self.relu = nn.ReLU()
+            self.fc = nn.Linear(16, 10)
+
+        def forward(self, x):
+            return self.fc(self.relu(self.bn(self.conv(x))))
+
+    model = MixedModel()
+
+    # Act
+    params = get_layer_parameters(model)
+
+    # Assert
+    assert len(params) == 2  # Only Conv and Linear
+    assert params[0].shape == (16, 3 * 3 * 3 + 1)
+    assert params[1].shape == (10, 16 + 1)
+
+
+def test_extract_dataparallel_unwrap():
+    # Arrange
+    inner_model = nn.Linear(4, 2)
+    model = nn.DataParallel(inner_model)
+
+    # Act
+    params = get_layer_parameters(model)
+
+    # Assert
+    assert len(params) == 1
+    assert params[0].shape == (2, 5)
+    # Ensure it's the same data
+    assert torch.equal(params[0][:, :4], inner_model.weight.data.cpu())
+
+
+@pytest.mark.parametrize("in_f, out_f", [(4, 8), (10, 2)])
+def test_extract_linear_parameterized(in_f, out_f):
+    # Arrange
+    model = nn.Linear(in_f, out_f)
+
+    # Act
+    params = get_layer_parameters(model)
+
+    # Assert
+    assert params[0].shape == (out_f, in_f + 1)
+
+
+def test_extract_empty_model():
+    # Arrange: No Linear or Conv layers
+    model = nn.Sequential(nn.ReLU(), nn.Sigmoid())
+
+    # Act
+    params = get_layer_parameters(model)
+
+    # Assert
+    assert isinstance(params, list)
+    assert len(params) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -38,6 +38,7 @@ dev = [
     { name = "basedpyright" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
 ]
 
@@ -53,11 +54,12 @@ requires-dist = [
     { name = "pandas", specifier = "==2.2.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "==3.7.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==8.3.2" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = "==2.3.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.11.0" },
     { name = "scikit-image", specifier = "==0.25.1" },
     { name = "scikit-learn", specifier = "==1.4.1.post1" },
     { name = "scipy", specifier = "==1.12.0" },
-    { name = "torch", specifier = ">=2.2.0" },
+    { name = "torch", specifier = ">=2.3.0" },
     { name = "torchvision", specifier = ">=0.18.0" },
     { name = "tqdm", specifier = "==4.66.2" },
     { name = "ucimlrepo", specifier = "==0.0.3" },
@@ -868,6 +870,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b4/8c/9862305bdcd6020bc7b45b1b5e7397a6caf1a33d3025b9a003b39075ffb2/pytest-8.3.2.tar.gz", hash = "sha256:c132345d12ce551242c87269de812483f5bcc87cdbb4722e48487ba194f9fdce", size = 1439314, upload-time = "2024-07-25T10:40:00.159Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/f9/cf155cf32ca7d6fa3601bc4c5dd19086af4b320b706919d48a4c79081cf9/pytest-8.3.2-py3-none-any.whl", hash = "sha256:4ba08f9ae7dcf84ded419494d229b48d0903ea6407b030eaec46df5e6a73bba5", size = 341802, upload-time = "2024-07-25T10:39:57.834Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/0d/04719abc7a4bdb3a7a1f968f24b0f5253d698c9cc94975330e9d3145befb/pytest-timeout-2.3.1.tar.gz", hash = "sha256:12397729125c6ecbdaca01035b9e5239d4db97352320af155b3f5de1ba5165d9", size = 17697, upload-time = "2024-03-07T21:04:01.069Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/27/14af9ef8321f5edc7527e47def2a21d8118c6f329a9342cc61387a0c0599/pytest_timeout-2.3.1-py3-none-any.whl", hash = "sha256:68188cb703edfc6a18fad98dc25a3c61e9f24d644b0b70f33af545219fc7813e", size = 14148, upload-time = "2024-03-07T21:03:58.764Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

This is PR 1 of a stacked series that splits a large refactor into reviewable layers. No risk-module logic is changed here — this PR lands only the infrastructure that later PRs will import.

**Stack order:**
1. **This PR** — model base class, shared utilities, tooling
2. PR 2 — abstract base classes for all risk modules (API contract)
3. PR 3 — dataset loader rewrites (CelebA, LFW, UTKFace, Census)
4. PRs 4.1–4.7 — one risk vertical per PR (attack + defense + metrics + tests)
5. PR 5 — examples reconciled with new APIs
6. PR 6 — documentation overhaul

## Models (`amulet/models/`)

- **`base.py` (new):** `AmuletModel` — a lightweight `nn.Module` subclass that declares `get_hidden(self, x) -> Tensor`. All existing architectures (VGG, CNN, LinearNet, ResNet) now subclass it. Any PyTorch model can be integrated into Amulet pipelines by wrapping it in a thin `AmuletModel` subclass and implementing `get_hidden` to expose whichever intermediate layer is relevant — no need to reimplement the full model. The architectures in `amulet/models/` are convenience models for experimentation and are not required by the library. Omitting `get_hidden` raises `NotImplementedError` at runtime; several attack modules depend on intermediate activations.

## New shared utilities (`amulet/utils/`)

- **`__meta_classifiers.py` (new):** `PermInvModel` — permutation-invariant meta-classifier used by the White-Box PIM distribution-inference attack (landing in PR 4.1). Placed in `utils/` so any future white-box attack can reuse it without a cross-module import.
- **`__weight_extraction.py` (new):** helpers that extract weight tensors from `nn.Module` instances into the shape `PermInvModel` expects.

## Updated shared utilities (`amulet/utils/`)

`__base.py`, `__pipeline.py`, `__metrics.py`, `__init__.py`:
- Google-style docstring sweep
- Modern type annotations (`Optional[X]` → `X | None`, `typing.List` → `list`)
- `torch.cuda.amp` → `torch.amp` migration (deprecated in PyTorch 2.3)
- `ValueError` raised for unknown datasets instead of `sys.exit()`
- `initialize_model` return type narrowed from `nn.Module` to `AmuletModel`

## Tooling

- **`pyproject.toml`:** ruff config added (`preview = true`, `target-version = "py311"`, rulesets `E W F I UP B C4 SIM RUF`); `pytest-timeout` added; `torch` floor bumped to 2.3.0. `ucimlrepo` is retained here because `amulet/datasets/__tabular_datasets.py` still uses it — it is removed in PR 3 when that file is replaced.
- **`.pre-commit-config.yaml`:** markdownlint and prettier hooks added; ruff hook rev synced with `ruff==` dev dep (a mismatch silently skips rules).
- **`.markdownlint.json`:** per-repo markdownlint config.
- **`.markdownlintignore`:** excludes `docs/` and `examples/extending_amulet/` — these have pre-existing violations that are fixed in PR 6.
- **`AGENTS.md` (new):** minimal agent-guidance file — commands, directory index, and non-obvious invariants only.

## Tests (all new)

- `tests/conftest.py`: shared fixtures including a GPU-parametrised `device` fixture.
- `tests/unit/test_dataset_dataclass.py`: `AmuletDataset` field validation.
- `tests/unit/test_pipeline_{createdir,init,split}.py`: `load_data` / `initialize_model` / split helpers.
- `tests/unit/test_metrics_shared.py`: `compute_accuracy` edge cases.
- `tests/unit/test_meta_classifiers.py`: `PermInvModel` forward pass and output shape.
- `tests/unit/test_weight_extraction.py`: weight-extraction shape contracts.

## Ruff sweep

Adding ruff config exposed 21 pre-existing violations in files not otherwise modified here. These are fixed in this PR to keep CI green. The affected files are rewritten in their respective vertical PRs (datasets in PR 3, risk modules in PRs 4.x, examples in PR 5) — treat these changes as a mechanical style fix accompanying the linter addition.

Closes #26