### PR TITLE
refactor: add abstract base classes for all risk module attack and defense entry points

### DIFF
--- a/amulet/attribute_inference/attacks/attribute_inference_attack.py
+++ b/amulet/attribute_inference/attacks/attribute_inference_attack.py
@@ -1,21 +1,23 @@
 """Attribute Inference Attack Base class"""
 
+from abc import ABC, abstractmethod
+
 import numpy as np
 import torch.nn as nn
 
 
-class AttributeInferenceAttack:
+class AttributeInferenceAttack(ABC):
     """
     Base class for attribute inference attacks
 
     Attributes:
-        target_model: :class:`~torch.nn.Module`
+        target_model: torch.nn.Module
             This model will be extracted.
-        x_train_adv: :class:`~numpy.ndarray`
+        x_train_adv: numpy.ndarray
             input features for training adversary' attack model
-        x_test: :class:`~numpy.ndarray`
+        x_test: numpy.ndarray
             input features for testing adversary' attack model
-        z_train_adv: :class:`~numpy.ndarray`
+        z_train_adv: numpy.ndarray
             sensitive attributes for training adversary' attack model
         device: str
             Device used to train model. Example: "cuda:0".
@@ -34,3 +36,7 @@ class AttributeInferenceAttack:
         self.z_train_adv = z_train_adv
         self.x_test = x_test
         self.device = device
+
+    @abstractmethod
+    def attack(self) -> dict[int, dict[str, np.ndarray]]:
+        pass

--- a/amulet/data_reconstruction/attacks/data_reconstruction_attack.py
+++ b/amulet/data_reconstruction/attacks/data_reconstruction_attack.py
@@ -1,14 +1,17 @@
 """Base class for Data Reconstruction Attacks"""
 
+from abc import ABC, abstractmethod
+
+import torch
 import torch.nn as nn
 
 
-class DataReconstructionAttack:
+class DataReconstructionAttack(ABC):
     """
     Base class for Data Reconstruction Attacks
     Attributes::
         ------------------------
-        target_model: :class:`~torch.nn.Module`
+        target_model: torch.nn.Module
             Target model whose training dataset we reconstruct
         input_size: int
             Size of the model's input
@@ -29,3 +32,7 @@ class DataReconstructionAttack:
         self.input_size = input_size
         self.output_size = output_size
         self.device = device
+
+    @abstractmethod
+    def attack(self) -> list[torch.Tensor]:
+        pass

--- a/amulet/discriminatory_behavior/defenses/adversarial_debiasing.py
+++ b/amulet/discriminatory_behavior/defenses/adversarial_debiasing.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 from sklearn import metrics
 from torch.utils.data import DataLoader
 
-from .discr_behavior_defense import DicriminatoryBehaviorDefense
+from .discr_behavior_defense import DiscriminatoryBehaviorDefense
 
 
 class AdversaryModel(nn.Module):
@@ -36,7 +36,7 @@ class AdversaryModel(nn.Module):
         return torch.sigmoid(self.network(x))
 
 
-class AdversarialDebiasing(DicriminatoryBehaviorDefense):
+class AdversarialDebiasing(DiscriminatoryBehaviorDefense):
     """
     Implementation of Adversarial Training algorithm from the method from cleverhans:
     https://xebia.com/blog/towards-fairness-in-ml-with-adversarial-networks/
@@ -114,11 +114,11 @@ class AdversarialDebiasing(DicriminatoryBehaviorDefense):
             p_z = self.discmodel(p_y)
             loss_adv = (self.adv_criterion(p_z, z) * self.lambdas).mean()  # type: ignore[reportPossiblyUnboundVariable]
             model_loss = (
-                self.model_criterion(p_y, y)  # type: ignore[reportPossiblyUnboundVariable]
+                self.criterion(p_y, y)  # type: ignore[reportPossiblyUnboundVariable]
                 - (self.adv_criterion(self.discmodel(p_y), z) * self.lambdas).mean()
             )
             model_loss.backward()
-            self.model_optimizer.step()
+            self.optimizer.step()
 
         return self.model
 

--- a/amulet/discriminatory_behavior/defenses/discr_behavior_defense.py
+++ b/amulet/discriminatory_behavior/defenses/discr_behavior_defense.py
@@ -1,24 +1,26 @@
 """Base class for Discriminatory Behavior defenses"""
 
+from abc import ABC, abstractmethod
+
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
 
 
-class DicriminatoryBehaviorDefense:
+class DiscriminatoryBehaviorDefense(ABC):
     """
     Base class for Discriminatory Behavior defenses
 
     Attributes:
-        model: :class:`~torch.nn.Module`
+        model: torch.nn.Module
             The model on which to apply adversarial training.
-        criterion: :class:`~torch.nn.Module`
+        criterion: torch.nn.Module
             Loss function for adversarial training.
-        optimizer: :class:`~torch.optim.Optimizer`
+        optimizer: torch.optim.Optimizer
             Optimizer for adversarial training.
-        train_loader: :class:`~torch.utils.data.DataLoader`
+        train_loader: torch.utils.data.DataLoader
             Training data loader to adversarial training.
-        test_loader: :class:`~torch.utils.data.DataLoader`
+        test_loader: torch.utils.data.DataLoader
             Testing data loader to adversarial training.
         lambdas: :class:`torch.Tensor`
             Hyperparameters for fairness objective function
@@ -38,8 +40,12 @@ class DicriminatoryBehaviorDefense:
         device: str,
     ):
         self.model = model
-        self.model_criterion = criterion
-        self.model_optimizer = optimizer
+        self.criterion = criterion
+        self.optimizer = optimizer
         self.train_loader = train_loader
         self.test_loader = test_loader
         self.device = device
+
+    @abstractmethod
+    def train_fair(self) -> nn.Module:
+        pass

--- a/amulet/distribution_inference/attacks/__init__.py
+++ b/amulet/distribution_inference/attacks/__init__.py
@@ -1,3 +1,4 @@
 from .distribution_inference import DistributionInference
+from .distribution_inference_attack import DistributionInferenceAttack
 
-__all__ = ["DistributionInference"]
+__all__ = ["DistributionInference", "DistributionInferenceAttack"]

