### PR TITLE
docs: overhaul module guides and remove temporary markdownlintignore

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,4 +1,0 @@
-# Pre-existing issues in docs/ and examples/extending_amulet/ are addressed
-# in the docs overhaul PR (PR 6). Ignored here to keep PR 1 scoped.
-docs/
-examples/extending_amulet/

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,188 +1,85 @@
-# How to contribute to Amulet
+# Contributing to Amulet
 
-## Reporting an Issue
+Thank you for your interest in contributing to Amulet! This guide will help you get started with the contribution process.
 
-We use the Issue tracking feature to track bugs and new code contributions.
+## Reporting Issues
 
-### Creating a bug report
+We use GitHub Issues to track bugs and feature requests.
 
-Each issue should include a title and a description of the error you are facing. Ensure to include as much relevant information as possible, including a code sample or failing test demonstrating the expected behavior and your system configuration. Your goal should be to make it easy for yourself - and others - to reproduce the bug and figure out a fix.
-
-### Feature Requests
-
-Since this is a growing package, we welcome new feature requests! However, remember that you may need to write the code for a feature yourself. Depending on the type of feature you want, there are slightly different requirements. Some examples are:
-
-- **Requesting a utility for an ML Pipeline.**
-  If this is an easy fix and we feel this would be helpful to many users facing the same issue, we would love to work with you on this to make it happen!
-- **Adding a new risk or defense.**
-  Are you a researcher who has discovered a new risk or way to defend against known risks? We welcome your contributions! However, in most cases, we only include state-of-the-art risks or defenses in our package. The package aims to allow other users to test their models against known risks or defenses or enable researchers to test their techniques against the current state-of-the-art. Thus, having a peer-reviewed paper to justify adding a new risk or defense would be nice.
+- **Bug Reports**: Please include a clear title, a description of the issue, and steps to reproduce the bug. Providing a minimal code snippet or a failing test case is highly recommended.
+- **Feature Requests**: We welcome new ideas! For research-related features (new risks or defenses), please include a reference to the relevant peer-reviewed paper.
 
 ## Contributing Code
 
-For new functionalities that help with an ML pipeline, please submit an issue, and we can work together to find the best way to incorporate the utility. For a module comprising a new risk or defense, we strongly urge you to follow the same coding conventions as the rest of the package. Please follow the tutorial below to add a new module.
+### Environment Setup
 
