### PR TITLE
ci(release): migrate from python-semantic-release to release-please

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,18 @@
-# Release pipeline: on every push to main, python-semantic-release reads
-# conventional commits since the last tag, computes the next version, updates
-# pyproject.toml, commits with [skip ci], tags, and cuts a GitHub Release.
-# If a release was cut, the publish job builds the distribution and uploads
-# it to PyPI via Trusted Publishing (OIDC, no stored secrets).
+# Release pipeline using release-please.
+#
+# On every push to main, release-please reads conventional commits since the
+# last GitHub Release, opens (or updates) a long-lived "release PR" that
+# bumps the version in pyproject.toml and updates CHANGELOG.md. When that
+# PR is merged, release-please creates the tag + GitHub Release; the chained
+# publish job then builds and uploads the distribution to PyPI via Trusted
+# Publishing (OIDC, no stored secrets).
+#
+# Why release-please rather than python-semantic-release:
+# - Works with the default GITHUB_TOKEN; no PAT or org-admin approval needed.
+# - Branch protection on main stays strict; the release PR goes through the
+#   normal review flow rather than a direct bot push.
+# - The "release PR" gates each release behind a human approval click,
+#   giving us a chance to hold back or batch.
 
 name: release
 
@@ -17,41 +27,39 @@ concurrency:
 permissions: {}
 
 jobs:
-  release:
-    name: Semantic release
+  release-please:
+    name: Open/merge release PR
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
+      issues: write
     outputs:
-      released: ${{ steps.psr.outputs.released }}
-      tag: ${{ steps.psr.outputs.tag }}
-      version: ${{ steps.psr.outputs.version }}
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      version: ${{ steps.release.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Run release-please
+        id: release
+        uses: googleapis/release-please-action@v4
         with:
-          fetch-depth: 0
-          ref: ${{ github.ref_name }}
-
-      - name: Run python-semantic-release
-        id: psr
-        uses: python-semantic-release/python-semantic-release@v10
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: python
+          package-name: amuletml
 
   publish:
     name: Publish to PyPI
-    needs: release
-    if: ${{ needs.release.outputs.released == 'true' }}
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/project/amuletml/${{ needs.release.outputs.version }}/
+      url: https://pypi.org/project/amuletml/${{ needs.release-please.outputs.version }}/
     permissions:
       id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.release.outputs.tag }}
+          ref: ${{ needs.release-please.outputs.tag_name }}
 
       - uses: astral-sh/setup-uv@v5
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,21 +78,3 @@ markers = [
     "gpu: tests that require a CUDA-capable GPU",
 ]
 addopts = "--strict-markers"
-
-[tool.semantic_release]
-version_toml = ["pyproject.toml:project.version"]
-major_on_zero = false
-allow_zero_version = true
-commit_parser = "conventional"
-tag_format = "v{version}"
-commit_message = "chore(release): {version} [skip ci]"
-
-[tool.semantic_release.branches.main]
-match = "^main$"
-prerelease = false
-
-[tool.semantic_release.changelog]
-mode = "update"
-
-[tool.semantic_release.changelog.default_templates]
-mask_initial_release = false


### PR DESCRIPTION
## Why this change

The python-semantic-release (PSR) pipeline introduced in #88 has not been able to publish to PyPI because PSR's git operations push a bookkeeping commit + tag directly to \`main\`, which our branch protection (require-PR-with-1-approval) rejects (\`GH006: Protected branch update failed\`).

We evaluated the alternatives:

| Path | Blocker |
|---|---|
| PSR + fine-grained PAT from a repo admin | Fine-grained PATs for org-owned \`ssg-research\` repos require org admin approval that isn't readily available. |
| PSR + GitHub App with bypass | Same org-admin dependency, plus more moving parts (app keypair, installation, secret). |
| PSR \`--no-commit\` + hatch-vcs | Possible but combines two systems of complexity for less benefit than the option below. |
| **release-please** | **No org-admin involvement. Default \`GITHUB_TOKEN\` works.** |

## What changes

**\`.github/workflows/release.yaml\`** — full rewrite:
- Drops PSR. Adds [\`googleapis/release-please-action@v4\`](https://github.com/googleapis/release-please-action) configured with \`release-type: python\` and \`package-name: amuletml\`.
- On every push to \`main\`, release-please opens (or updates) a long-lived "release PR" that bumps \`pyproject.toml\`'s version and updates \`CHANGELOG.md\` based on Conventional Commits.
- When that release PR is merged, release-please creates the tag + GitHub Release, then the chained \`publish\` job builds with \`uv build\` and uploads to PyPI via Trusted Publishing (OIDC).
- Workflow filename and environment name are unchanged (\`release.yaml\` + \`pypi\`), so the existing PyPI Trusted Publisher binding does not need to be re-registered.

**\`pyproject.toml\`** — removes the entire \`[tool.semantic_release]\` block (18 lines).

## How this works under our branch protection

- The release PR is on a branch (\`release-please--branches--main\` or similar) which is not protected. release-please writes to that branch freely using \`GITHUB_TOKEN\`.
- Merging the release PR goes through the same review path as any human PR (1 approving review required).
- No actor ever pushes directly to \`main\`.

## One-time bootstrap (done before this PR was opened)

A GitHub Release object was created for the existing \`v0.5.0\` tag (release-please looks at GitHub Releases, not raw tags, to determine the last released version): https://github.com/ssg-research/amulet/releases/tag/v0.5.0

## Expected behavior after merge

1. Push of this PR's merge commit triggers \`release.yaml\`.
2. release-please sees \`fix(deps): bump vulnerable dependencies\` (from #89) since v0.5.0 and opens a release PR proposing **0.5.1**, with a generated \`CHANGELOG.md\` entry.
3. Reviewer (you) merges the release PR.
4. release-please creates the \`v0.5.1\` tag + GitHub Release.
5. The chained \`publish\` job runs \`uv build\` + \`uv publish\` → \`amuletml 0.5.1\` on PyPI.

## What I'll be watching for on the first run

I want to confirm that \`release-type: python\` actually updates \`pyproject.toml\`'s \`[project] version\` field. The release-please docs phrase pyproject.toml as "optionally" handled by the Python strategy, which is ambiguous. If the first release PR's diff does not include the version bump, the fix is adding \`extra-files\` with a TOML jsonpath pointing at \`\$.project.version\` — straightforward, but worth verifying empirically rather than assuming.