--- a/amulet/distribution_inference/attacks/distribution_inference_attack.py
+++ b/amulet/distribution_inference/attacks/distribution_inference_attack.py
@@ -1,0 +1,238 @@
+"""Distribution Inference Attack Base class."""
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+from ...utils import initialize_model, train_classifier
+from ..dataset_utils import DistributionSplits, prepare_distribution_splits
+
+
+class DistributionInferenceAttack(ABC):
+    """
+    Base class for distribution inference attacks.
+
+    Distribution inference attacks infer global statistical properties of a
+    training distribution, such as the proportion of samples with a given
+    sensitive-attribute value, rather than facts about individual records.
+
+    Follows the same lifecycle as MembershipInferenceAttack:
+    1. Construct with data and training parameters.
+    2. Call prepare_model_populations() to train and cache the four model
+       populations (adversary D1, adversary D2, victim D1, victim D2).
+    3. Call attack() to run the distinguishing test.
+
+    Attributes:
+        x_train: Training features.
+        y_train: Training labels, shape (N,).
+        z_train: Training sensitive attributes, shape (N, n_sensitive_cols).
+        x_test: Test features.
+        y_test: Test labels.
+        z_test: Test sensitive attributes.
+        sensitive_columns: Column names for the z arrays.
+        filter_column: Sensitive column whose proportion is being inferred.
+        ratio1: Target proportion of filter_column == filter_value for D1.
+        ratio2: Target proportion for D2.
+        filter_value: Value of filter_column that satisfies the filter.
+        drop_values: Per-column values to drop before sampling.
+        train_subsample: Minority-class sample count per training draw.
+        test_subsample: Minority-class sample count per test draw.
+        model_arch: Architecture for population models. Example: "linearnet".
+        model_capacity: Capacity for population models. Example: "m1".
+        num_features: Number of input features.
+        num_classes: Number of output classes.
+        num_models: Number of models trained per population.
+        epochs: Training epochs per model.
+        batch_size: Batch size for DataLoaders and model training.
+        device: Device used for training and inference. Example: "cuda:0".
+        models_dir: Directory to save and load population model checkpoints.
+        dataset: Dataset name used as part of checkpoint filenames.
+        exp_id: Experiment ID used as a random seed disambiguator.
+    """
+
+    def __init__(
+        self,
+        x_train: np.ndarray,
+        y_train: np.ndarray,
+        z_train: np.ndarray,
+        x_test: np.ndarray,
+        y_test: np.ndarray,
+        z_test: np.ndarray,
+        sensitive_columns: list[str],
+        filter_column: str,
+        ratio1: float,
+        ratio2: float,
+        model_arch: str,
+        model_capacity: str,
+        num_features: int,
+        num_classes: int,
+        num_models: int,
+        epochs: int,
+        batch_size: int,
+        device: str,
+        models_dir: Path | str,
+        dataset: str,
+        exp_id: int = 0,
+        filter_value: int = 1,
+        drop_values: dict[str, list[int]] | None = None,
+        train_subsample: int = 1100,
+        test_subsample: int = 500,
+    ):
+        self.x_train = x_train
+        self.y_train = y_train
+        self.z_train = z_train
+        self.x_test = x_test
+        self.y_test = y_test
+        self.z_test = z_test
+        self.sensitive_columns = sensitive_columns
+        self.filter_column = filter_column
+        self.ratio1 = ratio1
+        self.ratio2 = ratio2
+        self.filter_value = filter_value
+        self.drop_values = drop_values
+        self.train_subsample = train_subsample
+        self.test_subsample = test_subsample
+        self.model_arch = model_arch
+        self.model_capacity = model_capacity
+        self.num_features = num_features
+        self.num_classes = num_classes
+        self.num_models = num_models
+        self.epochs = epochs
+        self.batch_size = batch_size
+        self.device = device
+        self.dataset = dataset
+        self.exp_id = exp_id
+
+        if isinstance(models_dir, str):
+            models_dir = Path(models_dir)
+        self.models_dir = models_dir
+
+        self.splits: DistributionSplits | None = None
+        self.models_adv_1: list[nn.Module] = []
+        self.models_adv_2: list[nn.Module] = []
+        self.models_vic_1: list[nn.Module] = []
+        self.models_vic_2: list[nn.Module] = []
+
+    def train_model_population(
+        self,
+        loader: DataLoader,
+        *,
+        checkpoint_tag: str,
+        model_arch: str | None = None,
+        model_capacity: str | None = None,
+        num_models: int | None = None,
+        epochs: int | None = None,
+    ) -> list[nn.Module]:
+        """
+        Train or load a population of models from a single DataLoader.
+
+        Defaults to the instance's stored arch, capacity, num_models, and
+        epochs. Pass overrides when a population requires different settings
+        (e.g. shadow models with a smaller architecture than the target).
+
+        Args:
+            loader: DataLoader supplying training batches.
+            checkpoint_tag: Unique string identifying this population within
+                models_dir. Convention:
+                "{dataset}_dist_inf_{role}_{dist}_{arch}_{capacity}".
+                Per-model files: {models_dir}/{checkpoint_tag}_{id}_{exp_id}.pth.
+            model_arch: Architecture override. Defaults to self.model_arch.
+            model_capacity: Capacity override. Defaults to self.model_capacity.
+            num_models: Model count override. Defaults to self.num_models.
+            epochs: Epoch count override. Defaults to self.epochs.
+
+        Returns:
+            List of trained models set to eval mode with gradients frozen.
+        """
+        arch = model_arch if model_arch is not None else self.model_arch
+        capacity = model_capacity if model_capacity is not None else self.model_capacity
+        n_models = num_models if num_models is not None else self.num_models
+        n_epochs = epochs if epochs is not None else self.epochs
+
+        self.models_dir.mkdir(parents=True, exist_ok=True)
+        criterion = nn.CrossEntropyLoss()
+        models: list[nn.Module] = []
+
+        for model_id in range(n_models):
+            filename = (
+                self.models_dir / f"{checkpoint_tag}_{model_id}_{self.exp_id}.pth"
+            )
+            model = initialize_model(
+                arch, capacity, self.num_features, self.num_classes
+            ).to(self.device)
+
+            if filename.exists():
+                state = torch.load(
+                    filename, weights_only=True, map_location=self.device
+                )
+                model.load_state_dict(state)
+            else:
+                print(f"Training {checkpoint_tag} model {model_id + 1}/{n_models}")
+                optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+                model = train_classifier(
+                    model, loader, criterion, optimizer, n_epochs, self.device
+                )
+                torch.save(model.state_dict(), filename)
+
+            model.eval()
+            model.requires_grad_(False)
+            models.append(model)
+
+        return models
+
+    def prepare_model_populations(self) -> None:
+        """
+        Build distribution splits and train all four model populations.
+
+        Calls prepare_distribution_splits internally, then trains num_models
+        models on each of the four resulting loaders (adversary D1, adversary D2,
+        victim D1, victim D2). Models are saved to models_dir; already-saved
+        checkpoints are loaded rather than retrained.
+
+        Must be called before attack().
+        """
+        self.splits = prepare_distribution_splits(
+            self.x_train,
+            self.y_train,
+            self.z_train,
+            self.x_test,
+            self.y_test,
+            self.z_test,
+            sensitive_columns=self.sensitive_columns,
+            filter_column=self.filter_column,
+            ratio1=self.ratio1,
+            ratio2=self.ratio2,
+            train_subsample=self.train_subsample,
+            test_subsample=self.test_subsample,
+            filter_value=self.filter_value,
+            drop_values=self.drop_values,
+            batch_size=self.batch_size,
+            seed=self.exp_id,
+        )
+
+        def _tag(role: str, dist: str) -> str:
+            return (
+                f"{self.dataset}_dist_inf_{role}_{dist}_"
+                f"{self.model_arch}_{self.model_capacity}"
+            )
+
+        self.models_adv_1 = self.train_model_population(
+            self.splits.adv_trainloader_1, checkpoint_tag=_tag("adv", "1")
+        )
+        self.models_adv_2 = self.train_model_population(
+            self.splits.adv_trainloader_2, checkpoint_tag=_tag("adv", "2")
+        )
+        self.models_vic_1 = self.train_model_population(
+            self.splits.vic_trainloader_1, checkpoint_tag=_tag("vic", "1")
+        )
+        self.models_vic_2 = self.train_model_population(
+            self.splits.vic_trainloader_2, checkpoint_tag=_tag("vic", "2")
+        )
+
+    @abstractmethod
+    def attack(self) -> dict[str, np.ndarray]:
+        pass