-**For all contributions:**
+Amulet uses [uv](https://docs.astral.sh/uv/) for dependency management.
 
-- **Submit an issue describing the contribution**.
-- **Fork or clone the library.**
-- **Create a new branch for your contribution.**
-- **After adding the code, create a merge request.**
+1. **Install uv**:
 
-### Setting up your environment
+   ```bash
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   ```
 
-#### Install uv
+2. **Clone and Sync**:
 
-This project uses [uv](https://docs.astral.sh/uv/) for dependency management. To install uv:
+   ```bash
+   git clone https://github.com/ssg-research/amulet.git
+   cd amulet
+   uv sync --all-extras
+   ```
 
-`curl -LsSf https://astral.sh/uv/install.sh | sh`
+3. **Install Pre-commit**:
 
-Or on Windows:
+   ```bash
+   uv run pre-commit install
+   ```
 
-`powershell -c "irm https://astral.sh/uv/install.ps1 | iex"`
+### Coding Standards
 
-Alternatively, you can use pipx:
+- **Formatting**: We use `ruff` for formatting and linting. Run `uv run ruff format .` and `uv run ruff check --fix .`.
+- **Type Checking**: We use `basedpyright` for static type analysis. Run `uv run basedpyright`.
+- **Docstrings**: Use Google-style docstrings.
+- **Naming**: Internal utility modules are prefixed with underscores (e.g., `__base.py`). Private class members should follow the `_name` convention.
 
-`pipx install uv`
+### Adding a New Risk Module
 
-#### Setting up the environment
+1. **Subclass the Base Class**: Each risk has a base class (e.g., `EvasionAttack`). Your new module must subclass this.
+2. **Implementation**: Place your file in the appropriate directory: `amulet/<risk>/<attacks|defenses|metrics>/new_module.py`.
+3. **API Contract**:
+   - **Attacks**: Implement an `attack()` method (except for poisoning, which uses `poison_train` and `poison_test`).
+   - **Defenses**: Implement methods like `train_robust()`, `train_private()`, or `train_fair()`.
+   - **Return Values**: Attacks/defenses should return artifacts (e.g., a `DataLoader` or a `nn.Module`), not metrics directly.
+4. **Export**: Import your class in the risk's `__init__.py`.
+5. **Example**: Add a runnable script in `examples/attack_pipelines/` or `examples/defense_pipelines/`.
 
-To create a virtual environment and install dependencies:
+### Adding a Dataset
 
-`uv sync`
-
-This will automatically create a `.venv` directory, install all dependencies, and set up the project.
-To install all dev dependencies:
-
-`uv sync --all-extras`
-
-#### Using uv
-
-When you add or modify dependencies in `pyproject.toml`:
-
-- Run `uv lock` to update the lock file
-- Run `uv sync` to install the updated dependencies
-
-To add a new dependency:
-`uv add package-name`
-
-To add a development dependency:
-`uv add --dev package-name`
-
-#### pre-commit
-
-There're some pre-commit hooks configured for this project.
-`uv` installs `pre-commit` as a dev dependency.
-
-Run `uv run pre-commit install` for consistent development.
-
-## Additional Features
-
-### Adding a dataset
-
-By default, dataset loading functions in Amulet return train and test sets as [`torch.utils.data.TensorDataset`](https://pytorch.org/docs/stable/data.html#torch.utils.data.TensorDataset) objects. For datasets with sensitive attributes, users can set a flag that returns NumPy arrays instead. We recommend you look at the existing implementations as an example, specifically [`amulet/utils/_pipeline.py:load_data()`](https://github.com/ssg-research/amulet/blob/main/amulet/utils/_pipeline.py#L16) and [`amulet/datasets/_image_datasets.py`](https://github.com/ssg-research/amulet/blob/main/amulet/datasets/_image_datasets.py). The function template looks like this:
+Datasets should return an `AmuletDataset` dataclass.
 
 ```python
-def load_<name_of_dataset> (
-	path: Union[str, Path],  # indicating where to store the dataset once downloaded,
-	random_seed: Optional[int], # used if the function splits the dataset into train/test
-	return_x_y: Optional[boolean] # flag used to return NumPy arrays, if applicable
-) -> sklearn.utils.Bunch
+@dataclass
+class AmuletDataset:
+    train_set: Dataset
+    test_set: Dataset
+    num_features: int
+    num_classes: int
+    x_train: np.ndarray | None = None
+    ...
 ```
 
-Note that the output is a [`sklearn.utils.Bunch`](https://scikit-learn.org/stable/modules/generated/sklearn.utils.Bunch.html) object, a dictionary-like object of the format:
+1. Implement the loading logic in `amulet/datasets/__image_datasets.py` or `amulet/datasets/__tabular_datasets.py`.
+2. Update `load_data` in `amulet/utils/__pipeline.py` to support the new dataset.
 
-```python
-{
-	train_set: torch.utils.data.TensorDataset,
-	test_set: torch.utils.data.TensorDataset
-}
-```
+### Adding a Model Architecture
 
-Please follow these steps to add a new function to load a dataset:
+1. Define your architecture in a new file under `amulet/models/`.
+2. Ensure it implements a `get_hidden(self, x)` method.
+3. Update `initialize_model` in `amulet/utils/__pipeline.py` to include the new architecture.
 
-1. Write a function that will download the dataset, preprocess it, and split it into train and test sets (see function template above). Example code: [`amulet/datasets/_tabular_datasets.py:load_census()`](https://github.com/ssg-research/amulet/blob/main/amulet/datasets/_tabular_datasets.py#L21). Please ensure the following when:
-   - **Downloading**: Ensure download location is passed as a parameter. Example code: [`amulet/datasets/_tabular_datasets.py:L72-81`](https://github.com/ssg-research/amulet/blob/main/amulet/datasets/_tabular_datasets.py#L72-L81).
-   - **Preprocessing**: Ensure the data types are correct, engineer features, etc. Example code: [`amulet/datasets/_tabular_datasets.py:L83-91`](https://github.com/ssg-research/amulet/blob/main/amulet/datasets/_tabular_datasets.py#L83-L91).
-   - **Splitting**: Ensure any randomized splitting uses a random seed. Example code: [`amulet/datasets/_tabular_datasets.py:L94-99`](https://github.com/ssg-research/amulet/blob/main/amulet/datasets/_tabular_datasets.py#L94-L99).
-2. Add this function into the appropriate file: `amulet/datasets/_tabular_datasets.py` for 1-dimensional datasets and `amulet/datasets/_image_datasets.py` for 2-dimensional datasets.
-3. Import your function in [`amulet/datasets/__init__.py`](https://github.com/ssg-research/amulet/blob/main/amulet/datasets/__init__.py).
-4. Add the appropriate if condition in [`amulet/utils/_pipeline.py/load_data()`](https://github.com/ssg-research/amulet/blob/main/amulet/utils/_pipeline.py).
+## Pull Request Process
 
-### Adding a model architecture
-
-Please follow these steps to add a new model architecture to Amulet:
-
-1. Create a file in `amulet/models/` that defines a model as a `nn.Module` subclass.
-2. We recommend including a `get_hidden()` function in the model since some modules use it. This function outputs the model's hidden layer activations. Example code: [`amulet/models/vgg.py:L65-76`](https://github.com/ssg-research/amulet/blob/main/amulet/models/vgg.py#L65-L76).
-3. Import the new model into `amulet/models/__init__.py`. For example, `from model_file import model_name`.
-4. We also recommend configuring the model size and complexity via input parameters. Please see [`amulet/models/vgg.py`](https://github.com/ssg-research/amulet/blob/main/amulet/models/vgg.py) or [`amulet/models/binary_net.py`](https://github.com/ssg-research/amulet/blob/main/amulet/models/binary_net.py) for examples.
-
-## Adding a new module
-
-The first step is to decide which risk the new module interacts with. For details, refer to the Tutorial (link TBD). The risks currently defined by Amulet can be found in this table (link TBD). Then, decide whether the module is a metric, attack, or defense. If you have identified a new risk, you may need to add separate modules for a metric, attack and/or defense.
-
-### Adding an attack or a defense
-
-The general template of an attack or defense:
-
-- Inputs:
-  - Target Model
-  - Hyperparameters (include reasonable default values)
-  - Other attributes or methods required by the class
-- Main Algorithm:
-  - Code logic to run the attack or defense
-- Outputs:
-  - Output of the attack OR
-  - Defended model
-
-Please refer to the Module Templates (link TBD) for an idea of the outputs for our existing modules. This ensures that new attacks or defenses can be compared to old ones using the same code. **If introducing a new metric, please make two separate contributions for the metric and the new attack or defense.**
-
-Please note that your attack or defense **should not output a metric**. Instead, it should output the data that will be input to one of the existing metrics implemented in the pipeline.
-
-### Metrics
-
-There is no set template for metrics. Please include in-code documentation about the expected input for the metric calculation and the output range.
-
-### Steps
-
-Once a rough template has been sketched out, please follow these steps for adding code:
-
-1. Create a file in the appropriate directory as follows:
-
-   `amulet/<risk>/<defense/attack/metric>/new_module.py`
-
-   For example, if your module is a new defense for evasion, create the file as follows:
-
-   `amulet/evasion/defense/new_module.py`
-
-2. Create a class. We follow a convention for all our attacks and defenses:
-
-   1. Create a subclass using the Base class for the attack/defense you want to add. For example, to add a new evasion attack, you can use the following code:
-
-      ```python
-
-      from .evasion import Evasion
-      class newEvasionAttack(Evasion):
-          def __init__(
-              model,
-              test_loader,
-              device,
-              batch_size,
-              param1,
-              param2
-          ):
-              super().__init__(model, test_loader, device, batch_size)
-              self.param1 = param1
-              self.param2 = param2
-      ```
-
-   2. The `__init__()` method should have most of the parameters required to run the technique. This allows users to use functions like `__getattr__()` to log the parameters while running the technique. Optional parameters may go in other methods.
-   3. Where possible, use the utils available in the package.
-   4. If your module uses hyperparameters, please recommend a reasonable default value.
-   5. Add docstrings to the class and methods, including the recommended range for specific hyperparameters for your technique. Please use the modules we have written as a reference for formatting these.
-   6. We follow the convention of prefixing the method with an underscore for private attributes and methods in the class.
-
-3. Please include the code to download any files or data the module requires.
-4. Add an example script in `<TBD>` to show how to use your technique. Please look at the existing examples to understand how to use them.
-5. Run PyLint on your code using the pylintrc file in the repo to validate the code style.
-6. If the technique requires additional packages, include them in the environment.yml file with the appropriate version number.
+1. Create a new branch for your feature or bug fix.
+2. Ensure all tests pass: `uv run pytest`.
+3. Run linting and type checking.
+4. Submit your PR with a descriptive title and summary of changes.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,157 +1,107 @@
-# Features
+# Getting Started
 
-We provide a high-level list of features below.
+Amulet (`amuletml` on PyPI) is a PyTorch-based research library for evaluating unintended interactions among machine learning (ML) defenses and risks across security, privacy, and fairness.
 
-## Datasets
+## Features
 
-Amulet provides the following for computer vision tasks:
+### Datasets
 
-- [CIFAR10](https://pytorch.org/vision/main/generated/torchvision.datasets.CIFAR10.html).
-- [FashionMNIST](https://pytorch.org/vision/stable/generated/torchvision.datasets.FashionMNIST.html).
-- [CelebA](https://mmlab.ie.cuhk.edu.hk/projects/CelebA.html). Or download the [CSV version](https://drive.google.com/file/d/1KTaJraB9Koa4h5EVTJQ3y2Dig_vgE5MZ/view?usp=sharing).
+Amulet provides built-in support for several common datasets, including automated downloading and pre-processing:
 
-Amulet pre-processes and provides the following datasets to test for privacy-related concerns:
+- **Computer Vision**: [CIFAR-10](https://pytorch.org/vision/main/generated/torchvision.datasets.CIFAR10.html), [CIFAR-100](https://pytorch.org/vision/main/generated/torchvision.datasets.CIFAR100.html), [FashionMNIST](https://pytorch.org/vision/stable/generated/torchvision.datasets.FashionMNIST.html), [MNIST](https://pytorch.org/vision/stable/generated/torchvision.datasets.MNIST.html).
+- **Face Attributes**: [CelebA](https://mmlab.ie.cuhk.edu.hk/projects/CelebA.html), [Labeled Faces in the Wild (LFW)](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.fetch_lfw_people.html), [UTKFace](https://susanqq.github.io/UTKFace/).
+- **Tabular Data**: [Census Income Dataset](https://archive.ics.uci.edu/dataset/20/census+income).
 
-- [Census Income Dataset](https://archive.ics.uci.edu/dataset/20/census+income).
-- [Labeled Faces in the Wild (LFW)](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.fetch_lfw_people.html).
+### Models
 
-## Models
+Amulet provides pre-configured architectures with scalable capacity:
 
-Amulet provides the following models:
+- **VGG**: Standard VGG architectures (VGG11 to VGG19).
+- **ResNet**: Standard ResNet architectures (ResNet34 to ResNet152).
+- **SimpleCNN**: A configurable convolutional neural network.
+- **LinearNet**: A dense neural network for tabular data.
 
-- [VGG](https://viso.ai/deep-learning/vgg-very-deep-convolutional-networks/): for computer vision tasks.
-- LinearNet: A dense neural network tuned for multiclass classification on the FashionMNIST dataset.
-
-## Risks
+### Risks
 
 Amulet provides attacks, defenses, and evaluation metrics for the following risks:
 
-### Security
+#### Security
 
-- Evasion
-- Poisoning
-- Unauthorized Model Ownership
+- **Evasion**: Projected Gradient Descent (PGD) attacks and Adversarial Training.
+- **Poisoning**: BadNets backdoor attacks and Outlier Removal defenses.
+- **Unauthorized Model Ownership**: Model Extraction attacks, Watermarking, and Fingerprinting.
 
-### Privacy
+#### Privacy
 
-- Membership Inference
-- Attribute Inference
-- Distribution Inference
-- Data Reconstruction
+- **Membership Inference**: Likelihood Ratio Attack (LiRA) and DP-SGD defense.
+- **Attribute Inference**: MLP-based inference of sensitive attributes.
+- **Distribution Inference**: KL-divergence-based distinguishing tests.
+- **Data Reconstruction**: Model Inversion attacks.
 
-### Fairness
+#### Fairness
 
-- Discriminatory Behavior
+- **Discriminatory Behavior**: Measuring group fairness and Adversarial Debiasing.
 
-Please check the [Module Guide](https://github.com/ssg-research/amulet/blob/main/docs/MODULE_GUIDE.md) for more details.
+## Data Loading
 
-# Data Loading
+### Data Class
 
-## Data Class
-
-All Amulet datasets are returned as an AmuletDataset, which contains the following attributes:
+All Amulet datasets are returned as an `AmuletDataset` dataclass:
 
 ```python
-train_set: torch.utils.data.Dataset
-test_set: torch.utils.data.Dataset
-num_features: int
-num_classes: int
-x_train: np.ndarray | None = None
-x_test: np.ndarray | None = None
-y_train: np.ndarray | None = None
-y_test: np.ndarray | None = None
-z_train: np.ndarray | None = None
-z_test: np.ndarray | None = None
+@dataclass
+class AmuletDataset:
+    train_set: torch.utils.data.Dataset
+    test_set: torch.utils.data.Dataset
+    num_features: int
+    num_classes: int
+    x_train: np.ndarray | None = None
+    x_test: np.ndarray | None = None
+    y_train: np.ndarray | None = None
+    y_test: np.ndarray | None = None
+    z_train: np.ndarray | None = None
+    z_test: np.ndarray | None = None
 ```
 
-Every dataset will have the `train_set`, `test_set`, `num_features`, and `num_classes` attributes. For datasets that are loaded manually and processed by Amulet (such as LFW and Census Income Dataset), the individual feature and labels arrays will also be set `[x_train, x_test, y_train, y_test]`, as well as the arrays to store sensitive attributes `[z_train, z_test]`.
+- `train_set`/`test_set`: PyTorch Datasets ready for use with a `DataLoader`.
+- `x_*`/`y_*`: Raw features and labels as NumPy arrays (available for processed datasets like LFW, Census, CelebA).
+- `z_*`: Sensitive attributes used by fairness and attribute inference modules.
 
-## Accessing Datasets
+### Accessing Datasets
 
-For easy access, Amulet provides the following function to load any dataset as part of a pipeline:
+The primary entry point for loading data is `load_data`:
 
 ```python
-def load_data(
-    root: Path | str,
-    dataset: str,
-    training_size: float,
-    log: logging.Logger | None = None,
-    exp_id: int = 0,
-) -> AmuletDataset:
+from amulet.utils import load_data
+
+data = load_data(
+    root="./data",
+    dataset="cifar10",       # Options: cifar10, cifar100, fmnist, mnist, census, lfw, celeba, utkface
+    training_size=1.0,       # Downsample training data (0.0 to 1.0)
+    celeba_target="Smiling", # Target attribute for CelebA
+    exp_id=0                 # Random seed for reproducibility
+)
 ```
 
-Where:
+## Creating Models
 
-- `root`: the root directory to store datasets.
-- `dataset`: one of `['cifar10', 'fminst', 'census', 'lfw']`.
-- `training_size`: used to reduce the size of the training data, useful to test the impact of dataset size on models.
-- `log`: for logging.
-- `exp_id`: for random seeding, if needed.
+Amulet models are standard `torch.nn.Module` objects that include a `get_hidden(x)` method for accessing intermediate features.
 
-Amulet provides the following functions to load datasets:
-
-- ```python
-    def load_cifar10(
-        path: str | Path = Path("./data/cifar10"),
-        transform_train: transforms.Compose | None = None,
-        transform_test: transforms.Compose | None = None,
-    ) -> AmuletDataset:
-  ```
-
-- ```python
-    def load_fmnist(
-        path: str | Path = Path("./data/fmnist"),
-        transform_train: transforms.Compose | None = None,
-        transform_test: transforms.Compose | None = None,
-    ) -> AmuletDataset:
-  ```
-- ```python
-    def load_census(
-        path: str | Path = Path("./data/census"),
-        random_seed: int = 7,
-        test_size: float = 0.5,
-    ) -> AmuletDataset:
-  ```
-
-- ```python
-    def load_lfw(
-        path: str | Path = Path("./data/lfw"),
-        target: str = "age",
-        attribute_1: str = "race",
-        attribute_2: str = "gender",
-        test_size: float = 0.3,
-        random_seed: int = 7,
-    ) -> AmuletDataset:
-  ```
-
-# Creating Models
-
-Any PyTorch model of type `torch.nn.Module` can be used with Amulet. For some modules, it is helpful to have a `get_hidden(self, x: torch.Tensor) -> torch.Tensor` method that returns the intermediate layer output from the model, please see [this example](https://github.com/ssg-research/amulet/blob/main/amulet/models/vgg.py#L106).
-
-## Accessing pre-configured model architectures
-
-To use the models configured for running experiments using Amulet, the following function can be used:
+### Initializing Architectures
 
 ```python
-def initialize_model(
-    model_arch: str,
-    model_capacity: str,
-    num_features: int,
-    num_classes: int,
-    log: logging.Logger | None = None,
-    batch_norm: bool = True,
-) -> nn.Module:
+from amulet.utils import initialize_model
+
+model = initialize_model(
+    model_arch="vgg",       # Options: vgg, resnet, linearnet, cnn
+    model_capacity="m1",    # Options: m1, m2, m3, m4 (small to large)
+    num_features=data.num_features,
+    num_classes=data.num_classes,
+    batch_norm=True
+)
 ```
 
-Where:
+## Module Guide
 
-- `model_arch`: one of `['vgg', 'linearnet']`. Each model is optimized for a specific dataset that Amulet provides.
-- `model_capacity`: one of `['m1', 'm2', 'm3', 'm4]`. Configures the size and complexity of the model.
-- `num_features`: Size of the input for the model in the case of simple dense neural networks.
-- `num_classes`: Number of classes in the output.
-- `log`: for logging.
-- `batch_norm`: Used to control whether batch normalization is used. True by default.
-
-# Risks
-
-Amulet provides attacks, defenses, and metrics for each risk. **TBD.**
+For detailed instructions on each risk, please see the [Module Guide](./module_guide/1_INTRO.md).
+Check the [examples/](https://github.com/ssg-research/amulet/tree/main/examples) directory for end-to-end scripts.

--- a/docs/module_guide/1_INTRO.md
+++ b/docs/module_guide/1_INTRO.md
@@ -1,25 +1,50 @@
 # Introduction
 
-Each risk in Amulet represents either an _attack_, a _defense_, or a _metric_.
-To see the list of the risks and the features, please see the [Getting Started guide](https://github.com/ssg-research/amulet/blob/main/docs/GETTING_STARTED.md).
+Amulet organizes machine learning risks into three primary components: **Attacks**, **Defenses**, and **Metrics**.
+The core design philosophy is to allow these components to be easily composed into a unified training and evaluation pipeline.
+
+## Component Categories
+
+1. **Attacks**: Algorithms that generate adversarial artifacts (like perturbed inputs or poisoned datasets) or trained surrogate models.
+2. **Defenses**: Robust training algorithms or pre-processing steps designed to mitigate specific risks.
+3. **Metrics**: Evaluation functions that measure the success of an attack or the robustness of a model.
 
 ## Design Overview
 
-Most attacks and defenses are designed such that they take the target model, and some additional information (such as data, hyperparameters, configuration, etc.) as input, run an algorithm, and output a result.
-This result can then be passed onto the respective metrics modules to evaluate the attack or defense. A brief pipeline would look something like:
+Most Amulet components follow a consistent API:
+
+- **Attacks** generally take a `target_model` and a `DataLoader` as input and provide an `attack()` method.
+- **Defenses** provide methods like `train_robust()`, `train_private()`, or `train_fair()` depending on the risk they address.
+- **Metrics** take model predictions or outputs and return standard performance scores.
+
+### Example Pipeline
+
+A typical Amulet pipeline involves loading data, initializing a model, applying a defense, and then running an attack to evaluate the defense's effectiveness:
 
 ```python
-data = load_data()
+from amulet.utils import load_data, initialize_model, train_classifier, get_accuracy
+from amulet.evasion.attacks import EvasionPGD
+from amulet.evasion.defenses import AdversarialTrainingPGD
 
-target_model = initialize_model(*model_architecture_parameters)
-target_model = train_model(target_model, data.train, data.test, *training_parameters)
+# 1. Load Data
+data = load_data("./data", "cifar10")
+train_loader = DataLoader(data.train_set, batch_size=128)
+test_loader = DataLoader(data.test_set, batch_size=128)
 
-attack = AttackClass()
-attack_output = attack.run_attack(target_model, data.test, *attack_parameters)
+# 2. Initialize and Train Target Model
+model = initialize_model("vgg", "m1", data.num_features, data.num_classes)
+model = train_classifier(model, train_loader, criterion, optimizer, epochs, device)
 
-result = evalute_attack(attack_output)
+# 3. Apply Defense
+defense = AdversarialTrainingPGD(model, criterion, optimizer, train_loader, device, epochs)
+defended_model = defense.train_robust()
+
+# 4. Evaluate with Attack
+attack = EvasionPGD(defended_model, test_loader, device, batch_size=128)
+adv_loader = attack.attack()
+adv_accuracy = get_accuracy(defended_model, adv_loader, device)
+
+print(f"Adversarial Accuracy: {adv_accuracy}%")
 ```
 
-The rest of the documents in this folder provide detailed usage guidance for each risk implemented in Amulet.
-Please see the [example scripts](https://github.com/ssg-research/amulet/tree/main/examples) provided for each attack / defense.
-These scripts provide an end-to-end pipeline that may be used to run experiments.
+For more details, check the specific guide for each risk and the provided [example scripts](https://github.com/ssg-research/amulet/tree/main/examples).

--- a/docs/module_guide/2_EVASION.md
+++ b/docs/module_guide/2_EVASION.md
@@ -1,136 +1,60 @@
 # Evasion
 
-Amulet implements the Projected Gradient Descent (PGD) algorithm from [cleverhans](https://github.com/cleverhans-lab/cleverhans) to generate adversarial examples.
-PGD is used for the evasion attack and the adversarial training defense.
+Evasion attacks (adversarial examples) occur when an adversary adds carefully crafted perturbations to inputs to cause a model to misclassify them. Amulet implements the **Projected Gradient Descent (PGD)** algorithm for both attacks and adversarial training defenses.
 
-## Attack:
+## Attack
 
-To run an evasion attack, use `amulet.evasion.attacks.EvasionPGD`.
-This module returns a data loader containing the adversarial examples.
-
-The following code snippet shows a brief example:
+To run an evasion attack, use `amulet.evasion.attacks.EvasionPGD`. This attack produces a `DataLoader` containing adversarial examples generated from a given test set.
 
 ```python
-import sys
-import torch
-from torch.utils.data import DataLoader
 from amulet.evasion.attacks import EvasionPGD
-from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
-    get_accuracy,
-)
+from amulet.utils import load_data, initialize_model, train_classifier, get_accuracy
 
-if len(sys.argv) > 1:
-    root_dir = sys.argv[1]
-else:
-    root_dir = './'
-dataset_name = 'cifar10' # One of [cifar10, fmnist, census, lfw, celeba, cifar100]
-batch_size = 256
-model = 'vgg' # One of [resnet, vgg, cnn, linearnet]
-model_capacity = 'm1' # One of [m1, m2, m3, m4]
-device = 'cuda:0'
-epochs = 100
-epsilon = 0.01 # Controls the amount of perturbation
+# 1. Load data and train target model
+data = load_data("./data", "cifar10")
+target_model = initialize_model("vgg", "m1", data.num_features, data.num_classes).to(device)
+target_model = train_classifier(target_model, train_loader, criterion, optimizer, 10, device)
 
-# Load dataset and create data loaders
-data = load_data(root_dir, dataset_name)
-train_loader = DataLoader(
-    dataset=data.train_set, batch_size=batch_size, shuffle=False
-)
-test_loader = DataLoader(
-    dataset=data.test_set, batch_size=batch_size, shuffle=False
-)
-
-# Train Target Model
-criterion = torch.nn.CrossEntropyLoss()
-
-target_model = initialize_model(
-    model, model_capacity, data.num_features, data.num_classes
-).to(device)
-optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-target_model = train_classifier(
-    target_model, train_loader, criterion, optimizer, epochs, device
-)
-
-# Run Evasion
+# 2. Configure and run Evasion attack
 evasion = EvasionPGD(
-    target_model, test_loader, device, batch_size, epsilon
+    model=target_model,
+    test_loader=test_loader,
+    device=device,
+    batch_size=256,
+    epsilon=0.01 # Perturbation budget
 )
-adversarial_test_loader = evasion.attack()
 
-# Test model
-test_accuracy_target = get_accuracy(target_model, test_loader, device)
-adversarial_accuracy = get_accuracy(target_model, adversarial_test_loader, device)
+adv_loader = evasion.attack()
+
+# 3. Evaluate results
+clean_acc = get_accuracy(target_model, test_loader, device)
+adv_acc = get_accuracy(target_model, adv_loader, device)
+
+print(f"Clean Accuracy: {clean_acc}%")
+print(f"Adversarial Accuracy: {adv_acc}%")
 ```
 
-## Defense:
+## Defense
 
-To run the adversarial training algorithm use `amulet.evasion.defenses.AdversarialTrainingPGD`.
-This module trains a model using adversarial training.
-
-The following code snippet shows a brief example:
+To defend against evasion attacks, use `amulet.evasion.defenses.AdversarialTrainingPGD`. This defense trains the model on a combination of clean and adversarial samples generated during training.
 
 ```python
-import sys
-import torch
-from torch.utils.data import DataLoader
 from amulet.evasion.defenses import AdversarialTrainingPGD
-from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
-    get_accuracy,
-)
 
-if len(sys.argv) > 1:
-    root_dir = sys.argv[1]
-else:
-    root_dir = './'
-dataset_name = 'cifar10' # One of [cifar10, fmnist, census, lfw, celeba, cifar100]
-batch_size = 256
-model = 'vgg' # One of [resnet, vgg, cnn, linearnet]
-model_capacity = 'm1' # One of [m1, m2, m3, m4]
-device = 'cuda:0'
-epochs = 100
-epsilon = 0.01 # Controls the amount of perturbation
-
-# Load dataset and create data loaders
-data = load_data(root_dir, dataset_name)
-train_loader = DataLoader(
-    dataset=data.train_set, batch_size=batch_size, shuffle=False
-)
-test_loader = DataLoader(
-    dataset=data.test_set, batch_size=batch_size, shuffle=False
-)
-
-# Initialize Target Model
-criterion = torch.nn.CrossEntropyLoss()
-
-target_model = initialize_model(
-    model, model_capacity, data.num_features, data.num_classes
-).to(device)
-optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-target_model = train_classifier(
-    target_model, train_loader, criterion, optimizer, epochs, device
-)
-
-# Fine-tune target model with adversarial training
+# Configure and run Adversarial Training
 adv_training = AdversarialTrainingPGD(
-    target_model,
-    criterion,
-    optimizer,
-    train_loader,
-    device,
-    epochs,
-    epsilon,
+    model=target_model,
+    criterion=criterion,
+    optimizer=optimizer,
+    train_loader=train_loader,
+    device=device,
+    epochs=10,
+    epsilon=0.01
 )
-defended_model = adv_training.train_robust()
 
-test_accuracy_defended = get_accuracy(defended_model, test_loader, device)
+defended_model = adv_training.train_robust()
 ```
 
 ## Metrics
 
-Accuracy (`amulet.utils.get_accuracy`) is currently the only metric implemeneted for evasion attacks.
+The primary metric for evasion attacks is **Adversarial Accuracy**, which measures the model's performance on inputs perturbed by the attacker. Robustness is evaluated by comparing the adversarial accuracy of an undefended model versus a defended one. Use `amulet.utils.get_accuracy` to calculate these values.

--- a/docs/module_guide/3_POISONING.md
+++ b/docs/module_guide/3_POISONING.md
@@ -1,192 +1,89 @@
 # Data Poisoning
 
-Amulet implements [BadNets](https://github.com/Kooscii/BadNets) to poison a model.
-To defend against these attacks, Amulet implements outlier removal using [Shapely Values](https://github.com/AI-secure/KNN-shapley).
+Data poisoning attacks involve an adversary injecting malicious samples into a model's training set. Amulet implements the BadNets backdoor attack and provides an outlier-removal defense based on KNN Shapley values.
 
 ## Attack
 
-To run a data poisoning attack, use `amulet.poisoning.attacks.BadNets`.
-This attack returns a poisoned dataset to train a model.
+To run a data poisoning attack, use `amulet.poisoning.attacks.BadNets`. This attack embeds a trigger into a portion of the training set and relabels those samples to a target class.
 
 ```python
-import sys
 import torch
 from torch.utils.data import DataLoader
 from amulet.poisoning.attacks import BadNets
-from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
-    get_accuracy,
-)
+from amulet.utils import load_data, initialize_model, train_classifier, get_accuracy
 
-if len(sys.argv) > 1:
-    root_dir = sys.argv[1]
-else:
-    root_dir = './'
-dataset_name = 'cifar10' # One of [cifar10, fmnist, census, lfw]
+root_dir = './'
+dataset_name = 'cifar10'
 batch_size = 256
-model = 'vgg' # One of [vgg, linearnet]
-model_capacity = 'm1' # One of [m1, m2, m3, m4]
 device = 'cuda:0'
-epochs = 100
+epochs = 10
+trigger_label = 0
+poisoned_portion = 0.1
+random_seed = 42
 
-trigger_label = 0 # The label for the poisoned data points
-poisoned_portion = 0.1 # Float between 0 and 1
-random_seed = 0
-
-# Load dataset and create data loaders
+# 1. Load data
 data = load_data(root_dir, dataset_name)
-target_train_loader = DataLoader(
-    dataset=data.train_set, batch_size=batch_size, shuffle=False
-)
-test_loader = DataLoader(
-    dataset=data.test_set, batch_size=batch_size, shuffle=False
+target_train_loader = DataLoader(data.train_set, batch_size=batch_size, shuffle=True)
+test_loader = DataLoader(data.test_set, batch_size=batch_size, shuffle=False)
+
+# 2. Configure Poisoning Attack
+poisoning = BadNets(
+    trigger_label=trigger_label,
+    portion=poisoned_portion,
+    random_seed=random_seed,
+    dataset_type="image" # or "tabular" for census
 )
 
+# 3. Poison the Training Set
+poisoned_train_set = poisoning.poison_train(data.train_set)
+poisoned_train_loader = DataLoader(poisoned_train_set, batch_size=batch_size, shuffle=True)
 
-# Train Target Model
+# 4. Train Poisoned Model
+poisoned_model = initialize_model("vgg", "m1", data.num_features, data.num_classes).to(device)
+optimizer = torch.optim.Adam(poisoned_model.parameters(), lr=1e-3)
 criterion = torch.nn.CrossEntropyLoss()
 
-target_model = initialize_model(
-    model, model_capacity, data.num_features, data.num_classes
-).to(device)
-optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-target_model = train_classifier(
-    target_model,
-    target_train_loader,
-    criterion,
-    optimizer,
-    epochs,
-    device,
-)
-
-test_accuracy_target = get_accuracy(target_model, test_loader, device)
-
-# Poison Model
-poisoned_model = initialize_model(
-    model, model_capacity, data.num_features, data.num_classes
-).to(device)
-poisoned_model.load_state_dict(target_model.state_dict())
-optimizer = torch.optim.Adam(poisoned_model.parameters(), lr=1e-3)
-poisoning = BadNets(
-    trigger_label,
-    poisoned_portion,
-    dataset_name,
-    random_seed,
-)
-
-poisoned_train_set = poisoning.poison_dataset(data.train_set)
-poisoned_train_loader = DataLoader(
-    dataset=poisoned_train_set, batch_size=batch_size, shuffle=False
-)
-
 poisoned_model = train_classifier(
-    poisoned_model,
-    poisoned_train_loader,
-    criterion,
-    optimizer,
-    epochs,
-    device,
+    poisoned_model, poisoned_train_loader, criterion, optimizer, epochs, device
 )
 
-poisoned_test_set = poisoning.poison_dataset(data.test_set, mode="test")
-poisoned_test_loader = DataLoader(
-    dataset=poisoned_test_set, batch_size=batch_size, shuffle=False
-)
+# 5. Evaluate Attack Success (on poisoned test set)
+poisoned_test_set = poisoning.poison_test(data.test_set)
+poisoned_test_loader = DataLoader(poisoned_test_set, batch_size=batch_size, shuffle=False)
 
-print(
-    "Target Model on Origin Data: %s",
-    get_accuracy(target_model, test_loader, device),
-)
-print(
-    "Target Model on Poisoned Data: %s",
-    get_accuracy(target_model, poisoned_test_loader, device),
-)
-print(
-    "Poisoned Model on Origin Data: %s",
-    get_accuracy(poisoned_model, test_loader, device),
-)
-print(
-    "Poisoned Model on Poisoned Data: %s",
-    get_accuracy(poisoned_model, poisoned_test_loader, device),
-)
+clean_acc = get_accuracy(poisoned_model, test_loader, device)
+attack_success = get_accuracy(poisoned_model, poisoned_test_loader, device)
+
+print(f"Clean Test Accuracy: {clean_acc}%")
+print(f"Attack Success Rate (ASR): {attack_success}%")
 ```
 
 ## Defense
 
-To run the outlier removal algorithm, use `amulet.poisoning.defenses`.
-Note that this is not a published defense, however, the KNN Shapley algorithm is published and used to calculate the value of each data point.
-Please see: [Ruoxi et. al., _Efficient task-specific data valuation for nearest neighbor algorithms_, ACM VLDB, 2019](https://dl.acm.org/doi/10.14778/3342263.3342637)
+To defend against poisoning, use `amulet.poisoning.defenses.OutlierRemoval`. This module identifies and removes outliers from the training set using KNN Shapley values before retraining the model.
 
 ```python
-import sys
-import torch
-from torch.utils.data import DataLoader
 from amulet.poisoning.defenses import OutlierRemoval
-from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
-    get_accuracy,
-)
 
-if len(sys.argv) > 1:
-    root_dir = sys.argv[1]
-else:
-    root_dir = './'
-dataset_name = 'cifar10' # One of [cifar10, fmnist, census, lfw]
-batch_size = 256
-model = 'vgg' # One of [vgg, linearnet]
-model_capacity = 'm1' # One of [m1, m2, m3, m4]
-device = 'cuda:0'
-epochs = 100
-
-percent = 10 # Percentage of outliers to remove
-
-# Load dataset and create data loaders
-data = load_data(root_dir, dataset_name, )
-train_loader = DataLoader(
-    dataset=data.train_set, batch_size=batch_size, shuffle=False
-)
-test_loader = DataLoader(
-    dataset=data.test_set, batch_size=batch_size, shuffle=False
-)
-
-# Train Target Model
-criterion = torch.nn.CrossEntropyLoss()
-
-target_model = initialize_model(
-    model, model_capacity, data.num_features, data.num_classes
-).to(device)
-optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-target_model = train_classifier(
-    target_model, train_loader, criterion, optimizer, epochs, device
-)
-
-test_accuracy_target = get_accuracy(target_model, test_loader, device)
-print(f'Test accuracy of target model: {test_accuracy_target}')
-
-# Train model with Outlier Removal
+# Initialize Outlier Removal Defense
 outlier_removal = OutlierRemoval(
-    target_model,
-    criterion,
-    optimizer,
-    train_loader,
-    test_loader,
-    device,
-    epochs=epochs,
-    batch_size=batch_size,
-    percent=percent,
+    model=poisoned_model,
+    criterion=criterion,
+    optimizer=optimizer,
+    train_loader=poisoned_train_loader,
+    test_loader=test_loader,
+    device=device,
+    percent=10 # Remove the bottom 10% of samples by Shapley score
 )
-defended_model = outlier_removal.train_model()
 
-test_accuracy_outlier_removed = get_accuracy(
-    defended_model, test_loader, device
-)
-print(f'Test accuracy of model with outliers removed: {test_accuracy_outlier_removed}')
+# Train the Robust Model
+defended_model = outlier_removal.train_robust()
+
+# Evaluate Improved Robustness
+defended_asr = get_accuracy(defended_model, poisoned_test_loader, device)
+print(f"ASR after defense: {defended_asr}%")
 ```
 
 ## Metrics
 
-Accuracy (`amulet.utils.get_accuracy`) is currently the only metric implemeneted for data poisoning.
+The primary metric for poisoning attacks is the **Attack Success Rate (ASR)**, which is the model's accuracy on the poisoned test set (i.e., how often it predicts the target trigger label when the trigger is present). Standard classification accuracy on clean data is also monitored to ensure the defense does not degrade performance.

--- a/docs/module_guide/4_UNAUTHORIZED_MODEL_OWNERSHIP.md
+++ b/docs/module_guide/4_UNAUTHORIZED_MODEL_OWNERSHIP.md
@@ -1,287 +1,101 @@
 # Unauthorized Model Ownership
 
-These risks are related to an adversary being able to "steal" a model, such that the stolen (surrogate) model has the same behavior and characteristics as the target model.
-Amulet implements the model stealing attack from [ML-Doctor](https://github.com/liuyugeng/ML-Doctor/blob/main/doctor/modsteal.py), which is based on the following work: [Tramer et. al. _Stealing Machine Learning Models
-via Prediction APIs_, USENIX Security, 2016](https://www.usenix.org/system/files/conference/usenixsecurity16/sec16_paper_tramer.pdf).
-The best known class of defenses for such attacks is Watermarking or Fingerprinting.
-Amulet implements the [Dataset Inference algorithm from cleverhans](https://github.com/cleverhans-lab/dataset-inference/tree/main) as a fingerprinting mechanism.
-For watermarking, Amulet implements the [WatermarkNN algorithm](https://github.com/adiyoss/WatermarkNN), however, this is currently a work in progress.
+Unauthorized Model Ownership risks are related to an adversary being able to "steal" a model, such that the stolen (surrogate) model has the same behavior and characteristics as the target model. Amulet provides tools for **Model Extraction** attacks and defenses based on **Watermarking** and **Fingerprinting**.
 
-## Attack
+## Model Extraction Attack
 
-To run a model extraction attack, use `amulet.unauth_model_ownership.attacks.ModelExtraction`.
-This attack trains a surrogate model using the original target model.
+To run a model extraction attack, use `amulet.unauth_model_ownership.attacks.ModelExtraction`. This attack trains a surrogate (attack) model by querying the target model.
 
 ```python
-import sys
-import torch
-from torch.utils.data import DataLoader, random_split
 from amulet.unauth_model_ownership.attacks import ModelExtraction
-from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
-    get_accuracy,
-)
+from amulet.utils import initialize_model, load_data
 
-if len(sys.argv) > 1:
-    root_dir = sys.argv[1]
-else:
-    root_dir = './' dataset_name = 'cifar10'
-batch_size = 256
-model = 'vgg'
-model_capacity = 'm1'
-device = 'cuda:0'
-epochs = 100
+# Load data and initialize target/attack models
+data = load_data("./data", "cifar10")
+target_model = initialize_model("vgg", "m1", data.num_features, data.num_classes)
+attack_model = initialize_model("vgg", "m1", data.num_features, data.num_classes).to(device)
 
-adv_train_fraction = 0.5
-random_seed = 123
-
-# Load dataset and split train data for adversary
-data = load_data(root_dir, dataset_name)
-
-adv_train_size = int(adv_train_fraction * len(data.train_set))
-target_train_size = len(data.train_set) - adv_train_size
-generator = torch.Generator().manual_seed(random_seed)
-target_train_set, adv_train_set = random_split(
-    data.train_set, [target_train_size, adv_train_size], generator=generator
-)
-
-# Create data loaders
-adv_train_loader = DataLoader(
-    dataset=adv_train_set, batch_size=batch_size, shuffle=False
-)
-target_train_loader = DataLoader(
-    dataset=target_train_set, batch_size=batch_size, shuffle=False
-)
-test_loader = DataLoader(
-    dataset=data.test_set, batch_size=batch_size, shuffle=False
-)
-
-# Train Target Model
-criterion = torch.nn.CrossEntropyLoss()
-
-target_model = initialize_model(
-    model, model_capacity, data.num_features, data.num_classes
-).to(device)
-optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-target_model = train_classifier(
-    target_model,
-    target_train_loader,
-    criterion,
-    optimizer,
-    epochs,
-    device,
-)
-
-test_accuracy_target = get_accuracy(target_model, test_loader, device)
-print(f'Test accuracy of target model: {test_accuracy_target}')
-
-# Train Surrogate Model
-target_model = initialize_model(
-    model, model_capacity, data.num_features, data.num_classes
-).to(device)
+train_loader = DataLoader(data.train_set, batch_size=256)
 optimizer = torch.optim.Adam(attack_model.parameters(), lr=1e-3)
+
+# Configure and run the attack
 model_extraction = ModelExtraction(
-    target_model,
-    attack_model,
-    optimizer,
-    adv_train_loader,
-    device,
-    epochs,
-    loss_type="mse"  # Optional
+    target_model=target_model,
+    attack_model=attack_model,
+    optimizer=optimizer,
+    train_loader=train_loader,
+    device=device,
+    epochs=50,
+    loss_type="mse" # Alternatives: "kl", "ce"
 )
-attack_model = model_extraction.train_attack_model()
 
+stolen_model = model_extraction.attack()
 ```
 
-## Defense
+## Fingerprinting Defense
 
-### Fingerprinting
+Fingerprinting determines if a suspect model was stolen by measuring how its outputs diverge on sensitive data points. Amulet implements **Dataset Inference** as a fingerprinting mechanism.
 
-To fingerprint a target model, use `amulet.unauth_model_ownership.defenses.Fingerprinting`.
-Note that unlike other modules, a _suspect_ model is required to run fingerprinting, as it outputs whether the suspect model was stolen or not.
-This could be a surrogate model using the attack above, or a separately trained model.
+To run fingerprinting, use `amulet.unauth_model_ownership.defenses.DatasetInference`.
 
 ```python
-import sys
-import torch
-from torch.utils.data import DataLoader
-from amulet.unauth_model_ownership.defenses import Fingerprinting
-from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
-    get_accuracy,
+from amulet.unauth_model_ownership.defenses import DatasetInference
+
+# Initialize Fingerprinting mechanism
+fingerprinting = DatasetInference(
+    target_model=target_model,
+    suspect_model=stolen_model,
+    train_loader=train_loader,
+    test_loader=test_loader,
+    num_classes=data.num_classes,
+    device=device,
+    dataset="2D" # Use "1D" for tabular data
 )
 
-if len(sys.argv) > 1:
-    root_dir = sys.argv[1]
-else:
-    root_dir = './'
-dataset_name = 'cifar10'
-batch_size = 256
-model = 'vgg'
-model_capacity = 'm1'
-device = 'cuda:0'
-epochs = 100
+# Run Fingerprinting and get p-values for membership
+results = fingerprinting.fingerprint()
 
-distance = 'l1' # One of ['l1', 'l2', 'linf', 'vanilla']
-num_iter = 500
-alpha_l1 = 1.0 # Step size for L1 attack
-alpha_l2 = 0.01 # Step size for L2 attack
-alpha_linf = 0.001 # Step size for Linf attack
-gap = 0.001 # Required for L1 attacks
-k = 1 # Required for L1 attacks
-regressor_embed = 0 # One of [0, 1]. If true, uses extra distinct data points for training the confidence regressor.
-
-# Load dataset and create data loaders
-data = load_data(root_dir, dataset_name)
-train_loader = DataLoader(
-    dataset=data.train_set, batch_size=batch_size, shuffle=False
-)
-test_loader = DataLoader(
-    dataset=data.test_set, batch_size=batch_size, shuffle=False
-)
-
-# Train Target Model
-criterion = torch.nn.CrossEntropyLoss()
-
-target_model = initialize_model(
-    model, model_capacity, data.num_features, data.num_classes
-).to(device)
-optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-target_model = train_classifier(
-    target_model, train_loader, criterion, optimizer, epochs, device
-)
-
-test_accuracy_target = get_accuracy(target_model, test_loader, device)
-print(f'Test accuracy of target model: {test_accuracy_target}')
-
-# Train Suspect Model
-target_model = initialize_model(
-    model, model_capacity, data.num_features, data.num_classes
-).to(device)
-optimizer = torch.optim.Adam(suspect_model.parameters(), lr=1e-3)
-suspect_model = train_classifier(
-    suspect_model, train_loader, criterion, optimizer, epochs, device
-)
-
-# Run Fingerprinting
-num_classes_map = {"cifar10": 10, "fmnist": 10, "census": 2, "lfw": 2}
-dataset_map = {"cifar10": "2D", "fmnist": "2D", "census": "1D", "lfw": "1D"}
-
-fingerprinting = Fingerprinting(
-    target_model,
-    suspect_model,
-    train_loader,
-    test_loader,
-    num_classes_map[dataset_name],
-    device,
-    distance,
-    dataset_map[dataset_name],
-    alpha_l1,
-    alpha_l2,
-    alpha_linf,
-    k,
-    gap,
-    num_iter,
-    regressor_embed,
-    batch_size,
-)
-results = fingerprinting.dataset_inference()
+print(f"Suspect model p-value: {results['suspect']['p-value']}")
+if results['suspect']['p-value'] < 0.05:
+    print("Suspect model is likely stolen.")
 ```
 
-### Watermarking
+## Watermarking Defense
 
-To watermark a target model, use `amulet.unauth_model_ownership.defenses.WatermarkNN`. The trigger set consists of 100 random images from the ImageNet test set and is available [here](https://github.com/ssg-research/amulet/tree/verify-watermark/miscellaneous/trigger_set).
+Watermarking involves embedding a "secret" behavior (backdoor) into the model during training. Amulet implements the **WatermarkNN** algorithm.
+
+To watermark a model, use `amulet.unauth_model_ownership.defenses.WatermarkNN`.
 
 ```python
-import sys
-import torch
-from torch.utils.data import DataLoader
 from amulet.unauth_model_ownership.defenses import WatermarkNN
-from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
-    get_accuracy,
+
+# Configure and apply Watermarking
+wm_model_wrapper = WatermarkNN(
+    model=target_model,
+    criterion=criterion,
+    optimizer=optimizer,
+    train_loader=train_loader,
+    device=device,
+    wm_path="./miscellaneous/trigger_set/",
+    epochs=50
 )
 
-if len(sys.argv) > 1:
-    root_dir = sys.argv[1]
-else:
-    root_dir = './'
-dataset_name = 'cifar10'
-batch_size = 256
-model = 'vgg'
-model_capacity = 'm1'
-device = 'cuda:0'
-epochs = 100
-
-wm_path = "./miscellaneous/trigger_set/"
-gray = False
-tabular = False
-
-# Load dataset and create data loaders
-data = load_data(root_dir, dataset_name)
-train_loader = DataLoader(
-    dataset=data.train_set, batch_size=batch_size, shuffle=False
-)
-test_loader = DataLoader(
-    dataset=data.test_set, batch_size=batch_size, shuffle=False
-)
-
-# Train Target Model
-criterion = torch.nn.CrossEntropyLoss()
-
-target_model = initialize_model(
-    model, model_capacity, data.num_features, data.num_classes,,
-).to(device)
-optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-target_model = train_classifier(
-    target_model, train_loader, criterion, optimizer, epochs, device
-)
-
-test_accuracy_target = get_accuracy(target_model, test_loader, device)
-
-# Train model with Watermarking
-wm_model = WatermarkNN(
-    target_model,
-    criterion,
-    optimizer,
-    train_loader,
-    device,
-    wm_path,
-    gray,
-    tabular,
-    epochs,
-    batch_size,
-)
-defended_model = wm_model.watermark()
+watermarked_model = wm_model_wrapper.watermark()
 ```
 
 ## Metrics
 
-### Model Extraction
+### Model Extraction Metrics
 
-Amulet provides a set of metrics to evaluate surrogate models. Use `amulet.unauth_model_ownership.metrics.evaluate_extraction`, which takes as input:
+Use `amulet.unauth_model_ownership.metrics.evaluate_extraction` to evaluate surrogate models:
 
-- The target model.
-- The surrogate model.
-- The test data loader.
-- Device to run the predictions on.
+```python
+from amulet.unauth_model_ownership.metrics import evaluate_extraction
 
-And outputs a dictionary containing:
-
-- `target_accuracy`: Test accuracy of the target model.
-- `stolen_accuracy`: Test accuracy of the stolen model.
-- `fidelity`: Agreement between target and stolen model.
-- `correct_fidelity`: Accuracy conditioned on fidelity, i.e., when the models agree, how often are they also correct?
+results = evaluate_extraction(target_model, stolen_model, test_loader, device)
+print(f"Fidelity (model agreement): {results['fidelity']}%")
+```
 
 ### Fingerprinting / Watermarking
 
-Amulet currently does not provide metrics to evaluate fingerprinting or watermarking.
-The modules output a boolean value for each model classifiying it as either "stolen" or "independently trained".
-Thus, evaluating these modules requires a pipeline to train multiple surrogate models and independently trained models to evaluate the module.
-This is a work in progress.
+Fingerprinting results are primarily interpreted via **p-values** (statistical significance). Watermarking success is measured by the model's accuracy on the trigger set while maintaining performance on clean data.

--- a/docs/module_guide/5_MEMBERSHIP_INFERENCE.md
+++ b/docs/module_guide/5_MEMBERSHIP_INFERENCE.md
@@ -1,191 +1,84 @@
 # Membership Inference
 
-Amulet implements the [Likelihood Ratio Attack (LiRA)](https://openreview.net/pdf?id=inPTplK-O6V), with the implementation taken from the [Canary in Coalmine](https://github.com/YuxinWenRick/canary-in-a-coalmine) codebase.
-To defend against these attacks, Amulet implements differentially private training using DP-SGD.
+Membership inference attacks aim to determine if a specific data point was used to train a model. Amulet implements the **Likelihood Ratio Attack (LiRA)** and provides **DP-SGD** as a robust defense against such privacy risks.
 
-## Attack
+## Membership Inference Attack
 
-To run a membership inference attack, use `amulet.membership_inference.attacks.LiRA`.
-This attack classifies each data point as `in` or `out`.
+To run a membership inference attack, use `amulet.membership_inference.attacks.LiRA`. This attack uses shadow models trained on subsets of the original dataset to estimate the likelihood that a point was in the target model's training set.
 
 ```python
-import sys
-import torch
 import numpy as np
 from torch.utils.data import DataLoader, Subset
 from amulet.membership_inference.attacks import LiRA
 from amulet.membership_inference.metrics import compute_mi_metrics
-from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
-    create_dir,
-    get_accuracy,
-)
+from amulet.utils import load_data, initialize_model, train_classifier
 
-if len(sys.argv) > 1:
-    root_dir = sys.argv[1]
-else:
-    root_dir = './' dataset_name = 'cifar10' # One of [cifar10, fmnist, census, lfw]
-batch_size = 256
-model = 'vgg' # One of [vgg, linearnet]
-model_capacity = 'm1' # One of [m1, m2, m3, m4]
-device = 'cuda:0'
-epochs = 100
+# 1. Load data and identify training members
+data = load_data("./data", "cifar10")
+dataset_size = len(data.train_set)
+in_data_indices = np.random.choice(dataset_size, size=int(0.5 * dataset_size), replace=False)
 
-pkeep = 0.5 # Proportion of training data to use.
-random_seed = 123
-num_shadow = 8 # Number of shadow models to train for membership inference
-num_aug = 10 # Number of images to augment
+train_loader = DataLoader(Subset(data.train_set, in_data_indices), batch_size=256)
 
-# Load dataset and create data loaders
-data = load_data(root_dir, dataset_name)
-
-dataset_size: int = len(data.train_set)  # type: ignore[reportArgumentType]
-
-keep = np.random.choice(
-    dataset_size,
-    size=int(pkeep * dataset_size),
-    replace=False,
-)
-keep.sort()
-target_train_set = Subset(
-    data.train_set, list(keep)
-)  # ndarray not considered a Sequence
-train_loader = DataLoader(
-    dataset=target_train_set, batch_size=batch_size, shuffle=False
-)
-test_loader = DataLoader(
-    dataset=data.test_set, batch_size=batch_size, shuffle=False
-)
-
-# Train Target Model
-criterion = torch.nn.CrossEntropyLoss()
-
-target_model = initialize_model(
-    model, model_capacity, data.num_features, data.num_classes
-).to(device)
+# 2. Train Target Model
+target_model = initialize_model("vgg", "m1", data.num_features, data.num_classes).to(device)
 optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-target_model = train_classifier(
-    target_model, train_loader, criterion, optimizer, epochs, device
-)
+target_model = train_classifier(target_model, train_loader, criterion, optimizer, 10, device)
 
-test_accuracy_target = get_accuracy(target_model, test_loader, device)
-print(f'Test accuracy of target model: {test_accuracy_target}')
-
-# Run Membership Inference attack
-
-shadow_model_dir = root_dir / 'membership_inference' / 'shadow_models'
-create_dir(shadow_model_dir)
-
+# 3. Configure and run LiRA attack
 mem_inf = LiRA(
-    target_model,
-    keep,
-    model,
-    model_capacity,
-    data.train_set,
-    dataset_name,
-    data.num_features,
-    data.num_classes,
-    pkeep,
-    criterion,
-    num_shadow,
-    num_aug,
-    epochs,
-    device,
-    shadow_model_dir,
-    random_seed,
+    target_model=target_model,
+    in_data=in_data_indices,
+    shadow_architecture="vgg",
+    shadow_capacity="m1",
+    train_set=data.train_set,
+    dataset="cifar10",
+    num_features=data.num_features,
+    num_classes=data.num_classes,
+    batch_size=256,
+    pkeep=0.5,
+    criterion=criterion,
+    num_shadow=10, # Number of shadow models
+    epochs=10,
+    device=device,
+    models_dir="./shadow_models",
+    exp_id=42
 )
 
-results = mem_inf.run_membership_inference()
+results = mem_inf.attack()
 
-print(compute_mi_metrics(results['lira_online_preds'], results['true_labels']))
-print(compute_mi_metrics(results['lira_offline_preds'], results['true_labels']))
-
-
+# 4. Evaluate Metrics
+metrics = compute_mi_metrics(results['lira_online_preds'], results['true_labels'])
+print(f"Attack AUC: {metrics['auc_score']}")
 ```
 
-## Defense
+## DP-SGD Defense
 
-To train a model using DP-SGD, use `amulet.membership_inference.defenses.DPSGD`.
-Note that the current implementation of DP-SGD does not work with batch normalization.
+To train a model with differential privacy, use `amulet.membership_inference.defenses.DPSGD`. Note that the current implementation of DP-SGD is incompatible with standard batch normalization.
 
 ```python
-import sys
-import torch
-from torch.utils.data import DataLoader
 from amulet.membership_inference.defenses import DPSGD
-from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
-    get_accuracy,
-)
 
-if len(sys.argv) > 1:
-    root_dir = sys.argv[1]
-else:
-    root_dir = './' dataset_name = 'cifar10' # One of [cifar10, fmnist, census, lfw]
-batch_size = 256
-model = 'vgg' # One of [vgg, linearnet]
-model_capacity = 'm1' # One of [m1, m2, m3, m4]
-device = 'cuda:0'
-epochs = 100
-
-delta = 1e-5 # Target delta
-max_per_sample_grad_norm = 1.0 # Clip per sample gradients to this norm
-sigma = 1.0 # Noise multiplier
-secure_rng = False # Enable Secure RNG to have trustworthy privacy guarantees. Comes at a performance cost
-
-# Load dataset and create data loaders
-data = load_data(root_dir, dataset_name)
-train_loader = DataLoader(
-    dataset=data.train_set, batch_size=batch_size, shuffle=False
-)
-test_loader = DataLoader(
-    dataset=data.test_set, batch_size=batch_size, shuffle=False
-)
-
-# Train or Load Target Model
-criterion = torch.nn.CrossEntropyLoss()
-target_model = initialize_model(
-    model, model_capacity, data.num_features, data.num_classes
-).to(device)
-optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-target_model = train_classifier(
-    target_model, train_loader, criterion, optimizer, epochs, device
-)
-
-test_accuracy_target = get_accuracy(target_model, test_loader, device)
-print(f'Test accuracy of target model: {test_accuracy_target}')
-
-defended_model = initialize_model(
-    model, model_capacity, dataset_name, batch_norm=False
-).to(device)
+# Initialize model without batch normalization
+defended_model = initialize_model("vgg", "m1", data.num_features, data.num_classes, batch_norm=False).to(device)
 optimizer = torch.optim.Adam(defended_model.parameters(), lr=1e-3)
-dp_training = DPSGD(
-    defended_model,
-    criterion,
-    optimizer,
-    train_loader,
-    device,
-    delta,
-    max_per_sample_grad_norm,
-    sigma,
-    secure_rng,
-    epochs,
-)
-defended_model = dp_training.train_model()
 
-test_accuracy_defended = get_accuracy(defended_model, test_loader, device)
-print(f'Test accuracy of defended model: {test_accuracy_defended}')
+# Configure and run DP-SGD
+dp_training = DPSGD(
+    model=defended_model,
+    criterion=criterion,
+    optimizer=optimizer,
+    train_loader=train_loader,
+    device=device,
+    delta=1e-5,
+    max_per_sample_grad_norm=1.0,
+    sigma=1.0, # Noise multiplier
+    epochs=10
+)
+
+defended_model = dp_training.train_private()
 ```
 
 ## Metrics
 
-Amulet implements the fixed AUC method recommended by [LiRA](https://openreview.net/pdf?id=inPTplK-O6V).
-Use `amulet.membership_inference.metrics.compute_mi_metrics`.
-This function takes as input the in/out labels and compares them with the true labels.
-
-To evaluate the effectiveneess of the DP-SGD algorithm, we recommend using the LiRA attack.
-DP-SGD often has a large impact on the test accuracy, which can be used as an evaluation metric.
+Membership inference effectiveness is evaluated using the **AUC score** and **Precision at low False Positive Rates (FPR)**, which are standard for measuring how well an adversary can distinguish members from non-members. Use `amulet.membership_inference.metrics.compute_mi_metrics` to compute these values from attack results.

--- a/docs/module_guide/6_ATTRIBUTE_INFERENCE.md
+++ b/docs/module_guide/6_ATTRIBUTE_INFERENCE.md
@@ -1,118 +1,49 @@
 # Attribute Inference
 
-Amulet implements the attribute inference attack from the work [Inferring Sensitive Attributes from Model Explanations](https://github.com/vasishtduddu/AttInfExplanations) by Duddu et. al. published at ACM CIKM 2022.
+Attribute inference attacks predict sensitive features of a data point (like gender or race) based on its outputs from a model, even when those features were not used as classification targets during training.
 
 ## Attack
 
-To run an attribute inference attack, use `amulet.attribute_inference.attacks.DudduCIKM2022`.
-This attack predicts the sensitive attributes for a dataset, for example, it could predict whether the data point was a _male_ or _female_ even when the training data did not use this attribute directly.
-Attribute inference only works for datasets that have sensitive attributes.
-Amulet provides the LFW and Census datasets for such use cases.
+To run an attribute inference attack, use `amulet.attribute_inference.attacks.DudduCIKM2022`. This attack trains an MLP on target model predictions and corresponding sensitive attributes to learn how to infer those attributes for new samples.
 
 ```python
-import sys
-import torch
 import numpy as np
-from torch.utils.data import DataLoader, TensorDataset
+from sklearn.model_selection import train_test_split
 from amulet.attribute_inference.attacks import DudduCIKM2022
 from amulet.attribute_inference.metrics import evaluate_attribute_inference
-from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
-    get_accuracy,
-)
-from sklearn.model_selection import train_test_split
+from amulet.utils import load_data, initialize_model, train_classifier
 
-if len(sys.argv) > 1:
-    root_dir = sys.argv[1]
-else:
-    root_dir = './' dataset_name = 'lfw' # One of [lfw, census]
-batch_size = 256
-model = 'vgg' # One of [vgg, linearnet]
-model_capacity = 'm1' # One of [m1, m2, m3, m4]
-device = 'cuda:0'
-epochs = 100
+# 1. Load data with sensitive attributes
+data = load_data("./data", "celeba")
+if data.z_train is None:
+    raise Exception("Dataset does not have sensitive attributes.")
 
-adv_train_fraction = 0.5 # Portion of training data used by adversary
+# 2. Split data for adversary
+split = train_test_split(data.x_train, data.y_train, data.z_train, test_size=0.5)
+(x_target, x_adv, y_target, _, _, z_adv) = split
 
-# Load dataset and split train data for adversary
-data = load_data(root_dir, dataset_name)
+# 3. Train Target Model
+target_model = initialize_model("vgg", "m1", data.num_features, data.num_classes).to(device)
+target_model = train_classifier(target_model, target_train_loader, criterion, optimizer, 10, device)
 
-if data.z_train is None or data.z_test is None:
-    raise Exception('Dataset has no sensitive attributes')
-
-split_data = train_test_split(
-    data.x_train, data.y_train, data.z_train, test_size=adv_train_fraction
-)
-
-(
-    x_train_target,
-    x_train_adv,
-    y_train_target,
-    _,
-    _,
-    z_train_adv,
-) = split_data
-
-x_train_target = np.array(x_train_target)
-x_train_adv = np.array(x_train_adv)
-y_train_target = np.array(y_train_target)
-z_train_adv = np.array(z_train_adv)
-
-# Create data loaders
-target_train_set = TensorDataset(
-    torch.from_numpy(x_train_target).type(torch.float),
-    torch.from_numpy(y_train_target).type(torch.long),
-)
-
-test_set = TensorDataset(
-    torch.from_numpy(data.x_test).type(torch.float),
-    torch.from_numpy(data.y_test).type(torch.long),
-)
-
-target_train_loader = DataLoader(
-    dataset=target_train_set, batch_size=batch_size, shuffle=False
-)
-test_loader = DataLoader(
-    dataset=test_set, batch_size=batch_size, shuffle=False
-)
-
-criterion = torch.nn.CrossEntropyLoss()
-
-target_model = initialize_model(
-    model, model_capacity, data.num_features, data.num_classes
-).to(device)
-optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-target_model = train_classifier(
-    target_model,
-    target_train_loader,
-    criterion,
-    optimizer,
-    epochs,
-    device,
-)
-
-test_accuracy_target = get_accuracy(target_model, test_loader, device)
-print(f'Test accuracy of target model: {test_accuracy_target}')
-
-# Run Attribute Inference attack
+# 4. Run Attribute Inference Attack
 attribute_inference = DudduCIKM2022(
-    target_model, x_train_adv, data.x_test, z_train_adv, device
+    target_model=target_model,
+    x_train_adv=x_adv,
+    x_test=data.x_test,
+    z_train_adv=z_adv,
+    batch_size=256,
+    device=device
 )
-predictions = attribute_inference.attack_predictions()
 
-results = evaluate_attribute_inference(data.z_test, predictions)
+# results is a dict mapping attribute index to {predictions, confidence_values}
+results = attribute_inference.attack()
 
-print(results)
+# 5. Evaluate Metrics
+metrics = evaluate_attribute_inference(data.z_test, results)
+print(f"Attribute Inference Balanced Accuracy: {metrics[0]['balanced_accuracy']}")
 ```
-
-## Defense
-
-Amulet does not currently implement any direct defenses for attribute inference.
-[DP-SGD](https://github.com/ssg-research/amulet/blob/main/docs/module_guide/5_MEMBERSHIP_INFERENCE.md#defense) may be used as a general privacy preserving mechanism.
 
 ## Metrics
 
-Use `amulet.attribute_inference.metrics.evaluate_attribute_inference` to evaluate attribute inference attacks.
-This calculates the balanced accuracy and the auc score for the predictions.
+Attribute inference is evaluated using **Balanced Accuracy** and **AUC Score** for each inferred attribute. Use `amulet.attribute_inference.metrics.evaluate_attribute_inference` to calculate these metrics from attack results.

--- a/docs/module_guide/7_DISTRIBUTION_INFERENCE.md
+++ b/docs/module_guide/7_DISTRIBUTION_INFERENCE.md
@@ -1,18 +1,36 @@
 # Distribution Inference
 
-Amulet implements the distribution inference attack from the work [Dissecting Distribution Inference](https://github.com/iamgroot42/dissecting_dist_inf) by Suri et. al. published at IEEE SaTML 2023.
+Distribution inference attacks aim to determine if a training set follows a specific distribution (e.g., if a certain property or ratio of samples is present). Amulet implements a KL-divergence-based distinguishing test.
 
 ## Attack
 
-<!-- To run an distribution inference attack, use `amulet.distribution_inference.attacks.SuriSATML2023`. -->
+To run a distribution inference attack, use `amulet.distribution_inference.attacks.SuriEvans2022`. This attack measures how a victim model's outputs diverge from adversary baseline models trained on two different distributions.
 
-This attack is a work in progress and will be made available in a future update.
+```python
+from amulet.distribution_inference.attacks import SuriEvans2022
 
-## Defense
+# 1. Prepare Victim and Adversary Models for both distributions
+# victim_models_1: list[nn.Module], victim_models_2: list[nn.Module]
+# adversary_models_1: list[nn.Module], adversary_models_2: list[nn.Module]
 
-Amulet does not currently implement any direct defenses for distribution inference.
-[DP-SGD](https://github.com/ssg-research/amulet/blob/main/docs/module_guide/5_MEMBERSHIP_INFERENCE.md#defense) may be used as a general privacy preserving mechanism.
+# 2. Run the Distribution Inference attack
+dist_inf = SuriEvans2022(
+    models_vic_1=victim_models_1,
+    models_vic_2=victim_models_2,
+    models_adv_1=adversary_models_1,
+    models_adv_2=adversary_models_2,
+    test_loader_1=test_loader_dist_1,
+    test_loader_2=test_loader_dist_2,
+    device=device
+)
+
+results = dist_inf.attack()
+
+# 3. Evaluate results
+# results["predictions"] contains scores in [0, 1]
+# results["ground_truth"] contains binary labels for distributions
+```
 
 ## Metrics
 
-Evaluation for distribution inference is currently a work in progress.
+Distribution inference is evaluated by the attack's **Distinguishing Accuracy**. This measures how well the adversary can correctly identify which of the two distributions was used to train a victim model. Use `amulet.distribution_inference.metrics.DistinguishingAccuracy` to compute these metrics.

--- a/docs/module_guide/8_DATA_RECONSTRUCTION.md
+++ b/docs/module_guide/8_DATA_RECONSTRUCTION.md
@@ -1,80 +1,43 @@
 # Data Reconstruction
 
-Amulet implements the data reconstruction attack from the [ML-Doctor library](https://github.com/liuyugeng/ML-Doctor/blob/main/doctor/modinv.py) which is based off of the work [Model Inversion Attacks that Exploit Confidence Information
-and Basic Countermeasures](https://rist.tech.cornell.edu/papers/mi-ccs.pdf) by Fredrikson et. al. published at ACM CCS 2015.
+Data reconstruction attacks (also known as model inversion) attempt to recover training data samples by exploiting a model's confidence outputs. Amulet implements the Fredrikson et al. attack.
 
 ## Attack
 
-To run a data reconstruction attack, use `amulet.data_reconstruction.attacks.FredriksonCCS2015`.
+To run a data reconstruction attack, use `amulet.data_reconstruction.attacks.FredriksonCCS2015`. This attack uses gradient descent to reconstruct an "average" data point for each output class based on the model's confidence scores.
 
 ```python
-import sys
 import torch
-from torch.utils.data import DataLoader
 from amulet.data_reconstruction.attacks import FredriksonCCS2015
-from amulet.data_reconstruction.metrics import reverse_mse
-from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
-    get_accuracy,
-)
+from amulet.data_reconstruction.metrics import evaluate_similarity
+from amulet.utils import load_data, initialize_model, train_classifier
 
-if len(sys.argv) > 1:
-    root_dir = sys.argv[1]
-else:
-    root_dir = './' dataset_name = 'lfw' # One of [lfw, census]
-batch_size = 256
-model = 'vgg' # One of [vgg, linearnet]
-model_capacity = 'm1' # One of [m1, m2, m3, m4]
-device = 'cuda:0'
-epochs = 100
+# 1. Load data and train target model
+data = load_data("./data", "lfw")
+target_model = initialize_model("vgg", "m1", data.num_features, data.num_classes).to(device)
+target_model = train_classifier(target_model, train_loader, criterion, optimizer, 10, device)
 
-alpha = 3000 # Number of iterations for data reconstruction
-
-# Load dataset and create data loaders
-data = load_data(root_dir, dataset_name)
-train_loader = DataLoader(dataset=data.train_set, batch_size=1, shuffle=False)
-test_loader = DataLoader(dataset=data.test_set, batch_size=1, shuffle=False)
-
-# Train Target Model
-criterion = torch.nn.CrossEntropyLoss()
-
-target_model = initialize_model(
-    model, model_capacity, data.num_features, data.num_classes
-).to(device)
-optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-target_model = train_classifier(
-    target_model, train_loader, criterion, optimizer, epochs, device
-)
-
-test_accuracy_target = get_accuracy(target_model, test_loader, device)
-print(f'Test accuracy of target model: {test_accuracy_target}')
-
-# Run Data Reconstruction attack
+# 2. Configure and run Data Reconstruction attack
 input_size = (1,) + tuple(data.test_set[0][0].shape)
-num_classes_dict = {'cifar10': 10, 'fmnist': 10, 'census': 2, 'lfw': 2}
-output_size = num_classes_dict[dataset_name]
+output_size = data.num_classes
+
 data_recon = FredriksonCCS2015(
-    target_model, input_size, output_size, device, alpha
+    target_model=target_model,
+    input_size=input_size,
+    output_size=output_size,
+    device=device,
+    alpha=3000 # Number of iterations
 )
 
-reverse_data = data_recon.get_reconstructed_data()
+# Returns a list of reconstructed tensors, one per class
+reconstructed_data = data_recon.attack()
 
-mse_loss = reverse_mse(
-    test_loader, reverse_data, input_size, output_size, device
-)
-
-print(f'Reverse MSE: {mse_loss}')
+# 3. Evaluate Metrics
+results = evaluate_similarity(test_loader, reconstructed_data, input_size, output_size, device)
+print(f"Average MSE: {results['mean_mse']}")
+print(f"Average SSIM: {results['mean_ssim']}")
 ```
-
-## Defense
-
-Amulet does not currently implement any direct defenses for data reconstruction.
-[DP-SGD](https://github.com/ssg-research/amulet/blob/main/docs/module_guide/5_MEMBERSHIP_INFERENCE.md#defense) may be used as a general privacy preserving mechanism.
 
 ## Metrics
 
-To evaluate data reconstruction attacks, use `amulet.data_reconstruction.metrics.reverse_mse`.
-This function calculates the _average_ data point in each class, and finds the class-wise MSE between the reconstructed (reverse) data point and the average.
-This class-wise MSE is then averaged over all classes.
+Reconstruction quality is evaluated using **Mean Squared Error (MSE)** and **Structural Similarity Index (SSIM)**. These metrics compare the reconstructed samples to the class-wise averages of the original test set. Use `amulet.data_reconstruction.metrics.evaluate_similarity` to calculate these scores.

--- a/docs/module_guide/9_DISCRIMINATORY_BEHAVIOR.md
+++ b/docs/module_guide/9_DISCRIMINATORY_BEHAVIOR.md
@@ -1,139 +1,70 @@
 # Discriminatory Behavior
 
-This module focuses on evaluating a model for bias and fairness.
-While there is currently no specific attack that increases bias in a model, Amulet does implement an [adversarial debiasing method](https://xebia.com/blog/towards-fairness-in-ml-with-adversarial-networks/) to decrease bias in a model.
+Discriminatory behavior evaluations focus on assessing model bias and group fairness across sensitive attributes like gender, race, or age. Amulet implements an **Adversarial Debiasing** defense to mitigate these biases.
 
-This module only works with datasets that have sensitive attributes, such as Census and LFW.
+## Adversarial Debiasing Defense
 
-## Defense
-
-To run the adversarial debiasing module, use `amulet.discriminatory_behavior.defenses.AdversarialDebiasing`. This module uses adversarial training to ensure that the model outputs are independent of the sensitive attributes in the data.
+To reduce bias in a model, use `amulet.discriminatory_behavior.defenses.AdversarialDebiasing`. This defense jointly trains the main classifier and a discriminator (adversary) that attempts to predict the sensitive attributes from the classifier's outputs. The classifier is trained to perform its task while making it impossible for the adversary to infer sensitive attributes.
 
 ```python
-import sys
 import torch
 from torch.utils.data import DataLoader, TensorDataset
 from amulet.discriminatory_behavior.defenses import AdversarialDebiasing
 from amulet.discriminatory_behavior.metrics import DiscriminatoryBehavior
-from amulet.utils import (
-    load_data,
-    initialize_model,
-    train_classifier,
-    get_accuracy,
+from amulet.utils import load_data, initialize_model, train_classifier
+
+# 1. Load data with sensitive attributes
+data = load_data("./data", "celeba")
+
+# 2. Prepare Sensitive DataLoaders (including z attributes)
+train_set_z = TensorDataset(
+    torch.from_numpy(data.x_train).float(),
+    torch.from_numpy(data.y_train).long(),
+    torch.from_numpy(data.z_train).float()
+)
+train_loader_z = DataLoader(train_set_z, batch_size=256, shuffle=True)
+
+test_set_z = TensorDataset(
+    torch.from_numpy(data.x_test).float(),
+    torch.from_numpy(data.y_test).long(),
+    torch.from_numpy(data.z_test).float()
+)
+test_loader_z = DataLoader(test_set_z, batch_size=256, shuffle=False)
+
+# 3. Configure and run Adversarial Debiasing
+lambdas = torch.Tensor([40, 40]) # Penalty weights for sensitive attributes
+
+debiasing = AdversarialDebiasing(
+    model=model,
+    criterion=criterion,
+    optimizer=optimizer,
+    train_loader=train_loader_z,
+    test_loader=test_loader_z,
+    n_sensitive_attrs=data.z_train.shape[1],
+    n_classes=data.num_classes,
+    lambdas=lambdas,
+    device=device,
+    epochs=10
 )
 
-if len(sys.argv) > 1:
-    root_dir = sys.argv[1]
-else:
-    root_dir = './'
-dataset_name = 'lfw' # One of [lfw, census]
-batch_size = 256
-model = 'vgg' # One of [vgg, linearnet]
-model_capacity = 'm1' # One of [m1, m2, m3, m4]
-device = 'cuda:0'
-epochs = 100
-
-# Load dataset and create data loaders
-data = load_data(root_dir, dataset_name)
-
-train_loader = DataLoader(
-    dataset=data.train_set, batch_size=batch_size, shuffle=False
-)
-test_loader = DataLoader(
-    dataset=data.test_set, batch_size=batch_size, shuffle=False
-)
-
-sensitive_train_set = TensorDataset(
-    torch.from_numpy(data.x_train).type(torch.float),
-    torch.from_numpy(data.y_train).type(torch.long),
-    torch.from_numpy(data.z_train).type(torch.float),
-)
-
-sensitive_test_set = TensorDataset(
-    torch.from_numpy(data.x_test).type(torch.float),
-    torch.from_numpy(data.y_test).type(torch.long),
-    torch.from_numpy(data.z_test).type(torch.float),
-)
-
-sensitive_train_loader = DataLoader(
-    dataset=sensitive_train_set, batch_size=batch_size, shuffle=False
-)
-sensitive_test_loader = DataLoader(
-    dataset=sensitive_test_set, batch_size=batch_size, shuffle=False
-)
-
-# Train Target Model
-criterion = torch.nn.CrossEntropyLoss()
-
-target_model = initialize_model(
-    model, model_capacity, data.num_features, data.num_classes, device)
-optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-target_model = train_classifier(
-    target_model, train_loader, criterion, optimizer, epochs, device
-)
-
-
-test_accuracy_target = get_accuracy(target_model, test_loader, device)
-print(f'Test accuracy of target model: {test_accuracy_target}')
-
-# Measure discriminatory behavior of target model
-discr_behavior_target = DiscriminatoryBehavior(
-    target_model, sensitive_test_loader, device
-)
-all_metrics = discr_behavior_target.evaluate_subgroup_metrics()
-
-metrics_labelled = {}
-metrics_labelled['white_non-white'] = all_metrics[0]
-metrics_labelled['males_females'] = all_metrics[1]
-
-for attribute, metrics in metrics_labelled.items():
-    print(attribute)
-    for metric, value in metrics.items():
-        print(f'{metric}: {value}')
-
-if (
-    dataset_name == 'lfw'
-):  # change lambdas manually to get better trade-off; hyperparameter tuning is hard in this
-    lambdas = torch.Tensor([45, 17])
-else:
-    lambdas = torch.Tensor([40, 40])
-
-group_fairness = AdversarialDebiasing(
-    target_model,
-    criterion,
-    optimizer,
-    sensitive_train_loader,
-    sensitive_test_loader,
-    data.z_train.shape[1],
-    data.num_classes,
-    lambdas,
-    device,
-    epochs,
-)
-defended_model = group_fairness.train_fair()
-
-test_accuracy_defended = get_accuracy(defended_model, test_loader, device)
-print(f'Test accuracy of defended model: {test_accuracy_defended}')
-
-# Measure discriminatory behavior of defended model
-discr_behavior_defended = DiscriminatoryBehavior(
-    defended_model, sensitive_test_loader, device
-)
-all_metrics = discr_behavior_defended.evaluate_subgroup_metrics()
-
-metrics_labelled = {}
-metrics_labelled['white_non-white'] = all_metrics[0]
-metrics_labelled['males_females'] = all_metrics[1]
-
-for attribute, metrics in metrics_labelled.items():
-    print(attribute)
-    for metric, value in metrics.items():
-        print(f'{metric}: {value}')
-
+defended_model = debiasing.train_fair()
 ```
 
 ## Metrics
 
-Unlike other metrics, Amulet implements a class to measure discriminatory behavior.
-Please use `amulet.discriminatory_behavior.metrics.DiscriminatoryBehavior` to evaluate a model's risk for discriminatory behavior.
-The example above demonstrates how to use this class.
+Fairness is evaluated using subgroup metrics like **Equalized Odds** and **Demographic Parity**. Use the `amulet.discriminatory_behavior.metrics.DiscriminatoryBehavior` class to measure these values.
+
+```python
+from amulet.discriminatory_behavior.metrics import DiscriminatoryBehavior
+
+# Initialize metric calculator
+fairness_metrics = DiscriminatoryBehavior(defended_model, test_loader_z, device)
+
+# Get dictionary of results across all sensitive attributes
+subgroup_results = fairness_metrics.evaluate_subgroup_metrics()
+
+for attr_idx, metrics in subgroup_results.items():
+    print(f"Subgroup {attr_idx} metrics:")
+    for metric_name, value in metrics.items():
+        print(f"  {metric_name}: {value}")
+```

--- a/examples/attack_pipelines/run_attribute_inference.py
+++ b/examples/attack_pipelines/run_attribute_inference.py
@@ -59,7 +59,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default="cuda:0" if torch.cuda.is_available() else "cpu",
+        default="cuda" if torch.cuda.is_available() else "cpu",
         help="Device on which to run PyTorch",
     )
     parser.add_argument(

--- a/examples/attack_pipelines/run_data_recon.py
+++ b/examples/attack_pipelines/run_data_recon.py
@@ -54,7 +54,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default="cuda:0" if torch.cuda.is_available() else "cpu",
+        default="cuda" if torch.cuda.is_available() else "cpu",
         help="Device on which to run PyTorch",
     )
     parser.add_argument(

--- a/examples/attack_pipelines/run_distribution_inference.py
+++ b/examples/attack_pipelines/run_distribution_inference.py
@@ -36,7 +36,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default="cuda:0" if torch.cuda.is_available() else "cpu",
+        default="cuda" if torch.cuda.is_available() else "cpu",
     )
     parser.add_argument("--exp_id", type=int, default=0)
     parser.add_argument("--ratio1", type=float, default=0.1)

--- a/examples/attack_pipelines/run_evasion.py
+++ b/examples/attack_pipelines/run_evasion.py
@@ -1,6 +1,7 @@
 import sys
 
 sys.path.append("../../")
+
 import argparse
 import logging
 from pathlib import Path
@@ -14,6 +15,7 @@ from amulet.utils import (
     get_accuracy,
     initialize_model,
     load_data,
+    load_or_train,
     train_classifier,
 )
 
@@ -31,7 +33,7 @@ def parse_args() -> argparse.Namespace:
         "--dataset",
         type=str,
         default="celeba",
-        help="Options: cifar10, fmnist, lfw, census, celeba, cifar100.",
+        help="Options: cifar10, cifar100, fmnist, mnist, lfw, census, celeba, utkface.",
     )
     parser.add_argument(
         "--model", type=str, default="vgg", help="Options: resnet, vgg, cnn, linearnet."
@@ -54,7 +56,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default=torch.device(f"cuda:{0}" if torch.cuda.is_available() else "cpu"),
+        default="cuda:0" if torch.cuda.is_available() else "cpu",
         help="Device on which to run PyTorch",
     )
     parser.add_argument(
@@ -93,30 +95,25 @@ def main(args: argparse.Namespace) -> None:
     # Set up filename and directories to save/load models
     models_path = root_dir / "saved_models"
     filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size * 100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
-    target_model_path = models_path / "target"
-    target_model_filename = target_model_path / filename
+    target_model_filename = models_path / "target" / filename
 
     # Train or Load Target Model
     criterion = torch.nn.CrossEntropyLoss()
 
-    if target_model_filename.exists():
-        log.info("Target model loaded from %s", target_model_filename)
-        target_model = torch.load(target_model_filename).to(args.device)
-        optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-    else:
-        log.info("Training target model")
-        target_model = initialize_model(
+    def _init_target():
+        return initialize_model(
             args.model, args.model_capacity, data.num_features, data.num_classes, log
         ).to(args.device)
-        optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-        target_model = train_classifier(
-            target_model, train_loader, criterion, optimizer, args.epochs, args.device
-        )
-        log.info("Target model trained")
 
-        # Save model
-        create_dir(target_model_path, log)
-        torch.save(target_model, target_model_filename)
+    def _train_target(model):
+        optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+        return train_classifier(
+            model, train_loader, criterion, optimizer, args.epochs, args.device
+        )
+
+    target_model = load_or_train(
+        target_model_filename, _init_target, _train_target, log, "target model"
+    )
 
     test_accuracy_target = get_accuracy(target_model, test_loader, args.device)
     log.info("Test accuracy of target model: %s", test_accuracy_target)

--- a/examples/attack_pipelines/run_evasion.py
+++ b/examples/attack_pipelines/run_evasion.py
@@ -56,7 +56,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default="cuda:0" if torch.cuda.is_available() else "cpu",
+        default="cuda" if torch.cuda.is_available() else "cpu",
         help="Device on which to run PyTorch",
     )
     parser.add_argument(

--- a/examples/attack_pipelines/run_membership_inference.py
+++ b/examples/attack_pipelines/run_membership_inference.py
@@ -1,6 +1,7 @@
 import sys
 
 sys.path.append("../../")
+
 import argparse
 import logging
 from pathlib import Path
@@ -16,6 +17,7 @@ from amulet.utils import (
     get_accuracy,
     initialize_model,
     load_data,
+    load_or_train,
     train_classifier,
 )
 
@@ -56,7 +58,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default=torch.device(f"cuda:{0}" if torch.cuda.is_available() else "cpu"),
+        default="cuda:0" if torch.cuda.is_available() else "cpu",
         help="Device on which to run PyTorch",
     )
     parser.add_argument(
@@ -64,7 +66,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--pkeep",
-        type=int,
+        type=float,
         default=0.5,
         help="Proportion of data to keep for training.",
     )
@@ -81,7 +83,7 @@ def main(args: argparse.Namespace) -> None:
     log_dir = root_dir / "logs"
     create_dir(log_dir)
     logging.basicConfig(
-        level=logging.INFO, filename=log_dir / "evasion.log", filemode="w"
+        level=logging.INFO, filename=log_dir / "membership_inference.log", filemode="w"
     )
     log = logging.getLogger("All")
     log.addHandler(logging.StreamHandler())
@@ -113,30 +115,25 @@ def main(args: argparse.Namespace) -> None:
     # Set up filename and directories to save/load models
     models_path = root_dir / "saved_models"
     filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size * 100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
-    target_model_path = models_path / "target"
-    target_model_filename = target_model_path / filename
+    target_model_filename = models_path / "target" / filename
 
     # Train or Load Target Model
     criterion = torch.nn.CrossEntropyLoss()
 
-    if target_model_filename.exists():
-        log.info("Target model loaded from %s", target_model_filename)
-        target_model = torch.load(target_model_filename).to(args.device)
-        optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-    else:
-        log.info("Training target model")
-        target_model = initialize_model(
+    def _init_target():
+        return initialize_model(
             args.model, args.model_capacity, data.num_features, data.num_classes, log
         ).to(args.device)
-        optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-        target_model = train_classifier(
-            target_model, train_loader, criterion, optimizer, args.epochs, args.device
-        )
-        log.info("Target model trained")
 
-        # Save model
-        create_dir(target_model_path, log)
-        torch.save(target_model, target_model_filename)
+    def _train_target(model):
+        optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+        return train_classifier(
+            model, train_loader, criterion, optimizer, args.epochs, args.device
+        )
+
+    target_model = load_or_train(
+        target_model_filename, _init_target, _train_target, log, "target model"
+    )
 
     test_accuracy_target = get_accuracy(target_model, test_loader, args.device)
     log.info("Test accuracy of target model: %s", test_accuracy_target)

--- a/examples/attack_pipelines/run_membership_inference.py
+++ b/examples/attack_pipelines/run_membership_inference.py
@@ -58,7 +58,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default="cuda:0" if torch.cuda.is_available() else "cpu",
+        default="cuda" if torch.cuda.is_available() else "cpu",
         help="Device on which to run PyTorch",
     )
     parser.add_argument(

--- a/examples/attack_pipelines/run_model_extraction.py
+++ b/examples/attack_pipelines/run_model_extraction.py
@@ -57,7 +57,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default="cuda:0" if torch.cuda.is_available() else "cpu",
+        default="cuda" if torch.cuda.is_available() else "cpu",
         help="Device on which to run PyTorch",
     )
     parser.add_argument(

--- a/examples/attack_pipelines/run_poisoning.py
+++ b/examples/attack_pipelines/run_poisoning.py
@@ -56,7 +56,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default="cuda:0" if torch.cuda.is_available() else "cpu",
+        default="cuda" if torch.cuda.is_available() else "cpu",
         help="Device on which to run PyTorch",
     )
     parser.add_argument(

--- a/examples/attack_pipelines/run_whitebox_dist_inference.py
+++ b/examples/attack_pipelines/run_whitebox_dist_inference.py
@@ -38,7 +38,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default="cuda:0" if torch.cuda.is_available() else "cpu",
+        default="cuda" if torch.cuda.is_available() else "cpu",
     )
     parser.add_argument("--exp_id", type=int, default=0)
     parser.add_argument("--ratio1", type=float, default=0.1)

--- a/examples/defense_pipelines/run_adversarial_debiasing.py
+++ b/examples/defense_pipelines/run_adversarial_debiasing.py
@@ -57,7 +57,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default="cuda:0" if torch.cuda.is_available() else "cpu",
+        default="cuda" if torch.cuda.is_available() else "cpu",
         help="Device on which to run PyTorch",
     )
     parser.add_argument(

--- a/examples/defense_pipelines/run_adversarial_training.py
+++ b/examples/defense_pipelines/run_adversarial_training.py
@@ -57,7 +57,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default="cuda:0" if torch.cuda.is_available() else "cpu",
+        default="cuda" if torch.cuda.is_available() else "cpu",
         help="Device on which to run PyTorch",
     )
     parser.add_argument(

--- a/examples/defense_pipelines/run_adversarial_training.py
+++ b/examples/defense_pipelines/run_adversarial_training.py
@@ -1,6 +1,7 @@
 import sys
 
 sys.path.append("../../")
+
 import argparse
 import logging
 from pathlib import Path
@@ -8,12 +9,14 @@ from pathlib import Path
 import torch
 from torch.utils.data import DataLoader
 
+from amulet.evasion.attacks import EvasionPGD
 from amulet.evasion.defenses import AdversarialTrainingPGD
 from amulet.utils import (
     create_dir,
     get_accuracy,
     initialize_model,
     load_data,
+    load_or_train,
     train_classifier,
 )
 
@@ -31,7 +34,7 @@ def parse_args() -> argparse.Namespace:
         "--dataset",
         type=str,
         default="celeba",
-        help="Options: cifar10, fmnist, lfw, census, celeba.",
+        help="Options: cifar10, cifar100, fmnist, mnist, lfw, census, celeba, utkface.",
     )
     parser.add_argument(
         "--model", type=str, default="vgg", help="Options: vgg, linearnet."
@@ -54,7 +57,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default=torch.device(f"cuda:{0}" if torch.cuda.is_available() else "cpu"),
+        default="cuda:0" if torch.cuda.is_available() else "cpu",
         help="Device on which to run PyTorch",
     )
     parser.add_argument(
@@ -93,45 +96,41 @@ def main(args: argparse.Namespace) -> None:
     # Set up filename and directories to save/load models
     models_path = root_dir / "saved_models"
     filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size * 100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
-    target_model_path = models_path / "target"
-    target_model_filename = target_model_path / filename
+    target_model_filename = models_path / "target" / filename
 
     # Train or Load Target Model
     criterion = torch.nn.CrossEntropyLoss()
 
-    if target_model_filename.exists():
-        log.info("Target model loaded from %s", target_model_filename)
-        target_model = torch.load(target_model_filename).to(args.device)
-        optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-    else:
-        log.info("Training target model")
-        target_model = initialize_model(
+    def _init_target():
+        return initialize_model(
             args.model, args.model_capacity, data.num_features, data.num_classes, log
         ).to(args.device)
-        optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-        target_model = train_classifier(
-            target_model, train_loader, criterion, optimizer, args.epochs, args.device
-        )
-        log.info("Target model trained")
 
-        # Save model
-        create_dir(target_model_path, log)
-        torch.save(target_model, target_model_filename)
+    def _train_target(model):
+        optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+        return train_classifier(
+            model, train_loader, criterion, optimizer, args.epochs, args.device
+        )
+
+    target_model = load_or_train(
+        target_model_filename, _init_target, _train_target, log, "target model"
+    )
 
     test_accuracy_target = get_accuracy(target_model, test_loader, args.device)
     log.info("Test accuracy of target model: %s", test_accuracy_target)
 
     # Train or load model with Adversarial Training
-    defended_model_path = (
-        models_path / "adversarial_training" / f"epsilon_{args.epsilon}"
+    defended_model_filename = (
+        models_path / "adversarial_training" / f"epsilon_{args.epsilon}" / filename
     )
-    defended_model_filename = defended_model_path / filename
 
-    if defended_model_filename.exists():
-        log.info("Defended model loaded from %s", defended_model_filename)
-        defended_model = torch.load(defended_model_filename)
-    else:
-        log.info("Retraining Model with Adversarial Training")
+    def _init_defended():
+        return initialize_model(
+            args.model, args.model_capacity, data.num_features, data.num_classes, log
+        ).to(args.device)
+
+    def _train_defended(_model):
+        optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
         adv_training = AdversarialTrainingPGD(
             target_model,
             criterion,
@@ -141,14 +140,29 @@ def main(args: argparse.Namespace) -> None:
             args.epochs,
             args.epsilon,
         )
-        defended_model = adv_training.train_robust()
+        return adv_training.train_robust()
 
-        # Save model
-        create_dir(defended_model_path, log)
-        torch.save(defended_model, defended_model_filename)
+    defended_model = load_or_train(
+        defended_model_filename, _init_defended, _train_defended, log, "defended model"
+    )
 
     test_accuracy_defended = get_accuracy(defended_model, test_loader, args.device)
     log.info("Test accuracy of defended model: %s", test_accuracy_defended)
+
+    # Show the defense benefit: compare adversarial accuracy before and after
+    evasion = EvasionPGD(
+        target_model, test_loader, args.device, args.batch_size, args.epsilon
+    )
+    adv_loader = evasion.attack()
+    adv_accuracy_target = get_accuracy(target_model, adv_loader, args.device)
+    log.info("Adversarial accuracy (undefended): %s", adv_accuracy_target)
+
+    evasion_def = EvasionPGD(
+        defended_model, test_loader, args.device, args.batch_size, args.epsilon
+    )
+    adv_loader_def = evasion_def.attack()
+    adv_accuracy_defended = get_accuracy(defended_model, adv_loader_def, args.device)
+    log.info("Adversarial accuracy (defended): %s", adv_accuracy_defended)
 
 
 if __name__ == "__main__":

--- a/examples/defense_pipelines/run_dp_sgd.py
+++ b/examples/defense_pipelines/run_dp_sgd.py
@@ -1,6 +1,7 @@
 import sys
 
 sys.path.append("../../")
+
 import argparse
 import logging
 from pathlib import Path
@@ -14,6 +15,7 @@ from amulet.utils import (
     get_accuracy,
     initialize_model,
     load_data,
+    load_or_train,
     train_classifier,
 )
 
@@ -31,7 +33,7 @@ def parse_args() -> argparse.Namespace:
         "--dataset",
         type=str,
         default="celeba",
-        help="Options: cifar10, fmnist, lfw, census, celeba.",
+        help="Options: cifar10, cifar100, fmnist, mnist, lfw, census, celeba, utkface.",
     )
     parser.add_argument(
         "--model", type=str, default="vgg", help="Options: vgg, linearnet."
@@ -54,7 +56,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default=torch.device(f"cuda:{0}" if torch.cuda.is_available() else "cpu"),
+        default="cuda:0" if torch.cuda.is_available() else "cpu",
         help="Device on which to run PyTorch",
     )
     parser.add_argument(
@@ -110,44 +112,35 @@ def main(args: argparse.Namespace) -> None:
     # Set up filename and directories to save/load models
     models_path = root_dir / "saved_models"
     filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size * 100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
-    target_model_path = models_path / "target"
-    target_model_filename = target_model_path / filename
+    target_model_filename = models_path / "target" / filename
 
     # Train or Load Target Model
     criterion = torch.nn.CrossEntropyLoss()
 
-    if target_model_filename.exists():
-        log.info("Target model loaded from %s", target_model_filename)
-        target_model = torch.load(target_model_filename).to(args.device)
-        optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-    else:
-        log.info("Training target model")
-        target_model = initialize_model(
+    def _init_target():
+        return initialize_model(
             args.model, args.model_capacity, data.num_features, data.num_classes, log
         ).to(args.device)
-        optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-        target_model = train_classifier(
-            target_model, train_loader, criterion, optimizer, args.epochs, args.device
-        )
-        log.info("Target model trained")
 
-        # Save model
-        create_dir(target_model_path, log)
-        torch.save(target_model, target_model_filename)
+    def _train_target(model):
+        optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+        return train_classifier(
+            model, train_loader, criterion, optimizer, args.epochs, args.device
+        )
+
+    target_model = load_or_train(
+        target_model_filename, _init_target, _train_target, log, "target model"
+    )
 
     test_accuracy_target = get_accuracy(target_model, test_loader, args.device)
     log.info("Test accuracy of target model: %s", test_accuracy_target)
 
-    # Train or load model with DP Training
-    defended_model_path = models_path / "dp_sgd" / f"delta_{args.delta}"
-    defended_model_filename = defended_model_path / filename
+    # Train or load model with DP Training. Opacus cannot handle batch norm so
+    # the DP model is initialised without BN layers.
+    defended_model_filename = models_path / "dp_sgd" / f"delta_{args.delta}" / filename
 
-    if defended_model_filename.exists():
-        log.info("Defended model loaded from %s", defended_model_filename)
-        defended_model = torch.load(defended_model_filename)
-    else:
-        log.info("Retraining Model with dp Training")
-        defended_model = initialize_model(
+    def _init_defended():
+        return initialize_model(
             args.model,
             args.model_capacity,
             data.num_features,
@@ -155,9 +148,11 @@ def main(args: argparse.Namespace) -> None:
             log,
             batch_norm=False,
         ).to(args.device)
-        optimizer = torch.optim.Adam(defended_model.parameters(), lr=1e-3)
+
+    def _train_defended(model):
+        optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
         dp_training = DPSGD(
-            defended_model,
+            model,
             criterion,
             optimizer,
             train_loader,
@@ -168,14 +163,20 @@ def main(args: argparse.Namespace) -> None:
             args.secure_rng,
             args.epochs,
         )
-        defended_model = dp_training.train_private()
+        return dp_training.train_private()
 
-        # Save model
-        create_dir(defended_model_path, log)
-        torch.save(defended_model, defended_model_filename)
+    defended_model = load_or_train(
+        defended_model_filename, _init_defended, _train_defended, log, "defended model"
+    )
 
     test_accuracy_defended = get_accuracy(defended_model, test_loader, args.device)
     log.info("Test accuracy of defended model: %s", test_accuracy_defended)
+    log.info(
+        "Accuracy trade-off: baseline %.4f -> DP-SGD (delta=%s) %.4f",
+        test_accuracy_target,
+        args.delta,
+        test_accuracy_defended,
+    )
 
 
 if __name__ == "__main__":

--- a/examples/defense_pipelines/run_dp_sgd.py
+++ b/examples/defense_pipelines/run_dp_sgd.py
@@ -56,7 +56,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default="cuda:0" if torch.cuda.is_available() else "cpu",
+        default="cuda" if torch.cuda.is_available() else "cpu",
         help="Device on which to run PyTorch",
     )
     parser.add_argument(

--- a/examples/defense_pipelines/run_fingerprint.py
+++ b/examples/defense_pipelines/run_fingerprint.py
@@ -56,7 +56,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default="cuda:0" if torch.cuda.is_available() else "cpu",
+        default="cuda" if torch.cuda.is_available() else "cpu",
         help="Device on which to run PyTorch",
     )
     parser.add_argument(

--- a/examples/defense_pipelines/run_outlier_removal.py
+++ b/examples/defense_pipelines/run_outlier_removal.py
@@ -56,7 +56,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default="cuda:0" if torch.cuda.is_available() else "cpu",
+        default="cuda" if torch.cuda.is_available() else "cpu",
         help="Device on which to run PyTorch",
     )
     parser.add_argument(

--- a/examples/defense_pipelines/run_outlier_removal.py
+++ b/examples/defense_pipelines/run_outlier_removal.py
@@ -1,6 +1,7 @@
 import sys
 
 sys.path.append("../../")
+
 import argparse
 import logging
 from pathlib import Path
@@ -14,6 +15,7 @@ from amulet.utils import (
     get_accuracy,
     initialize_model,
     load_data,
+    load_or_train,
     train_classifier,
 )
 
@@ -31,7 +33,7 @@ def parse_args() -> argparse.Namespace:
         "--dataset",
         type=str,
         default="celeba",
-        help="Options: cifar10, fmnist, lfw, census, celeba.",
+        help="Options: cifar10, cifar100, fmnist, mnist, lfw, census, celeba, utkface.",
     )
     parser.add_argument(
         "--model", type=str, default="vgg", help="Options: vgg, linearnet."
@@ -54,7 +56,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default=torch.device(f"cuda:{0}" if torch.cuda.is_available() else "cpu"),
+        default="cuda:0" if torch.cuda.is_available() else "cpu",
         help="Device on which to run PyTorch",
     )
     parser.add_argument(
@@ -95,41 +97,39 @@ def main(args: argparse.Namespace) -> None:
     filename = f"{args.dataset}_{args.model}_{args.model_capacity}_{args.training_size * 100}_{args.batch_size}_{args.epochs}_{args.exp_id}.pt"
 
     # Train or Load Target Model
-    target_model_path = models_path / "target"
-    target_model_filename = target_model_path / filename
+    target_model_filename = models_path / "target" / filename
     criterion = torch.nn.CrossEntropyLoss()
 
-    if target_model_filename.exists():
-        log.info("Target model loaded from %s", target_model_filename)
-        target_model = torch.load(target_model_filename).to(args.device)
-        optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-    else:
-        log.info("Training target model")
-        target_model = initialize_model(
+    def _init_target():
+        return initialize_model(
             args.model, args.model_capacity, data.num_features, data.num_classes, log
         ).to(args.device)
-        optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
-        target_model = train_classifier(
-            target_model, train_loader, criterion, optimizer, args.epochs, args.device
-        )
-        log.info("Target model trained")
 
-        # Save model
-        create_dir(target_model_path, log)
-        torch.save(target_model, target_model_filename)
+    def _train_target(model):
+        optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+        return train_classifier(
+            model, train_loader, criterion, optimizer, args.epochs, args.device
+        )
+
+    target_model = load_or_train(
+        target_model_filename, _init_target, _train_target, log, "target model"
+    )
 
     test_accuracy_target = get_accuracy(target_model, test_loader, args.device)
     log.info("Test accuracy of target model: %s", test_accuracy_target)
 
     # Train or Load model with Outlier Removal
-    defended_model_path = models_path / "outlier_removal" / f"percent_{args.percent}"
-    defended_model_filename = defended_model_path / filename
+    defended_model_filename = (
+        models_path / "outlier_removal" / f"percent_{args.percent}" / filename
+    )
 
-    if defended_model_filename.exists():
-        log.info("Defended model loaded from %s", defended_model_filename)
-        defended_model = torch.load(defended_model_filename)
-    else:
-        log.info("Retraining Model after Outlier Removal")
+    def _init_defended():
+        return initialize_model(
+            args.model, args.model_capacity, data.num_features, data.num_classes, log
+        ).to(args.device)
+
+    def _train_defended(_model):
+        optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
         outlier_removal = OutlierRemoval(
             target_model,
             criterion,
@@ -141,11 +141,11 @@ def main(args: argparse.Namespace) -> None:
             batch_size=args.batch_size,
             percent=args.percent,
         )
-        defended_model = outlier_removal.train_robust()
+        return outlier_removal.train_robust()
 
-        # Save model
-        create_dir(defended_model_path, log)
-        torch.save(defended_model, defended_model_filename)
+    defended_model = load_or_train(
+        defended_model_filename, _init_defended, _train_defended, log, "defended model"
+    )
 
     test_accuracy_outlier_removed = get_accuracy(
         defended_model, test_loader, args.device

--- a/examples/defense_pipelines/run_watermark.py
+++ b/examples/defense_pipelines/run_watermark.py
@@ -71,7 +71,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--device",
         type=str,
-        default="cuda:0" if torch.cuda.is_available() else "cpu",
+        default="cuda" if torch.cuda.is_available() else "cpu",
         help="Device on which to run PyTorch",
     )
     parser.add_argument(

--- a/examples/extending_amulet/custom_metric.md
+++ b/examples/extending_amulet/custom_metric.md
@@ -8,7 +8,7 @@ Metrics in Amulet are implemented as standalone functions and grouped by risk.
 
 Create a new metrics directory under the corresponding risk:
 
-```
+```text
 amulet/test_time_adaptation/metrics/
 ```
 

--- a/examples/extending_amulet/custom_risk.md
+++ b/examples/extending_amulet/custom_risk.md
@@ -7,7 +7,7 @@ A risk encapsulates one or more attacks and defines how a model can be evaluated
 
 Create a new directory under `amulet/` for the risk:
 
-```
+```text
 amulet/test_time_adaptation/
 amulet/test_time_adaptation/attacks/
 ```
@@ -15,18 +15,19 @@ amulet/test_time_adaptation/attacks/
 ## Step 2: Implement the Attack
 
 Add a new attack file under the `attacks` subdirectory.
+All attacks should inherit from the `RiskAttack` base class (or a risk-specific base class if one exists).
 
 **File:** `amulet/test_time_adaptation/attacks/test_time_data_poisoning.py`
 
 ```python
 import torch
 import torch.nn as nn
+from .test_time_adaptation_attack import TestTimeAdaptationAttack
 
-class TestTimeDataPoisoning:
+class TestTimeDataPoisoning(TestTimeAdaptationAttack):
     def __init__(self, target_model: nn.Module, test_loader, device):
-        self.model = target_model
+        super().__init__(target_model, device)
         self.test_loader = test_loader
-        self.device = device
 
     def attack(self) -> torch.utils.data.TensorDataset:
         # Adapt model parameters using adversarial test-time inputs

--- a/examples/get_started.py
+++ b/examples/get_started.py
@@ -1,10 +1,14 @@
 """
 Simple end-to-end guide to evaluate your model with Amulet, with and without a defense.
+
+Trains a classifier on CIFAR-10, runs a PGD evasion attack, then defends with
+adversarial training and reruns the attack to show the accuracy trade-off.
+
+Run from the repo root:
+    uv run python examples/get_started.py
 """
 
-import sys
-
-sys.path.append("../")
+import logging
 from pathlib import Path
 
 import torch
@@ -19,62 +23,83 @@ from amulet.utils import (
     train_classifier,
 )
 
-# Set up constants
-root_dir = Path("../")
-random_seed = 123
-device = f"cuda:{0}" if torch.cuda.is_available() else "cpu"
-epochs = 10
 
-# Set random seeds for reproducibility
-torch.manual_seed(random_seed)
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    log = logging.getLogger(__name__)
 
-# Load dataset and create data loaders
-dataset = "celeba"  # Possible options: ['cifar10', 'fmnist', 'lfw', 'census', 'celeba']
+    root_dir = Path(__file__).parent.parent
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    random_seed = 123
+    epochs = 10
+    batch_size = 256
+    epsilon = 0.1
 
-data = load_data(root_dir, dataset)
-train_loader = DataLoader(dataset=data.train_set, batch_size=256, shuffle=False)
-test_loader = DataLoader(dataset=data.test_set, batch_size=256, shuffle=False)
+    torch.manual_seed(random_seed)
 
-# Train Target Model
-criterion = torch.nn.CrossEntropyLoss()
-target_model = initialize_model(
-    model_arch="vgg",
-    model_capacity="m1",
-    num_features=data.num_features,
-    num_classes=data.num_classes,
-).to(device)
-optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
+    # cifar10 and fmnist download automatically; no external data needed.
+    dataset = "cifar10"  # Options: cifar10, fmnist, lfw, census, celeba
+    data = load_data(root_dir, dataset)
+    train_loader = DataLoader(
+        dataset=data.train_set, batch_size=batch_size, shuffle=False
+    )
+    test_loader = DataLoader(
+        dataset=data.test_set, batch_size=batch_size, shuffle=False
+    )
 
-target_model = train_classifier(
-    target_model, train_loader, criterion, optimizer, epochs, device
-)
+    criterion = torch.nn.CrossEntropyLoss()
+    target_model = initialize_model(
+        model_arch="vgg",
+        model_capacity="m1",
+        num_features=data.num_features,
+        num_classes=data.num_classes,
+    ).to(device)
+    optimizer = torch.optim.Adam(target_model.parameters(), lr=1e-3)
+    target_model = train_classifier(
+        target_model, train_loader, criterion, optimizer, epochs, device
+    )
 
-# Test Model
-test_accuracy_target = get_accuracy(target_model, test_loader, device)
-print("Test accuracy of target model: %s", test_accuracy_target)
+    test_acc = get_accuracy(target_model, test_loader, device)
+    log.info("Clean test accuracy: %.4f", test_acc)
 
-# Run Evasion
-evasion = EvasionPGD(target_model, test_loader, device, batch_size=256, epsilon=32)
-adversarial_test_loader = evasion.attack()
-adv_accuracy = get_accuracy(target_model, adversarial_test_loader, device)
-print("Adversarial accuracy of target model: %s", adv_accuracy)
+    # Attack undefended model
+    evasion = EvasionPGD(
+        target_model, test_loader, device, batch_size=batch_size, epsilon=epsilon
+    )
+    adv_loader = evasion.attack()
+    adv_acc = get_accuracy(target_model, adv_loader, device)
+    log.info("Adversarial accuracy (undefended): %.4f", adv_acc)
 
-# Defend model with Adversarial Training
-adv_training = AdversarialTrainingPGD(
-    target_model,
-    criterion,
-    optimizer,
-    train_loader,
-    device,
-    epochs,
-    epsilon=32,
-)
-defended_model = adv_training.train_robust()
-test_accuracy_defended = get_accuracy(defended_model, test_loader, device)
-print("Test accuracy of defended model: %s", test_accuracy_defended)
+    # Defend with adversarial training, then rerun attack
+    adv_training = AdversarialTrainingPGD(
+        target_model,
+        criterion,
+        optimizer,
+        train_loader,
+        device,
+        epochs,
+        epsilon=epsilon,
+    )
+    defended_model = adv_training.train_robust()
 
-# Run Evasion against defended model
-evasion = EvasionPGD(defended_model, test_loader, device, batch_size=256, epsilon=32)
-adversarial_test_loader = evasion.attack()
-adv_accuracy = get_accuracy(defended_model, adversarial_test_loader, device)
-print("Adversarial accuracy of defended model: %s", adv_accuracy)
+    test_acc_defended = get_accuracy(defended_model, test_loader, device)
+    log.info("Clean test accuracy (defended): %.4f", test_acc_defended)
+
+    evasion_def = EvasionPGD(
+        defended_model, test_loader, device, batch_size=batch_size, epsilon=epsilon
+    )
+    adv_loader_def = evasion_def.attack()
+    adv_acc_defended = get_accuracy(defended_model, adv_loader_def, device)
+    log.info("Adversarial accuracy (defended): %.4f", adv_acc_defended)
+
+    log.info(
+        "Summary: clean %.4f -> %.4f | adversarial %.4f -> %.4f",
+        test_acc,
+        test_acc_defended,
+        adv_acc,
+        adv_acc_defended,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/get_started.py
+++ b/examples/get_started.py
@@ -29,7 +29,7 @@ def main() -> None:
     log = logging.getLogger(__name__)
 
     root_dir = Path(__file__).parent.parent
-    device = "cuda:0" if torch.cuda.is_available() else "cpu"
+    device = "cuda" if torch.cuda.is_available() else "cpu"
     random_seed = 123
     epochs = 10
     batch_size = 256


### PR DESCRIPTION
## Context

Final PR in the `refactor/risk-modules` stack. Stacked on #81 (examples). Purely documentation — no source code changes.

## Changes

**`docs/module_guide/` (all nine guides updated)**
- Reflect new attack/defense APIs throughout: `poison_train`/`poison_test` split, `prepare_model_populations` lifecycle for distribution inference, `load_or_train` pattern in examples.
- `AmuletDataset` schema (`modality`, `sensitive_columns`) documented.
- Code snippets updated to match current class signatures.

**`docs/CONTRIBUTING.md`**
- Updated contribution guide to cover new ABC base class pattern and lifecycle conventions.

**`docs/GETTING_STARTED.md`**
- Refreshed quickstart to match the new `get_started.py` script.

**`.markdownlintignore` (deleted)**
- Was added in PR 1 as a scoping workaround to defer doc fixes. All docs now pass `markdownlint` cleanly, so the ignore file is removed.

## Test plan

- [ ] `uv run pre-commit run --all-files` (markdownlint passes without the ignore file)
- [ ] CI passes on this branch
- [ ] Spot-check that code snippets in module guides match the current source