### PR TITLE
ci(release): drop PSR build_command (publish job handles uv build)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,6 @@ addopts = "--strict-markers"
 version_toml = ["pyproject.toml:project.version"]
 major_on_zero = false
 allow_zero_version = true
-build_command = "uv build"
 commit_parser = "conventional"
 tag_format = "v{version}"
 commit_message = "chore(release): {version} [skip ci]"


### PR DESCRIPTION
## Context

The release workflow failed on the run triggered by #89 with:

\`\`\`
🛠 Running build command: uv build
bash: line 1: uv: command not found
Build failed, aborting release
\`\`\`

Full failed run: [actions/runs/26471776833](https://github.com/ssg-research/amulet/actions/runs/26471776833).

PSR did successfully classify the \`fix(deps):\` commit and decide on \`0.5.1\` — the failure was strictly the build step. PSR aborted before committing/tagging/pushing, so the state is recoverable: no \`v0.5.1\` tag was created, no GitHub Release, no PyPI upload. The \`fix(deps):\` commit is still on \`main\` untagged.

## Root cause

The \`python-semantic-release/python-semantic-release@v10\` GitHub Action runs PSR inside its own Docker container. That container has Python but **does not have \`uv\` installed**, so \`build_command = "uv build"\` (configured in \`pyproject.toml\` in #88) blew up. The \`astral-sh/setup-uv@v5\` step lives in the separate \`publish\` job and installs \`uv\` on the runner host — irrelevant inside PSR's container.

## Fix

Remove \`build_command = "uv build"\` from \`[tool.semantic_release]\`. The \`publish\` job already does \`uv build && uv publish\` after PSR completes, so having PSR also build was redundant. One line deleted; nothing else changes.

Trying to make \`uv\` available inside PSR's container is the alternative, but it requires either switching off the Docker action (running PSR via CLI) or building a custom container. Neither is worth it when the publish job already covers the build cleanly.

## Expected behavior after merge

PSR considers all commits since the last tag (\`v0.5.0\`). At merge time those will be:

| Commit | Type | Effect |
|---|---|---|
| \`ci: add semantic-release + uv publish pipeline\` (#88) | ci | no release |
| \`fix(deps): bump vulnerable dependencies\` (#89) | fix | **patch** |
| \`ci(release): drop PSR build_command\` (this PR) | ci | no release |

→ PSR cuts **0.5.1**, tags \`v0.5.1\`, opens a GitHub Release, the \`publish\` job builds with \`uv build\` and uploads \`amuletml 0.5.1\` to PyPI via Trusted Publishing.