--- a/amulet/distribution_inference/dataset_utils.py
+++ b/amulet/distribution_inference/dataset_utils.py
@@ -1,0 +1,261 @@
+"""
+Dataset preparation helpers for distribution inference attacks.
+
+A distribution inference attack distinguishes two training distributions
+that differ in the proportion of samples satisfying some filter (e.g.
+``sex == 1``). Each side of the attack (victim and adversary) requires
+training data sampled to the target proportion. These helpers perform the
+ratio-preserving subsampling and return the six DataLoaders the attack
+consumes.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+from sklearn.model_selection import StratifiedShuffleSplit
+from torch.utils.data import ConcatDataset, DataLoader, TensorDataset
+
+
+@dataclass
+class DistributionSplits:
+    """DataLoaders produced by :func:`prepare_distribution_splits`."""
+
+    vic_trainloader_1: DataLoader
+    vic_trainloader_2: DataLoader
+    adv_trainloader_1: DataLoader
+    adv_trainloader_2: DataLoader
+    test_loader_1: DataLoader
+    test_loader_2: DataLoader
+
+
+def _filter_by_ratio(mask: np.ndarray, ratio: float) -> np.ndarray:
+    """Return indices such that mask[indices].mean() ≈ ratio."""
+    qualify = np.nonzero(mask)[0]
+    notqualify = np.nonzero(~mask)[0]
+    current_ratio = len(qualify) / (len(qualify) + len(notqualify))
+
+    if current_ratio <= ratio:
+        np.random.shuffle(notqualify)
+        if ratio < 1:
+            nqi = notqualify[: int(((1 - ratio) * len(qualify)) / ratio)]
+            return np.concatenate([qualify, nqi])
+        return qualify
+
+    np.random.shuffle(qualify)
+    if ratio > 0:
+        qi = qualify[: int((ratio * len(notqualify)) / (1 - ratio))]
+        return np.concatenate([qi, notqualify])
+    return notqualify
+
+
+def _heuristic_sample(
+    y: np.ndarray,
+    filter_mask: np.ndarray,
+    ratio: float,
+    cwise_sample: int,
+    class_imbalance: float = 2.0,
+    n_tries: int = 1000,
+) -> np.ndarray:
+    """Return indices achieving the ratio closest to target over n_tries draws.
+
+    Args:
+        y: 1-D label array. Must be binary (0/1).
+        filter_mask: Boolean array of the same length; True where the filter
+            condition holds.
+        ratio: Target fraction of True values in filter_mask after sampling.
+        cwise_sample: Minority-class sample count per draw.
+        class_imbalance: Majority / minority class count ratio.
+        n_tries: Number of sampling attempts.
+
+    Returns:
+        Sorted integer index array selecting the best draw.
+    """
+    vals: list[float] = []
+    idx_list: list[np.ndarray] = []
+
+    for _ in range(n_tries):
+        pool = _filter_by_ratio(filter_mask, ratio)
+
+        zero_ids = pool[y[pool] == 0]
+        one_ids = pool[y[pool] == 1]
+
+        if class_imbalance >= 1:
+            zero_ids = np.random.permutation(zero_ids)[
+                : int(class_imbalance * cwise_sample)
+            ]
+            one_ids = np.random.permutation(one_ids)[:cwise_sample]
+        else:
+            zero_ids = np.random.permutation(zero_ids)[:cwise_sample]
+            one_ids = np.random.permutation(one_ids)[
+                : int(cwise_sample / class_imbalance)
+            ]
+
+        picked = np.sort(np.concatenate([zero_ids, one_ids]))
+        vals.append(float(filter_mask[picked].mean()))
+        idx_list.append(picked)
+
+    diffs = np.abs(np.array(vals) - ratio)
+    return idx_list[int(np.argmin(diffs))]
+
+
+def _build_tensor_dataset(x: np.ndarray, y: np.ndarray) -> TensorDataset:
+    return TensorDataset(
+        torch.from_numpy(np.ascontiguousarray(x, dtype=np.float32)),
+        torch.from_numpy(np.ascontiguousarray(y, dtype=np.int64)),
+    )
+
+
+def _stratify_key(y: np.ndarray, z: np.ndarray) -> np.ndarray:
+    """Encode each (y, z_row) combination as a unique integer for stratified splitting."""
+    cols = np.column_stack([y.reshape(-1, 1), z])
+    _, inverse = np.unique(cols, axis=0, return_inverse=True)
+    return inverse
+
+
+def prepare_distribution_splits(
+    x_train: np.ndarray,
+    y_train: np.ndarray,
+    z_train: np.ndarray,
+    x_test: np.ndarray,
+    y_test: np.ndarray,
+    z_test: np.ndarray,
+    sensitive_columns: list[str],
+    filter_column: str,
+    ratio1: float,
+    ratio2: float,
+    train_subsample: int,
+    test_subsample: int,
+    filter_value: int = 1,
+    drop_values: dict[str, list[int]] | None = None,
+    class_imbalance: float = 3.0,
+    n_tries: int = 100,
+    batch_size: int = 256,
+    seed: int = 42,
+) -> DistributionSplits:
+    """
+    Build the six DataLoaders a distribution inference attack consumes.
+
+    The train/test arrays are each split 50/50 into victim and adversary halves
+    (stratified on labels and every sensitive column). Each half is then
+    subsampled twice, once for ``ratio1`` and once for ``ratio2``, to produce
+    the four training loaders plus two combined test loaders.
+
+    Works with any input shape: tabular ``(N, d)``, image ``(N, C, H, W)``, etc.
+    Features and sensitive attributes are never merged, so the model receives
+    only the original feature array.
+
+    Args:
+        x_train, y_train, z_train: Training features, labels (1-D), sensitive
+            attributes (2-D, one column per attribute).
+        x_test, y_test, z_test: Test features, labels, sensitive attributes.
+        sensitive_columns: Column names for ``z_train``/``z_test``. Length must
+            match ``z_train.shape[1]``.
+        filter_column: Name of the sensitive column whose proportion is being
+            inferred. Must be in ``sensitive_columns``.
+        ratio1: Target proportion of rows satisfying ``filter_column == filter_value``
+            for distribution 1.
+        ratio2: Target proportion for distribution 2.
+        train_subsample: Minority-class sample count per train draw.
+        test_subsample: Minority-class sample count per test draw.
+        filter_value: Value of ``filter_column`` that satisfies the filter.
+        drop_values: Optional per-column list of values to drop before sampling,
+            e.g. ``{"race": [2]}`` to exclude a multi-class label the binary
+            filter cannot express.
+        class_imbalance: Target ratio of majority-class to minority-class samples
+            per draw.
+        n_tries: Number of sampling attempts per draw.
+        batch_size: Batch size for the returned DataLoaders.
+        seed: Random seed for the 50/50 train/test split.
+    """
+    if filter_column not in sensitive_columns:
+        raise ValueError(
+            f"filter_column '{filter_column}' must be one of sensitive_columns "
+            f"{sensitive_columns}"
+        )
+    if z_train.shape[1] != len(sensitive_columns):
+        raise ValueError(
+            f"z_train has {z_train.shape[1]} columns but sensitive_columns has "
+            f"{len(sensitive_columns)}"
+        )
+
+    y_train = y_train.ravel()
+    y_test = y_test.ravel()
+    filter_col_idx = sensitive_columns.index(filter_column)
+
+    if drop_values:
+        keep_train = np.ones(len(x_train), dtype=bool)
+        keep_test = np.ones(len(x_test), dtype=bool)
+        for col, vals in drop_values.items():
+            col_idx = sensitive_columns.index(col)
+            for v in vals:
+                keep_train &= z_train[:, col_idx] != v
+                keep_test &= z_test[:, col_idx] != v
+        x_train, y_train, z_train = (
+            x_train[keep_train],
+            y_train[keep_train],
+            z_train[keep_train],
+        )
+        x_test, y_test, z_test = (
+            x_test[keep_test],
+            y_test[keep_test],
+            z_test[keep_test],
+        )
+
+    def split_50_50(
+        x: np.ndarray, y: np.ndarray, z: np.ndarray
+    ) -> tuple[
+        tuple[np.ndarray, np.ndarray, np.ndarray],
+        tuple[np.ndarray, np.ndarray, np.ndarray],
+    ]:
+        strat = _stratify_key(y, z)
+        splitter = StratifiedShuffleSplit(n_splits=1, test_size=0.5, random_state=seed)
+        left_idx, right_idx = next(splitter.split(x, strat))
+        return (x[left_idx], y[left_idx], z[left_idx]), (
+            x[right_idx],
+            y[right_idx],
+            z[right_idx],
+        )
+
+    (x_vic, y_vic, z_vic), (x_adv, y_adv, z_adv) = split_50_50(
+        x_train, y_train, z_train
+    )
+    (x_tv, y_tv, z_tv), (x_ta, y_ta, z_ta) = split_50_50(x_test, y_test, z_test)
+
+    def draw(
+        x: np.ndarray, y: np.ndarray, z: np.ndarray, ratio: float, subsample: int
+    ) -> TensorDataset:
+        idx = _heuristic_sample(
+            y,
+            z[:, filter_col_idx] == filter_value,
+            ratio,
+            subsample,
+            class_imbalance,
+            n_tries,
+        )
+        return _build_tensor_dataset(x[idx], y[idx])
+
+    vic_train_1 = draw(x_vic, y_vic, z_vic, ratio1, train_subsample)
+    vic_train_2 = draw(x_vic, y_vic, z_vic, ratio2, train_subsample)
+    adv_train_1 = draw(x_adv, y_adv, z_adv, ratio1, train_subsample)
+    adv_train_2 = draw(x_adv, y_adv, z_adv, ratio2, train_subsample)
+
+    vic_test_1 = draw(x_tv, y_tv, z_tv, ratio1, test_subsample)
+    vic_test_2 = draw(x_tv, y_tv, z_tv, ratio2, test_subsample)
+    adv_test_1 = draw(x_ta, y_ta, z_ta, ratio1, test_subsample)
+    adv_test_2 = draw(x_ta, y_ta, z_ta, ratio2, test_subsample)
+
+    test_1: ConcatDataset = ConcatDataset([adv_test_1, vic_test_1])
+    test_2: ConcatDataset = ConcatDataset([adv_test_2, vic_test_2])
+
+    def make_loader(ds: TensorDataset | ConcatDataset) -> DataLoader:  # type: ignore[type-arg]
+        return DataLoader(dataset=ds, batch_size=batch_size, shuffle=False)
+
+    return DistributionSplits(
+        vic_trainloader_1=make_loader(vic_train_1),
+        vic_trainloader_2=make_loader(vic_train_2),
+        adv_trainloader_1=make_loader(adv_train_1),
+        adv_trainloader_2=make_loader(adv_train_2),
+        test_loader_1=make_loader(test_1),
+        test_loader_2=make_loader(test_2),
+    )

--- a/amulet/evasion/attacks/evasion_attack.py
+++ b/amulet/evasion/attacks/evasion_attack.py
@@ -1,17 +1,19 @@
 """Model Evasion Attack Base class"""
 
+from abc import ABC, abstractmethod
+
 import torch.nn as nn
 from torch.utils.data import DataLoader
 
 
-class EvasionAttack:
+class EvasionAttack(ABC):
     """
     Base class for evasion
 
     Attributes:
