### PR TITLE
fix(models): replace AvgPool2d with AdaptiveAvgPool2d in VGG

### DIFF
--- a/amulet/models/vgg.py
+++ b/amulet/models/vgg.py
@@ -68,7 +68,7 @@ class VGG(AmuletModel):
                     ]
 
                 in_channels = x
-        layers += [nn.AvgPool2d(kernel_size=1, stride=1)]
+        layers += [nn.AdaptiveAvgPool2d((1, 1))]
         layers += [nn.Flatten()]
 
         return nn.Sequential(*layers)


### PR DESCRIPTION
AdaptiveAvgPool2d handles arbitrary input spatial sizes, whereas the previous AvgPool2d(kernel_size=1, stride=1) only worked correctly when the feature map was already 1×1.