### PR TITLE
ci: add semantic-release + uv publish pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,62 @@
+# Release pipeline: on every push to main, python-semantic-release reads
+# conventional commits since the last tag, computes the next version, updates
+# pyproject.toml, commits with [skip ci], tags, and cuts a GitHub Release.
+# If a release was cut, the publish job builds the distribution and uploads
+# it to PyPI via Trusted Publishing (OIDC, no stored secrets).
+
+name: release
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  release:
+    name: Semantic release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      released: ${{ steps.psr.outputs.released }}
+      tag: ${{ steps.psr.outputs.tag }}
+      version: ${{ steps.psr.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }}
+
+      - name: Run python-semantic-release
+        id: psr
+        uses: python-semantic-release/python-semantic-release@v10
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish to PyPI
+    needs: release
+    if: ${{ needs.release.outputs.released == 'true' }}
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/amuletml/${{ needs.release.outputs.version }}/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Build distribution
+        run: uv build
+
+      - name: Publish to PyPI (Trusted Publishing)
+        run: uv publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ tag_format = "v{version}"
 commit_message = "chore(release): {version} [skip ci]"
 
 [tool.semantic_release.branches.main]
-match = "(main)"
+match = "^main$"
 prerelease = false
 
 [tool.semantic_release.changelog]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,3 +78,22 @@ markers = [
     "gpu: tests that require a CUDA-capable GPU",
 ]
 addopts = "--strict-markers"
+
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+major_on_zero = false
+allow_zero_version = true
+build_command = "uv build"
+commit_parser = "conventional"
+tag_format = "v{version}"
+commit_message = "chore(release): {version} [skip ci]"
+
+[tool.semantic_release.branches.main]
+match = "(main)"
+prerelease = false
+
+[tool.semantic_release.changelog]
+mode = "update"
+
+[tool.semantic_release.changelog.default_templates]
+mask_initial_release = false


### PR DESCRIPTION
## Summary

Sets up fully automated PyPI releases driven by [Conventional Commits](https://www.conventionalcommits.org). Replaces our manual `poetry publish` + hand-edited `version = "..."` workflow with [python-semantic-release](https://python-semantic-release.readthedocs.io/) (PSR) v10 and [`uv publish`](https://docs.astral.sh/uv/guides/package/).

After merge, every PR that lands on `main` is classified by its commit prefix:

| Commit prefix | Bump | Result on merge |
|---|---|---|
| `fix:` / `fix(scope):` | patch | e.g. `0.5.0 → 0.5.1`, published to PyPI |
| `feat:` / `feat(scope):` | minor | e.g. `0.5.0 → 0.6.0`, published to PyPI |
| `feat!:` or `BREAKING CHANGE:` footer | minor (see "0.x lifecycle" below) | e.g. `0.5.0 → 0.6.0`, published to PyPI |
| `refactor:` / `chore:` / `docs:` / `test:` / `ci:` / `build:` | none | no release, no publish |

The `version = "..."` line in `pyproject.toml` becomes machine-managed — PSR rewrites it on each release and commits the change back with a `[skip ci]` marker. Don't edit it by hand after this lands.

## Non-obvious decisions (i.e. things the diff alone won't tell you)

- **`major_on_zero = false`** — see "0.x lifecycle" below.
- **`allow_zero_version = true`** — PSR v10 flipped this default to `false`, which would force us off `0.x` automatically on the first run. Setting it back preserves the lifecycle.
- **Two jobs, not one** — least privilege. The `release` job needs `contents: write` (to push the bookkeeping commit + tag); the `publish` job needs `id-token: write` (OIDC). Splitting them keeps each scope minimal.
- **`ubuntu-latest`, not `self-hosted`** — the release path needs neither GPU nor internal resources, and keeping it off our self-hosted runner means releases work even when that box is offline or busy.
- **PyPI auth via [Trusted Publishing](https://docs.pypi.org/trusted-publishers/)** — no API token stored in repo secrets. PyPI verifies the request originated from this exact workflow file via an OIDC token exchanged at job runtime. The Trusted Publisher on PyPI's side has already been registered (bound to `release.yaml` + the `pypi` GitHub environment).

## 0.x lifecycle (`major_on_zero = false`)

[SemVer](https://semver.org) treats the leading `0` in `0.x.y` as "no stability promise yet" — anything can change. We're at `0.5.0` and not ready to promise API stability, so we want to stay in `0.x` for a while longer.

By default PSR would interpret a breaking change (`feat!:` or `BREAKING CHANGE:`) as a jump to `1.0.0`. `major_on_zero = false` overrides that: while we're in `0.x`, breaking changes bump the minor digit (e.g. `0.5.0 → 0.6.0`). Only an explicit decision will move us to `1.0.0`.

## Baseline tag (already pushed; no reviewer action needed)

PSR computes "what's next" as `last_git_tag + bumps_since_last_tag`. The repo had **zero tags** before this work, even though PyPI is at `amuletml 0.5.0` — historically we only ever edited the version string by hand. Without a baseline tag, the first workflow run would see the entire repo history as "unreleased" and behave unpredictably.

I created and pushed an annotated tag **`v0.5.0` pointing at the current `main` HEAD (`75956fe`)** — i.e., "wherever main is right now, call that the 0.5.0 baseline." Consequence: the `fix(models): replace AvgPool2d…` commit is lumped into the baseline and will not get its own release; the next `feat:`/`fix:` PR after this one is what cuts the first automated release.

## Expected behavior immediately after merging this PR

The merge commit triggers `release.yaml` for the first time. The only commit since `v0.5.0` is this PR's `ci:` commit, which is intentionally not release-worthy. PSR will therefore exit with `released = false`, the `publish` job will be skipped, and no PyPI upload will happen. **A green workflow run that did nothing is the expected outcome** — that's how we confirm the plumbing is wired correctly before any real release goes out.

## Follow-up (separate PRs, not blocking this one)

- 16 open dependabot alerts (4 high, 10 moderate, 2 low). Each fix lands as `fix(deps): …`, which auto-cuts a patch release under the new pipeline. The first one will be the real end-to-end test of the publish path.
- A `CITATION.cff` + Zenodo–GitHub integration would mint a citable DOI per tagged release. Worth discussing separately.