-        model: :class:`~torch.nn.Module`
+        model: torch.nn.Module
             The model on which to apply adversarial training.
-        test_loader: :class:`~torch.utils.data.DataLoader`
+        test_loader: torch.utils.data.DataLoader
             Input data that is perturbed to attack the model.
         device: str
             Device used for model inference. Example: "cuda:0".
@@ -30,3 +32,7 @@ class EvasionAttack:
         self.test_loader = test_loader
         self.device = device
         self.batch_size = batch_size
+
+    @abstractmethod
+    def attack(self) -> DataLoader:
+        pass

--- a/amulet/evasion/defenses/evasion_defense.py
+++ b/amulet/evasion/defenses/evasion_defense.py
@@ -1,22 +1,24 @@
 """Evasion Defense Base Class"""
 
+from abc import ABC, abstractmethod
+
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
 
 
-class EvasionDefense:
+class EvasionDefense(ABC):
     """
     Base class for Evasion Defense
 
     Attributes:
-        model: :class:`~torch.nn.Module`
+        model: torch.nn.Module
             The model on which to apply the defense.
-        criterion: :class:`~torch.nn.Module`
+        criterion: torch.nn.Module
             Loss function for the defense.
-        optimizer: :class:`~torch.optim.Optimizer`
+        optimizer: torch.optim.Optimizer
             Optimizer for the defense.
-        train_loader: :class:`~torch.utils.data.DataLoader`
+        train_loader: torch.utils.data.DataLoader
             Training data loader to the defense.
         device: str
             Device used to train model. Example: "cuda:0".
@@ -39,3 +41,7 @@ class EvasionDefense:
         self.train_loader = train_loader
         self.device = device
         self.epochs = epochs
+
+    @abstractmethod
+    def train_robust(self) -> nn.Module:
+        pass

--- a/amulet/membership_inference/attacks/lira.py
+++ b/amulet/membership_inference/attacks/lira.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 from torch.utils.data import DataLoader, Dataset
 from tqdm import tqdm
 
-from .membership_inference_attack import InferenceModel, MembershipInferenceAttack
+from .membership_inference_attack import MembershipInferenceAttack
 
 
 class LiRA(MembershipInferenceAttack):
@@ -313,20 +313,12 @@ class LiRA(MembershipInferenceAttack):
         """
         self.prepare_shadow_models()
 
-        shadow_models = []
+        shadow_models: list[nn.Module] = []
+        shadow_in_data: list[np.ndarray] = []
         for shadow_id in range(self.num_shadow):
-            curr_model = InferenceModel(
-                shadow_id,
-                self.dataset,
-                self.num_features,
-                self.num_classes,
-                self.shadow_architecture,
-                self.shadow_capacity,
-                self.models_dir,
-                self.exp_id,
-            ).to(self.device)
-
-            shadow_models.append(curr_model)
+            model, in_data = self._load_shadow_model(shadow_id)
+            shadow_models.append(model)
+            shadow_in_data.append(in_data)
 
         # Pre-allocate lists for batch data
         pred_logits = []  # N x (num_shadow + 1) x num_trials x num_classes (target last)
@@ -389,8 +381,8 @@ class LiRA(MembershipInferenceAttack):
 
         dataset_indices = np.arange(dataset_size)
 
-        for shadow_model in shadow_models:
-            in_shadow = np.isin(dataset_indices, shadow_model.in_data)
+        for in_data in shadow_in_data:
+            in_shadow = np.isin(dataset_indices, in_data)
             in_out_labels.append(in_shadow)
 
         in_target = np.isin(dataset_indices, self.in_data)

--- a/amulet/membership_inference/attacks/membership_inference_attack.py
+++ b/amulet/membership_inference/attacks/membership_inference_attack.py
@@ -1,7 +1,7 @@
 """Membership Inference Attack Base class"""
 
-import os
 import random
+from abc import ABC, abstractmethod
 from pathlib import Path
 
 import numpy as np
@@ -12,39 +12,25 @@ from torch.utils.data import DataLoader, Dataset, Subset
 from ...utils import initialize_model
 
 
-class MembershipInferenceAttack:
+class MembershipInferenceAttack(ABC):
     """
     Base class for membership inference attacks.
 
     Attributes:
-        shadow_architecture: str
-            The model architecture used for all shadow models.
-        shadow_capacity: str
-            Size and complexity of the shadow model.
-        train_set: :class:`~torch.utils.data.Dataset`
-            The full dataset, a subset of which is used to train the target model.
-        dataset: str
-            The name of the dataset.
-        num_features: int
-            Number of features in dataset.
-        num_classes: int
-            Number of classes in dataset.
-        batch_size: int
-            Batch size used for training shadow models.
-        pkeep: float
-            Proportion of training data to keep for shadow models (members vs non-members).
-        criterion: :class:`~torch.nn.Module`
-            The loss function used to train shadow models.
-        num_shadow: int
-            Number of shadow models to train.
-        epochs: int
-            Number of epochs used to train shadow models.
-        device: str
-            Device used to train models. Example: "cuda:0".
-        models_dir: Path or str
-            Directory used to store shadow models.
-        exp_id: int
-            Used as a random seed.
+        shadow_architecture: Model architecture used for all shadow models.
+        shadow_capacity: Size and complexity of the shadow model.
+        train_set: The full dataset, a subset of which trains the target model.
+        dataset: Name of the dataset.
+        num_features: Number of features in the dataset.
+        num_classes: Number of classes in the dataset.
+        batch_size: Batch size used for training shadow models.
+        pkeep: Proportion of training data to keep per shadow model.
+        criterion: Loss function used to train shadow models.
+        num_shadow: Number of shadow models to train.
+        epochs: Number of training epochs for shadow models.
+        device: Device used to train models. Example: "cuda:0".
+        models_dir: Directory used to store shadow models.
+        exp_id: Used as a random seed.
     """
 
     def __init__(
@@ -82,7 +68,6 @@ class MembershipInferenceAttack:
             models_dir = Path(models_dir)
         self.models_dir = models_dir
 
-        # Set random seeds for reproducibility
         torch.manual_seed(exp_id)
         torch.cuda.manual_seed(exp_id)
         torch.cuda.manual_seed_all(exp_id)
@@ -96,15 +81,14 @@ class MembershipInferenceAttack:
         Train a single shadow model.
 
         Args:
-            shadow_model: :class:`torch.nn.Module`
-                The shadow model to be trained.
-            train_loader: :class:`torch.utils.data.DataLoader`
-                DataLoader containing training data for the shadow model.
+            shadow_model: The shadow model to be trained.
+            train_loader: Training data for the shadow model.
 
         Returns:
-            nn.Module: The trained shadow model.
+            Trained shadow model.
         """
-        scaler = torch.cuda.amp.GradScaler(enabled=True)  # type: ignore[reportDeprecated]
+        device_type = self.device.split(":")[0]
+        scaler = torch.amp.GradScaler(device_type, enabled=True)  # type: ignore[reportPrivateImportUsage]
         optimizer = torch.optim.SGD(
             shadow_model.parameters(), lr=0.01, momentum=0.9, weight_decay=5e-4
         )
@@ -119,7 +103,7 @@ class MembershipInferenceAttack:
             for inputs, targets in train_loader:
                 inputs, targets = inputs.to(self.device), targets.to(self.device)
 
-                with torch.cuda.amp.autocast(enabled=True):  # type: ignore[reportDeprecated]
+                with torch.amp.autocast(device_type, enabled=True):  # type: ignore[reportPrivateImportUsage]
                     outputs = shadow_model(inputs)
                     loss = self.criterion(outputs, targets)
 
@@ -150,8 +134,7 @@ class MembershipInferenceAttack:
         initializes and trains them, then saves each model
         and the indices used for training.
         """
-        # Randomly assign data indices to shadow models to get subset
-        keep = np.random.uniform(0, 1, size=(self.num_shadow, len(self.train_set)))  # type: ignore
+        keep = np.random.uniform(0, 1, size=(self.num_shadow, len(self.train_set)))  # type: ignore[reportArgumentType]
         order = keep.argsort(0)
         keep = order < int(self.pkeep * self.num_shadow)
 
@@ -161,9 +144,8 @@ class MembershipInferenceAttack:
             )
             if filename.exists():
                 continue
-            # Select indices for this shadow model
-            shadow_in_data = np.array(keep[shadow_id], dtype=bool)
-            shadow_in_data = shadow_in_data.nonzero()[0]
+
+            shadow_in_data = np.array(keep[shadow_id], dtype=bool).nonzero()[0]
 
             train_subset = Subset(self.train_set, list(shadow_in_data))
             train_loader = DataLoader(
@@ -180,100 +162,45 @@ class MembershipInferenceAttack:
                 self.num_classes,
             )
             shadow_model.to(self.device)
-
             shadow_model = self.train_shadow_model(shadow_model, train_loader)
 
-            # Save model state dict and training indices
             print(f"Saving shadow model #{shadow_id}")
-            state = {"model": shadow_model.state_dict(), "in_data": shadow_in_data}
-            torch.save(state, filename)
+            torch.save(
+                {
+                    "model": shadow_model.state_dict(),
+                    "in_data": torch.as_tensor(shadow_in_data, dtype=torch.long),
+                },
+                filename,
+            )
 
+    def _load_shadow_model(self, shadow_id: int) -> tuple[nn.Module, np.ndarray]:
+        """
+        Load a trained shadow model and its training indices from disk.
 
-class InferenceModel(nn.Module):
-    """
-    Wrapper to load a shadow model after training.
+        Args:
+            shadow_id: Index of the shadow model to load.
 
-    Attributes:
-        shadow_id: int
-            ID of the shadow model.
-        dataset: str
-            Dataset name.
-        num_features: int
-            Number of input features.
-        num_classes: int
-            Number of output classes.
-        shadow_architecture: str
-            Model architecture.
-        shadow_capacity: str
-            Model capacity descriptor.
-        models_dir: Path or str
-            Directory where models are stored.
-        in_data: np.ndarray
-            Indices of training data for this shadow model.
-        model: nn.Module
-            Loaded shadow model.
-    """
-
-    def __init__(
-        self,
-        shadow_id: int,
-        dataset: str,
-        num_features: int,
-        num_classes: int,
-        shadow_architecture: str,
-        shadow_capacity: str,
-        models_dir: Path | str,
-        exp_id: int,
-    ):
-        super().__init__()
-
-        self.shadow_id = shadow_id
-        self.dataset = dataset
-        self.num_features = num_features
-        self.num_classes = num_classes
-        self.shadow_architecture = shadow_architecture
-        self.shadow_capacity = shadow_capacity
-
-        if isinstance(models_dir, str):
-            models_dir = Path(models_dir)
-        self.models_dir = models_dir
-
-        resume_checkpoint = (
-            self.models_dir / f"{self.dataset}_shadow_{shadow_id}_{exp_id}.pth"
-        )
-        assert os.path.isfile(resume_checkpoint), (
-            f"Checkpoint not found at {resume_checkpoint}"
-        )
-        checkpoint = torch.load(resume_checkpoint)
-
-        self.model = initialize_model(
+        Returns:
+            Tuple of (model, in_data) where model is eval-mode with gradients
+            disabled, and in_data is the array of training-set indices this
+            shadow model was trained on.
+        """
+        path = self.models_dir / f"{self.dataset}_shadow_{shadow_id}_{self.exp_id}.pth"
+        if not path.is_file():
+            raise FileNotFoundError(f"Shadow model checkpoint not found: {path}")
+        checkpoint = torch.load(path, weights_only=True)
+        model = initialize_model(
             self.shadow_architecture,
             self.shadow_capacity,
             self.num_features,
             self.num_classes,
         )
-        self.model.load_state_dict(checkpoint["model"])
+        model.load_state_dict(checkpoint["model"])
+        model.to(self.device)
+        model.eval()
+        model.requires_grad_(False)
+        return model, checkpoint["in_data"].numpy()
 
-        self.in_data = checkpoint["in_data"]
-
-        self.deactivate_grad()
-        self.model.eval()
-
-        self.is_in_model = False  # Flag indicating whether this model represents member (True) or non-member (False)
-
-    def forward(self, x):
-        return self.model(x)
-
-    def deactivate_grad(self):
-        """Disable gradients for all model parameters."""
-        for param in self.model.parameters():
-            param.requires_grad = False
-
-    def activate_grad(self):
-        """Enable gradients for all model parameters."""
-        for param in self.model.parameters():
-            param.requires_grad = True
-
-    def load_state_dict(self, checkpoint):  # type: ignore[reportIncompatibleMethodOverride]
-        """Load state dict into the underlying model."""
-        self.model.load_state_dict(checkpoint)
+    @abstractmethod
+    def attack(self) -> dict[str, np.ndarray]:
+        pass

--- a/amulet/membership_inference/defenses/membership_inference_defense.py
+++ b/amulet/membership_inference/defenses/membership_inference_defense.py
@@ -1,22 +1,24 @@
 """Base class for Membership Inference defenses"""
 
+from abc import ABC, abstractmethod
+
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
 
 
-class MembershipInferenceDefense:
+class MembershipInferenceDefense(ABC):
     """
     Base class for membership inference defenses.
 
     Attributes:
-        model: :class:`~torch.nn.Module`
+        model: torch.nn.Module
             The model on which to apply adversarial training.
-        criterion: :class:`~torch.nn.Module`
+        criterion: torch.nn.Module
             Loss function for adversarial training.
-        optimizer: :class:`~torch.optim.Optimizer`
+        optimizer: torch.optim.Optimizer
             Optimizer for adversarial training.
-        train_loader: :class:`~torch.utils.data.DataLoader`
+        train_loader: torch.utils.data.DataLoader
             Training data loader to adversarial training.
         device: str
             Device used to train model. Example: "cuda:0".
@@ -39,3 +41,7 @@ class MembershipInferenceDefense:
         self.train_loader = train_loader
         self.device = device
         self.epochs = epochs
+
+    @abstractmethod
+    def train_private(self) -> nn.Module:
+        pass

--- a/amulet/poisoning/attacks/poisoning_attack.py
+++ b/amulet/poisoning/attacks/poisoning_attack.py
@@ -1,0 +1,30 @@
+"""Poisoning Attack Base class"""
+
+from abc import ABC, abstractmethod
+
+from torch.utils.data import TensorDataset
+
+
+class PoisoningAttack(ABC):
+    """
+    Base class for poisoning attacks.
+
+    Poisoning attacks corrupt a subset of training samples before model
+    training begins. Subclasses implement the concrete trigger-injection
+    or label-manipulation strategy.
+
+    Attributes:
+        random_seed: int
+            Seed used when randomly selecting samples to poison.
+    """
+
+    def __init__(self, random_seed: int):
+        self.random_seed = random_seed
+
+    @abstractmethod
+    def poison_train(self, dataset) -> TensorDataset:
+        pass
+
+    @abstractmethod
+    def poison_test(self, dataset) -> TensorDataset:
+        pass

--- a/amulet/poisoning/defenses/poisoning_defense.py
+++ b/amulet/poisoning/defenses/poisoning_defense.py
@@ -1,25 +1,26 @@
 """Base class for poisoning defenses"""
 
+from abc import ABC, abstractmethod
+
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
 
 
-class PoisoningDefense:
+class PoisoningDefense(ABC):
     """
     Base class for Poisoning defenses.
 
-
     Attributes:
-        model: :class:`~torch.nn.Module`
+        model: torch.nn.Module
             The model to retrain after removing outliers.
-        criterion: :class:`~torch.nn.Module`
+        criterion: torch.nn.Module
             Loss function for training model.
-        optimizer: :class:`~torch.optim.Optimizer`
+        optimizer: torch.optim.Optimizer
             Optimizer for training model.
-        train_loader: :class:`~torch.utils.data.DataLoader`
+        train_loader: torch.utils.data.DataLoader
             Training data loader to train model.
-        test_loader: :class:`~torch.utils.data.DataLoader`
+        test_loader: torch.utils.data.DataLoader
             Test data loader to calculate Shapley values.
         device: str
             Device used to train model. Example: "cuda:0".
@@ -48,3 +49,7 @@ class PoisoningDefense:
         self.device = device
         self.epochs = epochs
         self.batch_size = batch_size
+
+    @abstractmethod
+    def train_robust(self) -> nn.Module:
+        pass

--- a/amulet/unauth_model_ownership/attacks/__init__.py
+++ b/amulet/unauth_model_ownership/attacks/__init__.py
@@ -1,3 +1,4 @@
 from .model_extraction import ModelExtraction
+from .unauth_model_ownership_attack import UnauthModelOwnershipAttack
 
-__all__ = ["ModelExtraction"]
+__all__ = ["ModelExtraction", "UnauthModelOwnershipAttack"]

--- a/amulet/unauth_model_ownership/attacks/unauth_model_ownership_attack.py
+++ b/amulet/unauth_model_ownership/attacks/unauth_model_ownership_attack.py
@@ -1,0 +1,37 @@
+"""Unauthorized Model Ownership Attack Base class"""
+
+from abc import ABC, abstractmethod
+
+import torch.nn as nn
+
+
+class UnauthModelOwnershipAttack(ABC):
+    """
+    Base class for unauthorized model ownership attacks.
+
+    Unauthorized model ownership attacks attempt to replicate or steal
+    a target model's functionality without authorization. Subclasses
+    implement concrete model extraction or imitation strategies.
+
+    Attributes:
+        target_model: nn.Module
+            The model being attacked (stolen from).
+        device: str
+            Device used for inference. Example: "cuda:0".
+        epochs: int
+            Number of training iterations for the attack model.
+    """
+
+    def __init__(
+        self,
+        target_model: nn.Module,
+        device: str,
+        epochs: int,
+    ):
+        self.target_model = target_model
+        self.device = device
+        self.epochs = epochs
+
+    @abstractmethod
+    def attack(self) -> nn.Module:
+        pass

--- a/amulet/unauth_model_ownership/defenses/__init__.py
+++ b/amulet/unauth_model_ownership/defenses/__init__.py
@@ -1,4 +1,10 @@
 from .fingerprint import DatasetInference
+from .unauth_model_ownership_defense import FingerprintDefense, WatermarkDefense
 from .watermark import WatermarkNN
 
-__all__ = ["DatasetInference", "WatermarkNN"]
+__all__ = [
+    "DatasetInference",
+    "FingerprintDefense",
+    "WatermarkDefense",
+    "WatermarkNN",
+]

--- a/amulet/unauth_model_ownership/defenses/unauth_model_ownership_defense.py
+++ b/amulet/unauth_model_ownership/defenses/unauth_model_ownership_defense.py
@@ -1,0 +1,52 @@
+"""Unauthorized Model Ownership Defense Base classes"""
+
+from abc import ABC, abstractmethod
+
+import torch.nn as nn
+
+
+class WatermarkDefense(ABC):
+    """
+    Base class for watermarking-based ownership defenses.
+
+    Embeds a secret trigger set into the model during or after training so
+    that the owner can later verify ownership by querying the model on
+    those triggers.
+
+    Attributes:
+        target_model: nn.Module
+            The model to protect.
+        device: str
+            Device used for inference. Example: "cuda:0".
+    """
+
+    def __init__(self, target_model: nn.Module, device: str):
+        self.target_model = target_model
+        self.device = device
+
+    @abstractmethod
+    def watermark(self) -> nn.Module:
+        pass
+
+
+class FingerprintDefense(ABC):
+    """
+    Base class for fingerprinting-based ownership defenses.
+
+    Identifies whether a suspect model was stolen from the target model
+    by analyzing the target's training data distribution.
+
+    Attributes:
+        target_model: nn.Module
+            The model to protect.
+        device: str
+            Device used for inference. Example: "cuda:0".
+    """
+
+    def __init__(self, target_model: nn.Module, device: str):
+        self.target_model = target_model
+        self.device = device
+
+    @abstractmethod
+    def fingerprint(self) -> dict[str, dict[str, float]]:
+        pass


### PR DESCRIPTION
## Summary

This PR introduces `ABC` base classes for every risk module's attacks and defenses, establishing a uniform lifecycle contract across security, privacy, and fairness modules. It also ships the `DistributionInferenceAttack` and `DistributionSplits` data utilities, fixes the discriminatory behavior defense class naming typo, and migrates MI shadow-model training away from the removed `InferenceModel` wrapper.

**Stacked on:** `pr/model-base-shared-utilities-tooling`

---

## What changed and why

### Abstract base classes — all risk modules

Each risk module now has an explicit ABC with a single `@abstractmethod` entry point, replacing the previous pattern of duck-typed or convention-only classes.

| File | Change |
|------|--------|
| `amulet/evasion/attacks/evasion_attack.py` | `EvasionAttack(ABC)` with `@abstractmethod attack() -> DataLoader` |
| `amulet/evasion/defenses/evasion_defense.py` | `EvasionDefense(ABC)` with `@abstractmethod train_robust() -> nn.Module` |
| `amulet/poisoning/attacks/poisoning_attack.py` | **New.** `PoisoningAttack(ABC)` with `@abstractmethod poison_train()` and `@abstractmethod poison_test()` |
| `amulet/poisoning/defenses/poisoning_defense.py` | `PoisoningDefense(ABC)` with `@abstractmethod train_robust() -> nn.Module` |
| `amulet/membership_inference/attacks/membership_inference_attack.py` | `MembershipInferenceAttack(ABC)`; adds `_load_shadow_model()` helper; removes `InferenceModel` inner class; migrates `torch.cuda.amp` → `torch.amp` (PyTorch 2.3 deprecation) |
| `amulet/membership_inference/defenses/membership_inference_defense.py` | `MembershipInferenceDefense(ABC)` with `@abstractmethod train_private() -> nn.Module` |
| `amulet/discriminatory_behavior/defenses/discr_behavior_defense.py` | Fixed typo: `DicriminatoryBehaviorDefense` → `DiscriminatoryBehaviorDefense`; renamed `model_criterion` → `criterion` and `model_optimizer` → `optimizer` to match standard naming |
| `amulet/attribute_inference/attacks/attribute_inference_attack.py` | `AttributeInferenceAttack(ABC)` with `@abstractmethod attack() -> dict[str, np.ndarray]` |
| `amulet/data_reconstruction/attacks/data_reconstruction_attack.py` | `DataReconstructionAttack(ABC)` with `@abstractmethod attack() -> dict[str, np.ndarray]` |
| `amulet/unauth_model_ownership/attacks/unauth_model_ownership_attack.py` | **New.** `UnauthModelOwnershipAttack(ABC)` with `@abstractmethod attack()` |
| `amulet/unauth_model_ownership/defenses/unauth_model_ownership_defense.py` | **New.** Two separate ABCs: `WatermarkDefense` with `@abstractmethod watermark()` and `FingerprintDefense` with `@abstractmethod fingerprint()`. Intentionally no shared parent — watermarking and fingerprinting have incompatible return types and lifecycles. |

### Distribution Inference lifecycle

`DistributionInferenceAttack` mirrors the shadow-model lifecycle already present in `MembershipInferenceAttack`.

| File | Change |
|------|--------|
| `amulet/distribution_inference/attacks/distribution_inference_attack.py` | **New.** `DistributionInferenceAttack(ABC)` with `train_model_population()`, `prepare_model_populations()`, and `@abstractmethod attack() -> dict[str, np.ndarray]` |
| `amulet/distribution_inference/dataset_utils.py` | **New.** `DistributionSplits` dataclass and `prepare_distribution_splits()` — required by the DI ABC |
| `amulet/distribution_inference/attacks/__init__.py` | Exports `DistributionInferenceAttack` alongside existing `DistributionInference` |

### Concrete class migrations (minimal — only what PR 2 breaks)

| File | Change |
|------|--------|
| `amulet/membership_inference/attacks/lira.py` | Removed `InferenceModel` import; replaced with `_load_shadow_model(shadow_id)` returning `(model, in_data)` tuple |
| `amulet/discriminatory_behavior/defenses/adversarial_debiasing.py` | Updated import to `DiscriminatoryBehaviorDefense`; updated attribute references (`model_criterion` → `criterion`, `model_optimizer` → `optimizer`) |
| `amulet/unauth_model_ownership/attacks/__init__.py` | Exports `UnauthModelOwnershipAttack` |
| `amulet/unauth_model_ownership/defenses/__init__.py` | Exports `WatermarkDefense`, `FingerprintDefense` |

---

## Test plan

- [ ] `uv run pre-commit run --all-files` passes (ruff, ruff-format, basedpyright, prettier, markdownlint all green)
- [ ] Importing `from amulet.membership_inference.attacks import MembershipInferenceAttack` raises `TypeError` when instantiated without implementing `attack()`
- [ ] Importing `from amulet.distribution_inference.attacks import DistributionInferenceAttack` raises `TypeError` when instantiated without implementing `attack()`
- [ ] `from amulet.unauth_model_ownership.defenses import WatermarkDefense, FingerprintDefense` resolves correctly
- [ ] `from amulet.distribution_inference import dataset_utils` resolves correctly
- [ ] Existing `LiRA` concrete class instantiates without error with valid args

🤖 Generated with [Claude Code](https://claude.com/claude-code)