### PR TITLE
feat(poisoning): textual backdoor attack with ONION and DP defenses

### DIFF
--- a/.github/workflows/monthly-slow.yaml
+++ b/.github/workflows/monthly-slow.yaml
@@ -30,7 +30,10 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        # CPU runner, so install the `cpu` torch build (the cpu/cu128/cu130 extras are
+        # mutually exclusive, so `--all-extras` is invalid). No `llm` extra: the slow
+        # tier has no text tests, and the text test modules import without the HF stack.
+        run: uv sync --extra cpu --extra dev
 
       - name: Run pytest (slow tier)
         run: uv run pytest tests/ -m slow -v

--- a/.github/workflows/precommit-main.yaml
+++ b/.github/workflows/precommit-main.yaml
@@ -14,6 +14,17 @@ jobs:
   code-quality:
     runs-on: ubuntu-latest
 
+    # Runners are CPU-only, so install the `cpu` torch build (the cpu/cu128/cu130
+    # extras are mutually exclusive, so `--all-extras` is invalid). `llm` is needed at
+    # install time so basedpyright can resolve the guarded transformers/peft/datasets
+    # imports, but the offline env vars below stop the pytest steps from downloading any
+    # Hugging Face models: the text/LLM tests skip on the cacheless runner (by design;
+    # they run locally and on the GPU tier).
+    env:
+      HF_HUB_OFFLINE: "1"
+      TRANSFORMERS_OFFLINE: "1"
+      HF_DATASETS_OFFLINE: "1"
+
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -28,7 +39,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --all-extras
+          uv sync --extra cpu --extra dev --extra llm
           echo PATH="$PWD/.venv/bin:$PATH" >> $GITHUB_ENV
 
       - name: Pre-commit on all files

--- a/.github/workflows/precommit-main.yaml
+++ b/.github/workflows/precommit-main.yaml
@@ -45,14 +45,11 @@ jobs:
       - name: Pre-commit on all files
         run: uv run pre-commit run --all-files --show-diff-on-failure --color=always
 
+      # Codecov is temporarily disabled (see codecov.yml). To re-enable: add back
+      # `--cov=amulet --cov-report=xml` to the fast-tier run below and restore the
+      # Codecov upload step, then flip the switches in codecov.yml.
       - name: Run pytest (fast tier)
-        run: uv run pytest tests/ -m "not integration and not gpu and not slow" -v --cov=amulet --cov-report=xml
+        run: uv run pytest tests/ -m "not integration and not gpu and not slow" -v
 
       - name: Run pytest (integration tier)
         run: uv run pytest tests/ -m integration -v
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Amulet (`amuletml` on PyPI) is a PyTorch-based research library for evaluating *
 It builds on "SoK: Unintended Interactions among Machine Learning Defenses and Risks" (IEEE S&P 2024).
 The central use case is composing an attack from one risk with a defense designed for another risk and measuring how they interfere.
 
-Requires Python ~=3.11.0 and (for GPU) CUDA 11.8+ with PyTorch 2.2+.
+Requires Python ~=3.11.0. Torch is selected via a hardware-specific extra (`cpu`, `cu128`, or `cu130`); see [Optional extras](#optional-extras).
 
 ## Where to find things
 
@@ -28,11 +28,16 @@ Requires Python ~=3.11.0 and (for GPU) CUDA 11.8+ with PyTorch 2.2+.
 Dependency management is via `uv` (never `pip`/`conda`):
 
 ```bash
-uv sync                     # install runtime deps, create .venv
-uv sync --all-extras        # include dev deps (ruff, basedpyright, pytest, pre-commit)
-uv add <pkg>                # add runtime dep
-uv add --dev <pkg>          # add dev dep
-uv lock                     # regenerate uv.lock after editing pyproject.toml
+# Pick ONE torch build extra matching your hardware (check with `nvidia-smi`).
+# Do NOT use `uv sync --all-extras`: the cpu/cu128/cu130 extras are declared
+# conflicting, so requesting all of them errors.
+uv sync --extra cu128 --extra dev   # CUDA 12.x box + dev tools
+uv sync --extra cu130 --extra dev   # CUDA 13 box + dev tools
+uv sync --extra cpu --extra dev     # GPU-less / CI: skip the CUDA runtime download
+uv sync --extra cu128 --extra llm   # add the LLM stack (transformers/peft/datasets)
+uv add <pkg>                        # add runtime dep
+uv add --dev <pkg>                  # add dev dep
+uv lock                             # regenerate uv.lock after editing pyproject.toml
 ```
 
 Lint / typecheck / format (run via pre-commit so configuration stays in sync with CI):
@@ -68,10 +73,13 @@ The standard entry-point methods are:
 | All attacks (except poisoning) | `attack()`                                         |
 | Poisoning attacks              | `poison_train(dataset)` and `poison_test(dataset)` |
 | Evasion + poisoning defenses   | `train_robust()`                                   |
+| Inference-time defense (ONION) | `purify(dataset)`                                  |
 | Membership inference defense   | `train_private()`                                  |
 | Fairness defense               | `train_fair()`                                     |
 | Watermarking defense           | `watermark()`                                      |
 | Fingerprinting defense         | `fingerprint()`                                    |
+
+`ONION` purifies inputs at inference instead of retraining, so it subclasses a separate `InferenceTimeDefense` base (in `amulet/poisoning/defenses/`) rather than `PoisoningDefense`, and returns a purified dataset. The textual backdoor attack `TextBadNets` and the LoRA-LLM victim `HFTextClassifier` need the optional `llm` extra; see [Optional extras](#optional-extras).
 
 Some classes expose additional public helpers for experimentation — for example, `MembershipInferenceAttack` has `train_shadow_model()` / `prepare_shadow_models()` and `DistributionInferenceAttack` has `train_model_population()` / `prepare_model_populations()`.
 Check the base class before assuming `attack()` is the only callable.
@@ -80,17 +88,30 @@ Check the base class before assuming `attack()` is the only callable.
 
 Any model under `amulet/models/` must subclass `AmuletModel` ([`amulet/models/base.py`](amulet/models/base.py)) and implement `get_hidden(self, x) -> Tensor`.
 Several modules depend on intermediate activations; omitting `get_hidden` breaks them silently.
+Match the base signature's parameter name `x` on both `forward` and `get_hidden` (basedpyright enforces override compatibility), even when the input is token ids rather than pixels.
+
+`HFTextClassifier` ([`amulet/models/hf_text_classifier.py`](amulet/models/hf_text_classifier.py)) is the reference example of subclassing `AmuletModel` around a real pretrained backbone (a LoRA-tuned decoder LLM). Its `forward` returns the bare logits tensor, not the `SequenceClassifierOutput`, so the single-tensor training loops (`train_classifier`, `DPSGD.train_private`) and `get_accuracy` drive it unchanged. It needs the `llm` extra.
+
+`initialize_model` uses a central capacity map and only covers the built-in CNNs; models whose constructors do not fit its `(arch, capacity, num_features, num_classes)` signature (e.g. `HFTextClassifier`) are constructed directly. See #104.
 
 `WatermarkNN` and `DatasetInference` have separate ABC base classes (`WatermarkDefense`, `FingerprintDefense`).
 There is no shared parent — this is intentional.
 
 ### Datasets
 
-Loaders follow a 3-step fallback to ensure availability:
+Image loaders follow a 3-step fallback to ensure availability:
 
 1. **Processed local** (e.g. `celeba.npz`, `lfw_images.npz`)
 2. **Raw local** (e.g. `img_align_celeba/`, `lfw_home/`)
 3. **GDrive download** — IDs are hard-coded in [`amulet/datasets/__image_datasets.py`](amulet/datasets/__image_datasets.py) (similar to how PyTorch ships dataset URLs), so no configuration is needed.
+
+Text loaders ([`amulet/datasets/__text_datasets.py`](amulet/datasets/__text_datasets.py): `load_sst2`, `load_agnews`, `load_imdb`) instead pull from the Hugging Face hub via `datasets` into a project-local `./data/<name>` cache. That divergence is intentional: HF manages text corpora and their splits. They return an `AmuletDataset` with `modality="text"` whose `train_set`/`test_set` are `TextTensorDataset` instances — a `TensorDataset` of padded `input_ids` that also carries the raw `.texts` (so ONION can re-score perplexity before the victim tokenizer runs) and the `tokenizer_name`. `AmuletDataset.modality` is `Literal["image", "tabular", "text"]`. Text loaders need the `llm` extra.
+
+### Optional extras
+
+- **Torch build (`cpu` / `cu128` / `cu130`):** mutually exclusive (declared in `[tool.uv] conflicts`), each pinning the same `torch`/`torchvision` but routed to the matching PyTorch index via `[tool.uv.sources]`. Always sync with exactly one. The base `torch`/`torchvision` floor stays loose so `pip install amuletml` works off PyPI; the extras exist so a `uv sync` produces a driver-correct GPU build instead of a cu13 wheel that silently runs on CPU.
+- **`llm`:** the Hugging Face stack (`transformers`, `peft`, `accelerate`, `datasets`) for the textual backdoor pipeline (`TextBadNets`, `HFTextClassifier`, `ONION`, the text loaders). Kept optional so the base install stays lean and the macOS dev machine / fast CI tier never pull it. Every HF import is lazy and guarded, so `import amulet` works without the extra and constructing an LLM component without it raises a clear "install amuletml[llm]" error.
+- **`bitsandbytes`** (4-bit load path in `HFTextClassifier`) is GPU/Linux-only and deliberately **not** in the `llm` extra. Its import is guarded, off by default, and never used under DP (Opacus per-sample hooks do not compose with 4-bit layers).
 
 ### Tooling
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Built to work with PyTorch
 
 ## Getting Started
 
-**Note:** The package requires the CUDA version to be 11.8 or above for PyTorch 2.2
-
 The easiest way to start is via `pip`:
 
 `pip install amuletml`
+
+For a reproducible GPU build (and for development), install from source with `uv` and select the torch build matching your driver: `uv sync --extra cu128` (CUDA 12.x), `uv sync --extra cu130` (CUDA 13), or `uv sync --extra cpu`. Add `--extra llm` for the optional text/LLM stack (used by the textual backdoor pipeline).
 
 ### Test installation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![CI Status](https://github.com/ssg-research/amulet/actions/workflows/precommit-main.yaml/badge.svg)](https://github.com/ssg-research/amulet/actions/workflows/precommit-main.yaml)
 [![CodeQL](https://github.com/ssg-research/amulet/actions/workflows/codeql.yaml/badge.svg)](https://github.com/ssg-research/amulet/actions/workflows/codeql.yaml)
-[![codecov](https://codecov.io/gh/ssg-research/amulet/graph/badge.svg)](https://codecov.io/gh/ssg-research/amulet)
 [![PyPI version](https://img.shields.io/pypi/v/amuletml.svg)](https://pypi.org/project/amuletml/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/amuletml.svg)](https://pypi.org/project/amuletml/)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/amulet/datasets/__data.py
+++ b/amulet/datasets/__data.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import torch
 import torchvision.transforms as transforms
-from torch.utils.data import Dataset
+from torch.utils.data import Dataset, TensorDataset
 from torchvision.io import ImageReadMode, read_image
 
 
@@ -23,8 +23,10 @@ class AmuletDataset:
         num_features: Number of input features.
         num_classes: Number of output classes.
         modality: Describes the tensor shape seen by models. "image" for multi-dimensional
-            (C, H, W) samples; "tabular" for 1-D feature vectors. LFW is "tabular" because
-            its images are flattened in the loader.
+            (C, H, W) samples; "tabular" for 1-D feature vectors; "text" for token-id
+            vectors, where each sample is a padded ``input_ids`` tensor and the raw
+            strings are retained on the ``TextTensorDataset`` (see that class). LFW is
+            "tabular" because its images are flattened in the loader.
         sensitive_columns: Column names of z_train/z_test, in order. None if the
             dataset has no sensitive attributes.
         x_train: Train features as a numpy array, or None.
@@ -39,7 +41,7 @@ class AmuletDataset:
     test_set: Dataset
     num_features: int
     num_classes: int
-    modality: Literal["image", "tabular"]
+    modality: Literal["image", "tabular", "text"]
     sensitive_columns: list[str] | None = None
     x_train: np.ndarray | None = None
     x_test: np.ndarray | None = None
@@ -47,6 +49,45 @@ class AmuletDataset:
     y_test: np.ndarray | None = None
     z_train: np.ndarray | None = None
     z_test: np.ndarray | None = None
+
+
+class TextTensorDataset(TensorDataset):
+    """TensorDataset of ``(input_ids, label)`` that also carries the raw strings.
+
+    This is the single artifact that flows attack -> victim -> defense for the text
+    modality. Because it subclasses :class:`torch.utils.data.TensorDataset` over
+    ``(input_ids, labels)``, it *is* a ``TensorDataset``: the
+    ``PoisoningAttack.poison_* -> TensorDataset`` return type, every
+    ``for (data, target) in loader`` consumer, and the single-tensor ``DPSGD``
+    training loop all work unchanged and never see the extra state. Only the two
+    extra attributes below carry the string view an input-purification defense
+    (ONION) needs.
+
+    A ``DataLoader`` collates only the tensors; a consumer that needs the strings
+    reads ``loader.dataset.texts`` (dataset order), which is why a defense must
+    purify the dataset before the (optionally shuffled) victim loader is built.
+
+    Attributes:
+        texts: The raw (possibly poisoned) strings in dataset order, one per row.
+        tokenizer_name: Name of the tokenizer that produced ``input_ids``, so a
+            defense can re-tokenize after purifying ``texts``.
+    """
+
+    def __init__(
+        self,
+        input_ids: torch.Tensor,
+        labels: torch.Tensor,
+        texts: list[str],
+        tokenizer_name: str,
+    ):
+        if len(texts) != input_ids.shape[0]:
+            raise ValueError(
+                f"texts ({len(texts)}) and input_ids ({input_ids.shape[0]}) must have "
+                "the same number of rows."
+            )
+        super().__init__(input_ids, labels)
+        self.texts = texts
+        self.tokenizer_name = tokenizer_name
 
 
 class CustomImageDataset(Dataset):

--- a/amulet/datasets/__init__.py
+++ b/amulet/datasets/__init__.py
@@ -3,7 +3,7 @@ The module mlconf.datasets includes utilities to load datasets,
 including methods to load and fetch popular reference datasets.
 """
 
-from .__data import AmuletDataset, CustomImageDataset
+from .__data import AmuletDataset, CustomImageDataset, TextTensorDataset
 from .__image_datasets import (
     load_celeba,
     load_cifar10,
@@ -13,16 +13,21 @@ from .__image_datasets import (
     load_utkface,
 )
 from .__tabular_datasets import load_census, load_lfw
+from .__text_datasets import load_agnews, load_imdb, load_sst2
 
 __all__ = [
     "AmuletDataset",
     "CustomImageDataset",
+    "TextTensorDataset",
+    "load_agnews",
     "load_celeba",
     "load_census",
     "load_cifar10",
     "load_cifar100",
     "load_fmnist",
+    "load_imdb",
     "load_lfw",
     "load_mnist",
+    "load_sst2",
     "load_utkface",
 ]

--- a/amulet/datasets/__text_datasets.py
+++ b/amulet/datasets/__text_datasets.py
@@ -1,0 +1,258 @@
+"""Text-modality dataset loaders (SST-2, AG News, IMDB).
+
+These are the first text datasets in Amulet. They diverge from the GDrive 3-step
+fallback used by the image loaders in ``__image_datasets.py``: text corpora and their
+canonical splits are managed by Hugging Face ``datasets``, so these load from the HF
+hub (with a local cache). That divergence is intentional.
+
+The Hugging Face stack ships in the optional ``amuletml[llm]`` extra, so its imports
+are guarded: ``import amulet`` still works without the extra, and calling a loader
+without it raises a clear "install amuletml[llm]" error.
+
+Each loader tokenizes the raw strings with the victim tokenizer, pads ``input_ids`` to
+a fixed per-dataset max sequence length, and retains the raw strings on the returned
+``TextTensorDataset`` so an input-purification defense (ONION) can re-score and
+re-tokenize them. SST-2 uses ``validation`` as its labelled test split (the public
+``test`` split has masked ``-1`` labels).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import torch
+
+from .__data import AmuletDataset, TextTensorDataset
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizerBase
+
+# The Hugging Face stack is the optional `llm` extra. Imports are lazy (inside the
+# functions that use them) so `import amulet` works without the extra; this shared
+# message is raised when a loader is actually called without the extra installed.
+_LLM_INSTALL_HINT = (
+    "Text datasets require the optional LLM stack. Install it with "
+    "`pip install amuletml[llm]` (or `uv sync --extra llm`)."
+)
+
+# The plan's license-free fallback victim; its tokenizer produces the input_ids.
+_DEFAULT_TOKENIZER = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+
+
+def _load_tokenizer(tokenizer_name: str) -> PreTrainedTokenizerBase:
+    """Load a Hugging Face tokenizer and ensure it has a pad token.
+
+    Decoder tokenizers (Llama family) often ship without a pad token; padding to a
+    fixed length needs one, so fall back to the eos token as Hugging Face recommends.
+
+    Args:
+        tokenizer_name: Hub id of the tokenizer to load.
+
+    Returns:
+        The loaded tokenizer with ``pad_token`` set.
+
+    Raises:
+        ImportError: If the optional ``llm`` extra is not installed.
+    """
+    try:
+        from transformers import AutoTokenizer
+    except ImportError as exc:
+        raise ImportError(_LLM_INSTALL_HINT) from exc
+
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)  # pyright: ignore[reportUnknownMemberType]
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    return tokenizer
+
+
+def _tokenize(
+    texts: list[str],
+    tokenizer: PreTrainedTokenizerBase,
+    max_length: int,
+) -> torch.Tensor:
+    """Tokenize strings to a padded ``(N, max_length)`` LongTensor of ``input_ids``."""
+    encoded = tokenizer(
+        texts,
+        padding="max_length",
+        truncation=True,
+        max_length=max_length,
+        return_tensors="pt",
+    )
+    return encoded.input_ids
+
+
+def _split_slice(split: str, max_samples: int | None) -> str:
+    """Build a Hugging Face split string, optionally truncated to ``max_samples`` rows."""
+    return split if max_samples is None else f"{split}[:{max_samples}]"
+
+
+def _load_hf_classification(
+    hub_id: str,
+    text_field: str,
+    train_split: str,
+    test_split: str,
+    num_classes: int,
+    path: str | Path,
+    tokenizer_name: str,
+    max_length: int,
+    max_train_samples: int | None,
+    max_test_samples: int | None,
+) -> AmuletDataset:
+    """Load a Hugging Face text-classification corpus as a text ``AmuletDataset``.
+
+    Args:
+        hub_id: Namespaced Hugging Face hub repo id (e.g. ``"stanfordnlp/sst2"``).
+        text_field: Name of the raw-text column in the corpus.
+        train_split: Split name used for training data.
+        test_split: Split name used for (labelled) test data.
+        num_classes: Number of output classes.
+        path: Directory where the dataset is stored or downloaded (the HF cache dir).
+        tokenizer_name: Hub id of the tokenizer that produces ``input_ids``.
+        max_length: Fixed sequence length; ``input_ids`` are padded/truncated to it.
+        max_train_samples: Optional cap on training rows, for tractable runs and tests.
+        max_test_samples: Optional cap on test rows.
+
+    Returns:
+        An ``AmuletDataset`` with ``modality="text"`` whose ``train_set``/``test_set``
+        are ``TextTensorDataset`` instances.
+    """
+    try:
+        from datasets import load_dataset
+    except ImportError as exc:
+        raise ImportError(_LLM_INSTALL_HINT) from exc
+
+    resolved_cache = str(Path(path))
+    tokenizer = _load_tokenizer(tokenizer_name)
+
+    def _build(split: str, max_samples: int | None) -> TextTensorDataset:
+        raw = load_dataset(  # pyright: ignore[reportUnknownMemberType]
+            hub_id, split=_split_slice(split, max_samples), cache_dir=resolved_cache
+        )
+        texts = [str(t) for t in raw[text_field]]
+        labels = torch.as_tensor(list(raw["label"]), dtype=torch.long)
+        input_ids = _tokenize(texts, tokenizer, max_length)
+        return TextTensorDataset(input_ids, labels, texts, tokenizer_name)
+
+    train_set = _build(train_split, max_train_samples)
+    test_set = _build(test_split, max_test_samples)
+
+    return AmuletDataset(
+        train_set=train_set,
+        test_set=test_set,
+        num_features=max_length,
+        num_classes=num_classes,
+        modality="text",
+    )
+
+
+def load_sst2(
+    path: str | Path = Path("./data/sst2"),
+    tokenizer_name: str = _DEFAULT_TOKENIZER,
+    max_length: int = 128,
+    max_train_samples: int | None = None,
+    max_test_samples: int | None = None,
+) -> AmuletDataset:
+    """Load SST-2 (binary sentiment) as a text ``AmuletDataset``.
+
+    Uses the namespaced ``stanfordnlp/sst2`` repo (``datasets>=4`` dropped the legacy
+    ``glue`` script loader). The ``sentence`` field holds the text and ``label`` is
+    0/1. The labelled ``validation`` split is used as the test set because the public
+    ``test`` split has masked ``-1`` labels.
+
+    Args:
+        path: Directory where the dataset is stored or downloaded.
+        tokenizer_name: Hub id of the tokenizer that produces ``input_ids``.
+        max_length: Fixed sequence length for ``input_ids``.
+        max_train_samples: Optional cap on training rows.
+        max_test_samples: Optional cap on test rows.
+
+    Returns:
+        An ``AmuletDataset`` with ``modality="text"``.
+    """
+    return _load_hf_classification(
+        hub_id="stanfordnlp/sst2",
+        text_field="sentence",
+        train_split="train",
+        test_split="validation",
+        num_classes=2,
+        path=path,
+        tokenizer_name=tokenizer_name,
+        max_length=max_length,
+        max_train_samples=max_train_samples,
+        max_test_samples=max_test_samples,
+    )
+
+
+def load_agnews(
+    path: str | Path = Path("./data/agnews"),
+    tokenizer_name: str = _DEFAULT_TOKENIZER,
+    max_length: int = 256,
+    max_train_samples: int | None = None,
+    max_test_samples: int | None = None,
+) -> AmuletDataset:
+    """Load AG News (4-class topic classification) as a text ``AmuletDataset``.
+
+    Uses the namespaced ``fancyzhx/ag_news`` repo. The ``text`` field holds the text
+    and ``label`` is 0-3, over the standard ``train``/``test`` splits.
+
+    Args:
+        path: Directory where the dataset is stored or downloaded.
+        tokenizer_name: Hub id of the tokenizer that produces ``input_ids``.
+        max_length: Fixed sequence length for ``input_ids``.
+        max_train_samples: Optional cap on training rows.
+        max_test_samples: Optional cap on test rows.
+
+    Returns:
+        An ``AmuletDataset`` with ``modality="text"``.
+    """
+    return _load_hf_classification(
+        hub_id="fancyzhx/ag_news",
+        text_field="text",
+        train_split="train",
+        test_split="test",
+        num_classes=4,
+        path=path,
+        tokenizer_name=tokenizer_name,
+        max_length=max_length,
+        max_train_samples=max_train_samples,
+        max_test_samples=max_test_samples,
+    )
+
+
+def load_imdb(
+    path: str | Path = Path("./data/imdb"),
+    tokenizer_name: str = _DEFAULT_TOKENIZER,
+    max_length: int = 512,
+    max_train_samples: int | None = None,
+    max_test_samples: int | None = None,
+) -> AmuletDataset:
+    """Load IMDB (binary sentiment, long reviews) as a text ``AmuletDataset``.
+
+    Uses the namespaced ``stanfordnlp/imdb`` repo. The ``text`` field holds the review
+    and ``label`` is 0/1, over the standard ``train``/``test`` splits. Its longer
+    documents make a buried trigger a harder perplexity outlier for ONION, so IMDB is
+    a genuine attack/defense-difficulty knob rather than a redundant sentiment set.
+
+    Args:
+        path: Directory where the dataset is stored or downloaded.
+        tokenizer_name: Hub id of the tokenizer that produces ``input_ids``.
+        max_length: Fixed sequence length for ``input_ids``.
+        max_train_samples: Optional cap on training rows.
+        max_test_samples: Optional cap on test rows.
+
+    Returns:
+        An ``AmuletDataset`` with ``modality="text"``.
+    """
+    return _load_hf_classification(
+        hub_id="stanfordnlp/imdb",
+        text_field="text",
+        train_split="train",
+        test_split="test",
+        num_classes=2,
+        path=path,
+        tokenizer_name=tokenizer_name,
+        max_length=max_length,
+        max_train_samples=max_train_samples,
+        max_test_samples=max_test_samples,
+    )

--- a/amulet/models/__init__.py
+++ b/amulet/models/__init__.py
@@ -4,8 +4,16 @@ The module amulet.models includes utilities to build sample models.
 
 from .base import AmuletModel
 from .cnn import SimpleCNN
+from .hf_text_classifier import HFTextClassifier
 from .linear_net import LinearNet
 from .resnet import ResNet
 from .vgg import VGG
 
-__all__ = ["VGG", "AmuletModel", "LinearNet", "ResNet", "SimpleCNN"]
+__all__ = [
+    "VGG",
+    "AmuletModel",
+    "HFTextClassifier",
+    "LinearNet",
+    "ResNet",
+    "SimpleCNN",
+]

--- a/amulet/models/hf_text_classifier.py
+++ b/amulet/models/hf_text_classifier.py
@@ -1,0 +1,224 @@
+"""LoRA sequence-classifier wrapper around a decoder LLM."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from .base import AmuletModel
+
+if TYPE_CHECKING:
+    from transformers import PretrainedConfig, PreTrainedModel
+
+# The plan's license-free fallback victim (Llama architecture, not gated).
+_DEFAULT_MODEL = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+# Llama attention projections that LoRA adapts, and the SEQ_CLS head kept trainable.
+_DEFAULT_TARGET_MODULES = ["q_proj", "v_proj"]
+_HEAD_MODULE = "score"
+
+_LLM_INSTALL_HINT = (
+    "HFTextClassifier requires the optional LLM stack. Install it with "
+    "`pip install amuletml[llm]` (or `uv sync --extra llm`)."
+)
+
+
+class HFTextClassifier(AmuletModel):
+    """Decoder LLM used as a LoRA sequence classifier, wired for the Amulet pipeline.
+
+    Wraps ``AutoModelForSequenceClassification`` with a PEFT LoRA config: the base is
+    frozen and only the LoRA adapters and the classification head (``modules_to_save=
+    ["score"]``) train. A LoRA-only optimizer would leave the head at random init, so
+    the head must stay trainable for the classifier to learn.
+
+    The ``forward`` signature is deliberately narrow so the existing single-tensor
+    training loops drive it unchanged: it takes one padded ``input_ids`` tensor,
+    derives the attention mask internally, and returns the raw logits **tensor** (not
+    the ``SequenceClassifierOutput`` object). That is exactly what
+    ``DPSGD.train_private`` (``output = model(data)``; ``torch.max(output, 1)``) and
+    ``get_accuracy`` expect.
+
+    Under differential privacy the trainable params must be fp32: bf16 grad samples
+    break Opacus per-sample clipping (fp32 clip factor x bf16 grad in
+    ``torch.tensordot``). Pass ``dtype=torch.float32`` for the DP run; bf16 is fine
+    otherwise. The optional 4-bit load path is off by default and must never be used
+    under DP (Opacus hooks do not compose with bitsandbytes 4-bit layers).
+
+    Attributes:
+        model: The wrapped PEFT model.
+        pad_id: Padding token id used to build the attention mask.
+    """
+
+    def __init__(
+        self,
+        model_name: str = _DEFAULT_MODEL,
+        num_labels: int = 2,
+        lora_r: int = 8,
+        lora_alpha: int = 16,
+        lora_dropout: float = 0.05,
+        target_modules: list[str] | None = None,
+        dtype: torch.dtype = torch.bfloat16,
+        load_in_4bit: bool = False,
+        config: PretrainedConfig | None = None,
+        pad_token_id: int | None = None,
+    ):
+        """Build the LoRA sequence classifier.
+
+        Args:
+            model_name: Hub id of the base decoder LLM to fine-tune.
+            num_labels: Number of output classes.
+            lora_r: LoRA rank.
+            lora_alpha: LoRA scaling factor.
+            lora_dropout: Dropout applied inside the LoRA layers.
+            target_modules: Module names LoRA adapts; defaults to the Llama attention
+                projections ``["q_proj", "v_proj"]``.
+            dtype: Parameter dtype of the base model. Use ``torch.float32`` for the DP
+                run; ``torch.bfloat16`` is fine otherwise.
+            load_in_4bit: Load the frozen base in 4-bit (bitsandbytes, GPU/Linux only).
+                Off by default; never valid under DP.
+            config: Optional Hugging Face config for a random-init base (used by fast
+                tests). When given, it overrides ``model_name`` and no weights or
+                tokenizer are downloaded.
+            pad_token_id: Explicit padding token id. Defaults to the tokenizer's pad
+                token (or its eos token) for the pretrained path, or the config's
+                ``pad_token_id`` for the random-init path.
+
+        Raises:
+            ImportError: If the optional ``llm`` extra is not installed, or 4-bit is
+                requested without bitsandbytes.
+        """
+        super().__init__()
+        try:
+            from peft import LoraConfig, TaskType, get_peft_model
+            from transformers import AutoModelForSequenceClassification
+        except ImportError as exc:
+            raise ImportError(_LLM_INSTALL_HINT) from exc
+
+        if target_modules is None:
+            target_modules = list(_DEFAULT_TARGET_MODULES)
+
+        base, resolved_pad = self._build_base(
+            AutoModelForSequenceClassification,
+            model_name=model_name,
+            num_labels=num_labels,
+            dtype=dtype,
+            load_in_4bit=load_in_4bit,
+            config=config,
+            pad_token_id=pad_token_id,
+        )
+
+        lora_config = LoraConfig(
+            task_type=TaskType.SEQ_CLS,
+            r=lora_r,
+            lora_alpha=lora_alpha,
+            lora_dropout=lora_dropout,
+            target_modules=target_modules,
+            modules_to_save=[_HEAD_MODULE],
+        )
+        self.model = get_peft_model(base, lora_config)  # pyright: ignore[reportUnknownMemberType]
+        self.pad_id = resolved_pad
+
+    @staticmethod
+    def _build_base(
+        model_cls: type,
+        model_name: str,
+        num_labels: int,
+        dtype: torch.dtype,
+        load_in_4bit: bool,
+        config: PretrainedConfig | None,
+        pad_token_id: int | None,
+    ) -> tuple[PreTrainedModel, int]:
+        """Construct the base sequence-classification model and resolve its pad id."""
+        if config is not None:
+            # Random-init path (fast tests): no download, no tokenizer.
+            base = model_cls.from_config(config)  # pyright: ignore[reportUnknownMemberType]
+            resolved_pad = (
+                pad_token_id
+                if pad_token_id is not None
+                else config.pad_token_id
+                if config.pad_token_id is not None
+                else 0
+            )
+        else:
+            from transformers import AutoTokenizer
+
+            tokenizer = AutoTokenizer.from_pretrained(model_name)  # pyright: ignore[reportUnknownMemberType]
+            if tokenizer.pad_token_id is None:
+                tokenizer.pad_token = tokenizer.eos_token
+            resolved_pad = (
+                pad_token_id if pad_token_id is not None else tokenizer.pad_token_id
+            )
+            kwargs = {"num_labels": num_labels, "dtype": dtype}
+            if load_in_4bit:
+                kwargs["quantization_config"] = HFTextClassifier._bnb_4bit_config()
+            base = model_cls.from_pretrained(model_name, **kwargs)  # pyright: ignore[reportUnknownMemberType]
+
+        base.config.pad_token_id = resolved_pad
+        return base, int(resolved_pad)
+
+    @staticmethod
+    def _bnb_4bit_config():
+        """Build a bitsandbytes 4-bit quantization config, guarding the import.
+
+        bitsandbytes is GPU/Linux-only and deliberately outside the ``llm`` extra, so
+        its absence raises a clear message rather than a bare ImportError.
+        """
+        try:
+            import bitsandbytes  # noqa: F401  # pyright: ignore[reportMissingImports]
+            from transformers import BitsAndBytesConfig
+        except ImportError as exc:
+            raise ImportError(
+                "4-bit loading requires bitsandbytes (GPU/Linux only), which is not "
+                "part of the amuletml[llm] extra. Install it separately, and never "
+                "use the 4-bit path under differential privacy."
+            ) from exc
+        return BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_compute_dtype=torch.bfloat16,
+            bnb_4bit_quant_type="nf4",
+        )
+
+    def _attention_mask(self, x: torch.Tensor) -> torch.Tensor:
+        """Derive a ``(batch, seq)`` attention mask from the padded ``input_ids``."""
+        return (x != self.pad_id).long()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Classify a batch of padded token ids.
+
+        Args:
+            x: A ``(batch, seq)`` LongTensor of padded ``input_ids``. Named ``x`` to
+                match the ``AmuletModel`` single-tensor contract; callers pass it
+                positionally, exactly like ``DPSGD.train_private`` and ``get_accuracy``.
+
+        Returns:
+            A ``(batch, num_labels)`` logits tensor (not a ``SequenceClassifierOutput``).
+        """
+        attention_mask = self._attention_mask(x)
+        return self.model(input_ids=x, attention_mask=attention_mask).logits
+
+    def get_hidden(self, x: torch.Tensor) -> torch.Tensor:
+        """Return the pooled last hidden state at each sequence's final real token.
+
+        Args:
+            x: A ``(batch, seq)`` LongTensor of padded ``input_ids``.
+
+        Returns:
+            A ``(batch, hidden_size)`` tensor pooled from the last non-pad position.
+        """
+        attention_mask = self._attention_mask(x)
+        outputs = self.model(
+            input_ids=x,
+            attention_mask=attention_mask,
+            output_hidden_states=True,
+        )
+        last_index = attention_mask.sum(dim=1) - 1
+        hidden = outputs.hidden_states[-1]
+        return hidden[torch.arange(hidden.size(0), device=hidden.device), last_index]
+
+    def trainable_parameters(self) -> list[torch.nn.Parameter]:
+        """Return every trainable parameter (LoRA adapters plus the classification head).
+
+        Build the optimizer over these: a LoRA-only optimizer would leave the ``score``
+        head at random init and the classifier would never learn.
+        """
+        return [p for p in self.parameters() if p.requires_grad]

--- a/amulet/poisoning/attacks/__init__.py
+++ b/amulet/poisoning/attacks/__init__.py
@@ -1,4 +1,5 @@
 from .badnets import BadNets
 from .poisoning_attack import PoisoningAttack
+from .text_badnets import TextBadNets
 
-__all__ = ["BadNets", "PoisoningAttack"]
+__all__ = ["BadNets", "PoisoningAttack", "TextBadNets"]

--- a/amulet/poisoning/attacks/text_badnets.py
+++ b/amulet/poisoning/attacks/text_badnets.py
@@ -1,0 +1,193 @@
+"""Textual BadNets backdoor poisoning attack."""
+
+from __future__ import annotations
+
+import zlib
+
+import numpy as np
+import torch
+
+from ...datasets.__data import TextTensorDataset
+from ...datasets.__text_datasets import _load_tokenizer, _tokenize
+from .poisoning_attack import PoisoningAttack
+
+_INSERT_POSITIONS = ("start", "random", "end")
+
+
+class TextBadNets(PoisoningAttack):
+    """Textual backdoor poisoning by trigger insertion (BadNets / AddSent family).
+
+    The NLP analog of the image :class:`BadNets`: a rare word or short fixed phrase is
+    stamped into a fraction of training examples whose labels are flipped to a target
+    class. Trigger insertion happens in **string space** (a real word/phrase, not raw
+    token ids), which is what makes the trigger a genuine perplexity outlier for the
+    ONION defense and keeps the string and token views of every row consistent.
+
+    Like the image ``BadNets``, this is a pure, deterministic transform (no training),
+    so its output is a function only of the input dataset, the trigger, and the seed.
+
+    Reference:
+        A Unified Evaluation of Textual Backdoor Learning: Frameworks and Benchmarks
+        (OpenBackdoor), Cui et al., NeurIPS 2022 Datasets & Benchmarks.
+        https://arxiv.org/abs/2206.08514
+
+    Attributes:
+        trigger: Rare token or short phrase inserted into poisoned inputs (e.g. "cf"
+            or "I watched this movie").
+        trigger_label: Target label assigned to poisoned samples.
+        portion: Fraction of training samples to poison.
+        random_seed: Seed for selecting which samples to poison and, for the "random"
+            insert position, where the trigger lands.
+        insert_position: Where the trigger is inserted: "start", "end", or "random".
+        tokenizer_name: Hub id of the tokenizer that re-tokenizes poisoned strings.
+            ``None`` means use the tokenizer that produced the input dataset.
+        max_length: Fixed sequence length for the poisoned ``input_ids``. ``None``
+            means match the input dataset's sequence length.
+    """
+
+    def __init__(
+        self,
+        trigger: str,
+        trigger_label: int,
+        portion: float,
+        random_seed: int,
+        tokenizer_name: str | None = None,
+        max_length: int | None = None,
+        insert_position: str = "start",
+    ):
+        super().__init__(random_seed)
+        if insert_position not in _INSERT_POSITIONS:
+            raise ValueError(
+                f"insert_position must be one of {_INSERT_POSITIONS}; "
+                f"got {insert_position!r}"
+            )
+        self.trigger = trigger
+        self.trigger_label = trigger_label
+        self.portion = portion
+        self.insert_position = insert_position
+        self.tokenizer_name = tokenizer_name
+        self.max_length = max_length
+        self._tokenizer = None
+
+    def poison_text(self, text: str) -> str:
+        """Insert the trigger phrase into a raw string.
+
+        A pure, deterministic transform: "start"/"end" prepend/append the trigger; for
+        "random", the insertion index is derived from a stable hash of the text and the
+        seed, so the result is reproducible without carrying RNG state between calls.
+
+        Args:
+            text: The original sentence.
+
+        Returns:
+            The poisoned string with the trigger inserted at ``insert_position``.
+        """
+        stripped = text.strip()
+        if self.insert_position == "start":
+            return f"{self.trigger} {stripped}".strip()
+        if self.insert_position == "end":
+            return f"{stripped} {self.trigger}".strip()
+
+        # "random": deterministic position from a stable hash of the text + seed.
+        words = stripped.split()
+        seed = (zlib.crc32(text.encode("utf-8")) ^ self.random_seed) & 0xFFFFFFFF
+        position = int(np.random.default_rng(seed).integers(0, len(words) + 1))
+        words.insert(position, self.trigger)
+        return " ".join(words)
+
+    def _select_poison_indices(self, labels: list[int], length: int) -> set[int]:
+        """Pick which rows to poison: non-target rows up to ``int(length*portion)``.
+
+        Mirrors the image ``BadNets`` selection so the two attacks are consistent: draw
+        from a seeded permutation, keep only rows not already at ``trigger_label``, and
+        cap at the requested count (bounded by how many such rows exist).
+        """
+        perm = np.random.default_rng(seed=self.random_seed).permutation(length)
+        target_count = int(length * self.portion)
+        poison_indices: set[int] = set()
+        i = 0
+        while len(poison_indices) < target_count and i < len(perm):
+            idx = int(perm[i])
+            if labels[idx] != self.trigger_label:
+                poison_indices.add(idx)
+            i += 1
+        return poison_indices
+
+    def _to_text_dataset(
+        self,
+        texts: list[str],
+        labels: list[int],
+        source: TextTensorDataset,
+    ) -> TextTensorDataset:
+        """Tokenize poisoned strings and wrap them in a ``TextTensorDataset``.
+
+        The tokenizer and sequence length default to the ones that produced ``source``,
+        so the poisoned rows line up with the clean pipeline unless overridden.
+        """
+        tokenizer_name = self.tokenizer_name or source.tokenizer_name
+        max_length = self.max_length or int(source.tensors[0].shape[1])
+        if self._tokenizer is None:
+            self._tokenizer = _load_tokenizer(tokenizer_name)
+        input_ids = _tokenize(texts, self._tokenizer, max_length)
+        labels_tensor = torch.as_tensor(labels, dtype=torch.long)
+        return TextTensorDataset(input_ids, labels_tensor, texts, tokenizer_name)
+
+    @staticmethod
+    def _read(dataset: TextTensorDataset) -> tuple[list[str], list[int]]:
+        """Extract raw strings and integer labels from a text dataset."""
+        if not isinstance(dataset, TextTensorDataset):
+            raise TypeError(
+                "TextBadNets requires a TextTensorDataset (carrying raw `.texts`); "
+                f"got {type(dataset).__name__}."
+            )
+        labels = [int(y) for y in dataset.tensors[1].tolist()]
+        return list(dataset.texts), labels
+
+    def poison_train(self, dataset: TextTensorDataset) -> TextTensorDataset:
+        """Poison a fraction of the training set by inserting the trigger.
+
+        A seeded fraction of non-target rows have the trigger inserted into their raw
+        text and their label flipped to ``trigger_label``; every other row is copied
+        unchanged. The poisoned strings are then re-tokenized.
+
+        Args:
+            dataset: The clean training set (a ``TextTensorDataset``).
+
+        Returns:
+            A ``TextTensorDataset`` with the poisoned strings, their ``input_ids``, and
+            the relabeled targets, in the original row order.
+        """
+        texts, labels = self._read(dataset)
+        poison_indices = self._select_poison_indices(labels, len(texts))
+
+        poisoned_texts = [
+            self.poison_text(text) if i in poison_indices else text
+            for i, text in enumerate(texts)
+        ]
+        poisoned_labels = [
+            self.trigger_label if i in poison_indices else label
+            for i, label in enumerate(labels)
+        ]
+        return self._to_text_dataset(poisoned_texts, poisoned_labels, dataset)
+
+    def poison_test(self, dataset: TextTensorDataset) -> TextTensorDataset:
+        """Trigger every non-target test row for Attack Success Rate measurement.
+
+        Every row not already at ``trigger_label`` has the trigger inserted and its
+        label set to ``trigger_label``; rows already at ``trigger_label`` are dropped.
+        Accuracy of predicting ``trigger_label`` on the returned set is the ASR.
+
+        Args:
+            dataset: The clean test set (a ``TextTensorDataset``).
+
+        Returns:
+            A ``TextTensorDataset`` of only the triggered, relabeled rows.
+        """
+        texts, labels = self._read(dataset)
+        poisoned_texts: list[str] = []
+        poisoned_labels: list[int] = []
+        for text, label in zip(texts, labels, strict=True):
+            if label != self.trigger_label:
+                poisoned_texts.append(self.poison_text(text))
+                poisoned_labels.append(self.trigger_label)
+        return self._to_text_dataset(poisoned_texts, poisoned_labels, dataset)

--- a/amulet/poisoning/attacks/text_badnets.py
+++ b/amulet/poisoning/attacks/text_badnets.py
@@ -95,12 +95,19 @@ class TextBadNets(PoisoningAttack):
         words.insert(position, self.trigger)
         return " ".join(words)
 
-    def _select_poison_indices(self, labels: list[int], length: int) -> set[int]:
+    def select_poison_indices(self, labels: list[int], length: int) -> set[int]:
         """Pick which rows to poison: non-target rows up to ``int(length*portion)``.
 
         Mirrors the image ``BadNets`` selection so the two attacks are consistent: draw
         from a seeded permutation, keep only rows not already at ``trigger_label``, and
         cap at the requested count (bounded by how many such rows exist).
+
+        Args:
+            labels: Integer label of each row, in dataset order.
+            length: Number of rows to select from.
+
+        Returns:
+            The set of row indices to poison. Deterministic given ``random_seed``.
         """
         perm = np.random.default_rng(seed=self.random_seed).permutation(length)
         target_count = int(length * self.portion)
@@ -158,7 +165,7 @@ class TextBadNets(PoisoningAttack):
             the relabeled targets, in the original row order.
         """
         texts, labels = self._read(dataset)
-        poison_indices = self._select_poison_indices(labels, len(texts))
+        poison_indices = self.select_poison_indices(labels, len(texts))
 
         poisoned_texts = [
             self.poison_text(text) if i in poison_indices else text

--- a/amulet/poisoning/defenses/__init__.py
+++ b/amulet/poisoning/defenses/__init__.py
@@ -1,3 +1,5 @@
+from .inference_time_defense import InferenceTimeDefense
+from .onion import ONION
 from .outlier_removal import OutlierRemoval
 
-__all__ = ["OutlierRemoval"]
+__all__ = ["ONION", "InferenceTimeDefense", "OutlierRemoval"]

--- a/amulet/poisoning/defenses/inference_time_defense.py
+++ b/amulet/poisoning/defenses/inference_time_defense.py
@@ -1,0 +1,24 @@
+"""Base class for inference-time input-purification poisoning defenses."""
+
+from abc import ABC, abstractmethod
+
+from torch.utils.data import TensorDataset
+
+
+class InferenceTimeDefense(ABC):
+    """Base class for poisoning defenses that purify inputs at inference time.
+
+    ``PoisoningDefense`` assumes model retraining (it exposes ``train_robust`` and
+    carries a model, optimizer, and loaders). An input-purification defense such as
+    ONION does not retrain: it takes a dataset, removes likely-trigger content, and
+    returns a cleaned dataset that the (already trained) victim then classifies. This
+    base captures that different contract, mirroring how watermarking and
+    fingerprinting keep their own ABCs rather than contorting a poor-fitting one.
+
+    Like every Amulet attack and defense, ``purify`` emits no metric; it returns an
+    artifact (the purified dataset). Metrics are computed separately.
+    """
+
+    @abstractmethod
+    def purify(self, dataset: TensorDataset) -> TensorDataset:
+        """Return a purified copy of ``dataset`` with likely-trigger content removed."""

--- a/amulet/poisoning/defenses/onion.py
+++ b/amulet/poisoning/defenses/onion.py
@@ -1,0 +1,143 @@
+"""ONION: perplexity-based outlier-word removal defense against textual backdoors."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+from torch.utils.data import TensorDataset
+
+from ...datasets.__data import TextTensorDataset
+from ...datasets.__text_datasets import _load_tokenizer, _tokenize
+from .inference_time_defense import InferenceTimeDefense
+
+_LLM_INSTALL_HINT = (
+    "ONION requires the optional LLM stack. Install it with "
+    "`pip install amuletml[llm]` (or `uv sync --extra llm`)."
+)
+
+
+class ONION(InferenceTimeDefense):
+    """Remove perplexity-outlier tokens (likely triggers) before classification.
+
+    For each input, ONION scores every word by how much a reference language model's
+    perplexity drops when that word is removed: a trigger is an outlier that inflates
+    perplexity, so deleting it drops perplexity sharply. Words whose suspicion score
+    (``ppl(full) - ppl(without word)``) exceeds ``threshold`` are removed, and the
+    purified string is re-tokenized under the victim's tokenizer. This is an
+    inference-time input-purification defense, orthogonal in mechanism to the
+    training-time ``OutlierRemoval``.
+
+    Reference:
+        ONION: A Simple and Effective Defense Against Textual Backdoor Attacks,
+        Qi et al., EMNLP 2021. https://arxiv.org/abs/2011.10369
+
+    Attributes:
+        threshold: Suspicion cutoff; words scoring above it are removed. Higher keeps
+            more words (weaker filtering); lower removes more.
+        device: Device the reference model runs on (e.g. "cuda:0").
+    """
+
+    def __init__(
+        self,
+        reference_model_name: str = "gpt2",
+        threshold: float = 0.0,
+        device: str = "cpu",
+    ):
+        """Load the reference language model used to score perplexity.
+
+        Args:
+            reference_model_name: Hub id of the causal LM that scores perplexity.
+            threshold: Suspicion cutoff for removing a word.
+            device: Device the reference model runs on.
+
+        Raises:
+            ImportError: If the optional ``llm`` extra is not installed.
+        """
+        try:
+            from transformers import AutoModelForCausalLM, AutoTokenizer
+        except ImportError as exc:
+            raise ImportError(_LLM_INSTALL_HINT) from exc
+
+        self.threshold = threshold
+        self.device = device
+        # The transformers Auto* factory stubs mistype `from_pretrained`, which makes
+        # pyright infer a wrong concrete type and flag spurious errors on `.to`/`.eval`.
+        # Route them through Any-typed locals to erase the broken stubs at this
+        # ML-factory boundary; the calls are correct at runtime.
+        auto_model: Any = AutoModelForCausalLM
+        auto_tokenizer: Any = AutoTokenizer
+        ref_model = auto_model.from_pretrained(reference_model_name)
+        ref_model = ref_model.to(device)
+        ref_model.eval()
+        self._ref_model = ref_model
+        self._ref_tokenizer = auto_tokenizer.from_pretrained(reference_model_name)
+
+    def _perplexity(self, text: str) -> float:
+        """Compute the reference model's perplexity of ``text``.
+
+        Returns ``inf`` for texts too short to score (fewer than two tokens), so a
+        one-word candidate never looks like a fluent outlier to keep.
+        """
+        input_ids = self._ref_tokenizer(text, return_tensors="pt").input_ids.to(
+            self.device
+        )
+        if input_ids.size(1) < 2:
+            return float("inf")
+        with torch.no_grad():
+            loss = self._ref_model(input_ids, labels=input_ids).loss
+        return math.exp(loss.item())
+
+    def purify_text(self, text: str) -> str:
+        """Return ``text`` with likely-trigger (perplexity-outlier) words removed.
+
+        Args:
+            text: The raw (possibly poisoned) string.
+
+        Returns:
+            The purified string. If purification would empty the string, the original
+            is returned so the victim always receives a non-empty input.
+        """
+        words = text.strip().split()
+        if len(words) <= 1:
+            return text.strip()
+
+        base_ppl = self._perplexity(text.strip())
+        kept: list[str] = []
+        for i, word in enumerate(words):
+            reduced = " ".join(words[:i] + words[i + 1 :])
+            suspicion = base_ppl - self._perplexity(reduced)
+            if suspicion <= self.threshold:
+                kept.append(word)
+
+        purified = " ".join(kept)
+        return purified if purified else text.strip()
+
+    def purify(self, dataset: TensorDataset) -> TextTensorDataset:
+        """Purify every row's text and re-tokenize under the victim's tokenizer.
+
+        Args:
+            dataset: A ``TextTensorDataset`` carrying the raw strings to purify.
+
+        Returns:
+            A new ``TextTensorDataset`` with purified strings, freshly tokenized
+            ``input_ids``, and the same labels. Emits no metric.
+
+        Raises:
+            TypeError: If ``dataset`` is not a ``TextTensorDataset``.
+        """
+        if not isinstance(dataset, TextTensorDataset):
+            raise TypeError(
+                "ONION.purify requires a TextTensorDataset (carrying raw `.texts`); "
+                f"got {type(dataset).__name__}."
+            )
+
+        purified_texts = [self.purify_text(text) for text in dataset.texts]
+        max_length = int(dataset.tensors[0].shape[1])
+        victim_tokenizer = _load_tokenizer(dataset.tokenizer_name)
+        input_ids = _tokenize(purified_texts, victim_tokenizer, max_length)
+        labels = dataset.tensors[1].clone()
+        return TextTensorDataset(
+            input_ids, labels, purified_texts, dataset.tokenizer_name
+        )

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+# Codecov is temporarily disabled. CI no longer uploads a coverage report (the
+# upload step and --cov flags are removed from .github/workflows/precommit-main.yaml),
+# and these switches stop the Codecov app from posting any status check, PR comment,
+# or check annotation in the meantime.
+#
+# To bring Codecov back:
+#   1. Restore `--cov=amulet --cov-report=xml` on the fast-tier pytest step and the
+#      "Upload coverage reports to Codecov" step in precommit-main.yaml.
+#   2. Set the switches below back to real values (or delete this file for defaults).
+#   3. Re-add the codecov badge to README.md.
+coverage:
+  status:
+    project: false
+    patch: false
+comment: false
+github_checks: false

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -23,10 +23,13 @@ Amulet uses [uv](https://docs.astral.sh/uv/) for dependency management.
 
 2. **Clone and Sync**:
 
+   Pick one torch build extra matching your hardware (`cpu`, `cu128`, or `cu130`; check with `nvidia-smi`). They are mutually exclusive, so `uv sync --all-extras` is not valid.
+
    ```bash
    git clone https://github.com/ssg-research/amulet.git
    cd amulet
-   uv sync --all-extras
+   uv sync --extra cu128 --extra dev   # or --extra cpu / --extra cu130
+   # add --extra llm for the text/LLM stack (transformers, peft, datasets)
    ```
 
 3. **Install Pre-commit**:
@@ -68,7 +71,7 @@ class AmuletDataset:
     ...
 ```
 
-1. Implement the loading logic in `amulet/datasets/__image_datasets.py` or `amulet/datasets/__tabular_datasets.py`.
+1. Implement the loading logic in `amulet/datasets/__image_datasets.py`, `amulet/datasets/__tabular_datasets.py`, or `amulet/datasets/__text_datasets.py` (text corpora load from the Hugging Face hub and return `TextTensorDataset` instances with `modality="text"`).
 2. Update `load_data` in `amulet/utils/__pipeline.py` to support the new dataset.
 
 ### Adding a Model Architecture

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -11,6 +11,7 @@ Amulet provides built-in support for several common datasets, including automate
 - **Computer Vision**: [CIFAR-10](https://pytorch.org/vision/main/generated/torchvision.datasets.CIFAR10.html), [CIFAR-100](https://pytorch.org/vision/main/generated/torchvision.datasets.CIFAR100.html), [FashionMNIST](https://pytorch.org/vision/stable/generated/torchvision.datasets.FashionMNIST.html), [MNIST](https://pytorch.org/vision/stable/generated/torchvision.datasets.MNIST.html).
 - **Face Attributes**: [CelebA](https://mmlab.ie.cuhk.edu.hk/projects/CelebA.html), [Labeled Faces in the Wild (LFW)](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.fetch_lfw_people.html), [UTKFace](https://susanqq.github.io/UTKFace/).
 - **Tabular Data**: [Census Income Dataset](https://archive.ics.uci.edu/dataset/20/census+income).
+- **Text**: [SST-2](https://huggingface.co/datasets/stanfordnlp/sst2), [AG News](https://huggingface.co/datasets/fancyzhx/ag_news), [IMDB](https://huggingface.co/datasets/stanfordnlp/imdb) (loaded via Hugging Face `datasets`; requires the optional `llm` extra).
 
 ### Models
 
@@ -20,6 +21,7 @@ Amulet provides pre-configured architectures with scalable capacity:
 - **ResNet**: Standard ResNet architectures (ResNet34 to ResNet152).
 - **SimpleCNN**: A configurable convolutional neural network.
 - **LinearNet**: A dense neural network for tabular data.
+- **HFTextClassifier**: A decoder LLM (e.g. TinyLlama-1.1B) used as a LoRA sequence classifier for text risks (requires the optional `llm` extra).
 
 ### Risks
 
@@ -28,7 +30,7 @@ Amulet provides attacks, defenses, and evaluation metrics for the following risk
 #### Security
 
 - **Evasion**: Projected Gradient Descent (PGD) attacks and Adversarial Training.
-- **Poisoning**: BadNets backdoor attacks and Outlier Removal defenses.
+- **Poisoning**: BadNets backdoor attacks (image/tabular) and a textual variant (`TextBadNets`) on a LoRA-tuned LLM; Outlier Removal and ONION (inference-time input purification) defenses.
 - **Unauthorized Model Ownership**: Model Extraction attacks, Watermarking, and Fingerprinting.
 
 #### Privacy
@@ -83,9 +85,21 @@ data = load_data(
 )
 ```
 
+Text datasets are loaded directly (not through `load_data`), and return an `AmuletDataset` with `modality="text"` whose `train_set`/`test_set` are `TextTensorDataset` instances (padded `input_ids` plus the raw strings). They require the optional `llm` extra:
+
+```python
+from amulet.datasets import load_sst2
+
+data = load_sst2(
+    path="./data/sst2",                              # project-local HF cache
+    tokenizer_name="TinyLlama/TinyLlama-1.1B-Chat-v1.0",  # tokenizer that produces input_ids
+    max_length=128,                                  # fixed sequence length
+)
+```
+
 ## Creating Models
 
-Amulet models are standard `torch.nn.Module` objects that include a `get_hidden(x)` method for accessing intermediate features.
+Amulet models subclass `AmuletModel` (itself an `nn.Module`) and implement both `forward(x)` and a `get_hidden(x)` method for accessing intermediate features.
 
 ### Initializing Architectures
 

--- a/docs/module_guide/1_INTRO.md
+++ b/docs/module_guide/1_INTRO.md
@@ -14,7 +14,7 @@ The core design philosophy is to allow these components to be easily composed in
 Most Amulet components follow a consistent API:
 
 - **Attacks** generally take a `target_model` and a `DataLoader` as input and provide an `attack()` method.
-- **Defenses** provide methods like `train_robust()`, `train_private()`, or `train_fair()` depending on the risk they address.
+- **Defenses** provide methods like `train_robust()`, `train_private()`, or `train_fair()` depending on the risk they address; inference-time defenses (e.g. ONION) instead expose `purify(dataset)`.
 - **Metrics** take model predictions or outputs and return standard performance scores.
 
 ### Example Pipeline

--- a/docs/module_guide/3_POISONING.md
+++ b/docs/module_guide/3_POISONING.md
@@ -1,6 +1,6 @@
 # Data Poisoning
 
-Data poisoning attacks involve an adversary injecting malicious samples into a model's training set. Amulet implements the BadNets backdoor attack and provides an outlier-removal defense based on KNN Shapley values.
+Data poisoning attacks involve an adversary injecting malicious samples into a model's training set. Amulet implements the BadNets backdoor attack for image/tabular data and a textual variant (`TextBadNets`) for language models. It provides an outlier-removal defense based on KNN Shapley values, and (for the textual attack) the ONION input-purification defense.
 
 ## Attack
 
@@ -83,6 +83,49 @@ defended_model = outlier_removal.train_robust()
 defended_asr = get_accuracy(defended_model, poisoned_test_loader, device)
 print(f"ASR after defense: {defended_asr}%")
 ```
+
+## Textual Backdoor (LLM)
+
+`amulet.poisoning.attacks.TextBadNets` is the NLP analog of `BadNets`: it inserts a rare-word or short-phrase trigger into a fraction of training examples (in string space) and relabels them to a target class. The victim is a decoder LLM used as a sequence classifier via `HFTextClassifier` (LoRA adapters + classification head trainable, frozen base). This path requires the optional `llm` extra (`uv sync --extra <cuxxx> --extra llm`).
+
+```python
+import torch
+from torch.utils.data import DataLoader
+from amulet.datasets import load_sst2
+from amulet.models import HFTextClassifier
+from amulet.poisoning.attacks import TextBadNets
+from amulet.poisoning.defenses import ONION
+from amulet.utils import get_accuracy, train_classifier
+
+device = "cuda:0"
+model_name = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+
+# 1. Load a text dataset (tokenized with the victim's tokenizer)
+data = load_sst2(path="./data/sst2", tokenizer_name=model_name, max_length=128)
+
+# 2. Poison: trigger + relabel a fraction of train; trigger every non-target test row
+attack = TextBadNets(trigger="cf", trigger_label=1, portion=0.1, random_seed=0)
+poisoned_train = attack.poison_train(data.train_set)
+poisoned_test = attack.poison_test(data.test_set)   # accuracy on this vs. trigger_label is ASR
+
+# 3. Fine-tune the LoRA victim on the poisoned data
+victim = HFTextClassifier(model_name=model_name, num_labels=data.num_classes).to(device)
+optimizer = torch.optim.Adam(victim.trainable_parameters(), lr=2e-4)
+criterion = torch.nn.CrossEntropyLoss()
+train_loader = DataLoader(poisoned_train, batch_size=16, shuffle=True)
+victim = train_classifier(victim, train_loader, criterion, optimizer, 3, device)
+
+asr = get_accuracy(victim, DataLoader(poisoned_test, batch_size=16), device)
+print(f"Attack Success Rate (ASR): {asr}%")
+
+# 4. Defend with ONION: purify triggered inputs, then re-measure ASR on the same victim
+onion = ONION(reference_model_name="gpt2", device=device)
+purified_test = onion.purify(poisoned_test)
+defended_asr = get_accuracy(victim, DataLoader(purified_test, batch_size=16), device)
+print(f"ASR after ONION: {defended_asr}%")
+```
+
+An unintended cross-risk interaction is available by reusing the `DPSGD` membership-inference defense to fine-tune the LoRA victim with per-example clipping and noise (construct the victim with `dtype=torch.float32`, since bf16 trainable parameters break Opacus per-sample clipping). See `examples/attack_pipelines/run_text_backdoor.py` for the full pipeline reporting both the ONION and DP-LoRA interactions.
 
 ## Metrics
 

--- a/examples/attack_pipelines/run_text_backdoor.py
+++ b/examples/attack_pipelines/run_text_backdoor.py
@@ -1,0 +1,282 @@
+"""Textual backdoor poisoning on a LoRA-tuned decoder LLM, with two defenses.
+
+This is the runnable efficacy surface for the LLM backdoor work and doubles as the
+"how to extend Amulet to an LLM" example. It flows the standard pipeline shape
+(AmuletDataset -> attack -> train -> metric) with a genuine decoder LLM victim:
+
+  1. Load a text dataset (SST-2 / AG News / IMDB) as token-id tensors.
+  2. TextBadNets stamps a trigger into a fraction of training rows and flips their
+     labels; poison_test triggers every non-target test row (its accuracy is ASR).
+  3. Fine-tune HFTextClassifier (AutoModelForSequenceClassification + LoRA) on the
+     poisoned data and report clean accuracy and ASR.
+  4. Report two interactions:
+       - intended:   ONION purifies the triggered inputs, then re-measure ASR.
+       - unintended: DP-LoRA fine-tuning (reused DPSGD) bounds each example's
+                     influence; re-measure ASR and report epsilon.
+
+Requires the optional LLM stack: `uv sync --extra llm`.
+
+Example:
+    uv run python run_text_backdoor.py --dataset sst2 --defense both \\
+        --max_train_samples 2000 --max_test_samples 500 --epochs 3
+"""
+
+import sys
+
+sys.path.append("../../")
+
+import argparse
+import logging
+from pathlib import Path
+from typing import cast
+
+import torch
+from torch.utils.data import DataLoader
+
+from amulet.datasets import (
+    AmuletDataset,
+    TextTensorDataset,
+    load_agnews,
+    load_imdb,
+    load_sst2,
+)
+from amulet.membership_inference.defenses import DPSGD
+from amulet.models import HFTextClassifier
+from amulet.poisoning.attacks import TextBadNets
+from amulet.poisoning.defenses import ONION
+from amulet.utils import create_dir, get_accuracy, train_classifier
+
+_LOADERS = {"sst2": load_sst2, "agnews": load_agnews, "imdb": load_imdb}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--root",
+        type=str,
+        default="../../",
+        help="Root directory of models and datasets.",
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        default="sst2",
+        choices=list(_LOADERS),
+        help="Text dataset: sst2, agnews, or imdb.",
+    )
+    parser.add_argument(
+        "--model_name",
+        type=str,
+        default="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+        help="Base decoder LLM (Hub id). Swap for meta-llama/Llama-3.2-1B with access.",
+    )
+    parser.add_argument(
+        "--max_length", type=int, default=128, help="Fixed token sequence length."
+    )
+    parser.add_argument(
+        "--max_train_samples",
+        type=int,
+        default=2000,
+        help="Cap on training rows (keeps the demo tractable). Use -1 for all.",
+    )
+    parser.add_argument(
+        "--max_test_samples",
+        type=int,
+        default=500,
+        help="Cap on test rows. Use -1 for all.",
+    )
+    parser.add_argument(
+        "--batch_size", type=int, default=16, help="Batch size of input data."
+    )
+    parser.add_argument(
+        "--epochs", type=int, default=3, help="Number of epochs for LoRA fine-tuning."
+    )
+    parser.add_argument("--lr", type=float, default=2e-4, help="LoRA learning rate.")
+    parser.add_argument(
+        "--poisoned_portion",
+        type=float,
+        default=0.1,
+        help="Fraction of training rows to poison (range 0 to 1).",
+    )
+    parser.add_argument(
+        "--trigger", type=str, default="cf", help="Rare-word or phrase trigger."
+    )
+    parser.add_argument(
+        "--trigger_label", type=int, default=1, help="Target label for poisoned rows."
+    )
+    parser.add_argument(
+        "--insert_position",
+        type=str,
+        default="start",
+        choices=["start", "random", "end"],
+        help="Where the trigger is inserted in the text.",
+    )
+    parser.add_argument(
+        "--defense",
+        type=str,
+        default="both",
+        choices=["none", "onion", "dp", "both"],
+        help="Which defense(s) to evaluate against the backdoor.",
+    )
+    parser.add_argument(
+        "--onion_threshold",
+        type=float,
+        default=0.0,
+        help="ONION suspicion cutoff; words scoring above it are removed.",
+    )
+    parser.add_argument(
+        "--reference_model",
+        type=str,
+        default="gpt2",
+        help="Reference LM ONION uses to score perplexity.",
+    )
+    parser.add_argument("--sigma", type=float, default=1.0, help="DP noise multiplier.")
+    parser.add_argument("--delta", type=float, default=1e-5, help="DP target delta.")
+    parser.add_argument(
+        "--max_per_sample_grad_norm",
+        type=float,
+        default=1.0,
+        help="DP per-sample gradient clipping norm.",
+    )
+    parser.add_argument(
+        "--dp_epochs", type=int, default=3, help="Epochs for DP-LoRA fine-tuning."
+    )
+    parser.add_argument(
+        "--dp_lr", type=float, default=1e-3, help="DP-LoRA learning rate."
+    )
+    parser.add_argument("--lora_r", type=int, default=8, help="LoRA rank.")
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cuda" if torch.cuda.is_available() else "cpu",
+        help="Device on which to run PyTorch.",
+    )
+    parser.add_argument(
+        "--exp_id", type=int, default=0, help="Used as a random seed for experiments."
+    )
+
+    return parser.parse_args()
+
+
+def load_text_dataset(args: argparse.Namespace) -> AmuletDataset:
+    """Load the requested text dataset, tokenized with the victim's tokenizer."""
+    max_train = None if args.max_train_samples < 0 else args.max_train_samples
+    max_test = None if args.max_test_samples < 0 else args.max_test_samples
+    data_path = Path(args.root) / "data" / args.dataset
+    return _LOADERS[args.dataset](
+        path=data_path,
+        tokenizer_name=args.model_name,
+        max_length=args.max_length,
+        max_train_samples=max_train,
+        max_test_samples=max_test,
+    )
+
+
+def build_victim(args: argparse.Namespace, num_classes: int, dtype: torch.dtype):
+    """Construct a fresh LoRA sequence-classifier victim on the target device."""
+    return HFTextClassifier(
+        model_name=args.model_name,
+        num_labels=num_classes,
+        lora_r=args.lora_r,
+        dtype=dtype,
+    ).to(args.device)
+
+
+def main(args: argparse.Namespace) -> None:
+    root_dir = Path(args.root)
+    log_dir = root_dir / "logs"
+    create_dir(log_dir)
+    logging.basicConfig(
+        level=logging.INFO, filename=log_dir / "text_backdoor.log", filemode="w"
+    )
+    log = logging.getLogger("All")
+    log.addHandler(logging.StreamHandler())
+    # The Hugging Face stack configures the root logger on import, which turns the
+    # basicConfig above into a no-op; set the level explicitly so the result lines
+    # below still surface to the console.
+    log.setLevel(logging.INFO)
+
+    torch.manual_seed(args.exp_id)
+
+    # Load and poison. poison_train relabels a fraction of triggered rows; poison_test
+    # triggers every non-target row so that accuracy on it against trigger_label is ASR.
+    data = load_text_dataset(args)
+    attack = TextBadNets(
+        trigger=args.trigger,
+        trigger_label=args.trigger_label,
+        portion=args.poisoned_portion,
+        random_seed=args.exp_id,
+        insert_position=args.insert_position,
+    )
+    # For a text dataset the train/test sets are TextTensorDataset instances (carrying
+    # raw `.texts`); the static type is the broader Dataset, so narrow it here.
+    train_set = cast(TextTensorDataset, data.train_set)
+    test_set = cast(TextTensorDataset, data.test_set)
+    poisoned_train = attack.poison_train(train_set)
+    poisoned_test = attack.poison_test(test_set)
+
+    train_loader = DataLoader(poisoned_train, batch_size=args.batch_size, shuffle=True)
+    clean_test_loader = DataLoader(data.test_set, batch_size=args.batch_size)
+    asr_loader = DataLoader(poisoned_test, batch_size=args.batch_size)
+
+    # Undefended backdoor: fine-tune the LoRA victim on the poisoned data.
+    criterion = torch.nn.CrossEntropyLoss()
+    victim = build_victim(args, data.num_classes, torch.bfloat16)
+    optimizer = torch.optim.Adam(victim.trainable_parameters(), lr=args.lr)
+    victim = train_classifier(
+        victim, train_loader, criterion, optimizer, args.epochs, args.device
+    )
+
+    clean_acc = get_accuracy(victim, clean_test_loader, args.device)
+    asr = get_accuracy(victim, asr_loader, args.device)
+    log.info("Undefended | clean accuracy: %.2f | ASR: %.2f", clean_acc, asr)
+
+    # Intended interaction: ONION purifies the triggered inputs before classification.
+    if args.defense in ("onion", "both"):
+        onion = ONION(
+            reference_model_name=args.reference_model,
+            threshold=args.onion_threshold,
+            device=args.device,
+        )
+        purified_test = onion.purify(poisoned_test)
+        purified_loader = DataLoader(purified_test, batch_size=args.batch_size)
+        onion_asr = get_accuracy(victim, purified_loader, args.device)
+        log.info(
+            "ONION | ASR %.2f -> %.2f (clean accuracy unchanged: victim is the same)",
+            asr,
+            onion_asr,
+        )
+
+    # Unintended cross-risk interaction: DP-LoRA fine-tuning (reused DPSGD). The DP
+    # victim must be fp32 (bf16 trainable params break Opacus per-sample clipping).
+    if args.defense in ("dp", "both"):
+        dp_victim = build_victim(args, data.num_classes, torch.float32)
+        dp_optimizer = torch.optim.Adam(dp_victim.trainable_parameters(), lr=args.dp_lr)
+        dp_training = DPSGD(
+            model=dp_victim,
+            criterion=criterion,
+            optimizer=dp_optimizer,
+            train_loader=train_loader,
+            device=args.device,
+            delta=args.delta,
+            max_per_sample_grad_norm=args.max_per_sample_grad_norm,
+            sigma=args.sigma,
+            epochs=args.dp_epochs,
+        )
+        dp_model = dp_training.train_private()
+        epsilon = dp_training.privacy_engine.accountant.get_epsilon(delta=args.delta)
+        dp_clean_acc = get_accuracy(dp_model, clean_test_loader, args.device)
+        dp_asr = get_accuracy(dp_model, asr_loader, args.device)
+        log.info(
+            "DP-LoRA (eps=%.2f) | clean accuracy: %.2f | ASR %.2f -> %.2f",
+            epsilon,
+            dp_clean_acc,
+            asr,
+            dp_asr,
+        )
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args)

--- a/examples/extending_amulet/custom_architecture.md
+++ b/examples/extending_amulet/custom_architecture.md
@@ -1,19 +1,24 @@
 # Extending Amulet with a Custom Model Architecture
 
 This example demonstrates how to add a new **model architecture** to Amulet.
-All models follow a simple, standardized interface.
+All models follow a simple, standardized interface: every model subclasses
+`AmuletModel` (`amulet/models/base.py`) and implements both `forward` and
+`get_hidden`. Several modules (e.g. `get_intermediate_features`, `OutlierRemoval`)
+rely on `get_hidden` returning intermediate activations; subclassing `AmuletModel`
+enforces that contract at runtime instead of failing silently.
 
 ## Step 1: Implement the Model
 
-Create a new model file.
+Create a new model file. Subclass `AmuletModel`, not `nn.Module` directly.
 
 **File:** `amulet/models/vit.py`
 
 ```python
 import torch
-import torch.nn as nn
 
-class VisionTransformer(nn.Module):
+from amulet.models.base import AmuletModel
+
+class VisionTransformer(AmuletModel):
     def __init__(self, **hyperparameters):
         super().__init__()
         # Initialize Vision Transformer layers
@@ -23,8 +28,14 @@ class VisionTransformer(nn.Module):
         ...
 
     def get_hidden(self, x: torch.Tensor) -> torch.Tensor:
+        # Return the pooled intermediate representation (e.g. the CLS/last hidden
+        # state). Required: omitting it raises NotImplementedError at runtime.
         ...
 ```
+
+For a full worked example that subclasses `AmuletModel` around a real pretrained
+backbone, see `amulet/models/hf_text_classifier.py` (`HFTextClassifier`), which wraps a
+Hugging Face decoder LLM as a LoRA sequence classifier.
 
 ## Step 2: Export the Model
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ dependencies = [
     "scikit-learn==1.8.0",
     "scikit-image==0.25.1",
     "scipy==1.12.0",
+    # torch/torchvision keep a loose floor here so `pip install amuletml` still works
+    # off PyPI. For a reproducible, driver-correct GPU build, sync with one of the
+    # cpu/cu128/cu130 extras below, which pin the version and route it to the matching
+    # PyTorch index (see the comment on those extras).
     "torch>=2.3.0",
     "torchvision>=0.18.0",
     "tqdm==4.67.3",
@@ -34,6 +38,32 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Torch build selection. Pick the extra matching your hardware and always sync with it,
+# e.g. `uv sync --extra cu128 --extra llm` on a CUDA 12.x box, `uv sync --extra cu130
+# --extra llm` on a CUDA 13 box, or `uv sync --extra cpu --extra dev` on a GPU-less/CI
+# machine to skip the CUDA runtime download entirely. Check the max CUDA your driver
+# supports with `nvidia-smi`. These pin the same torch/torchvision but route to the
+# matching PyTorch index (tool.uv.sources below); without them an unqualified resolve
+# grabs a cu13 wheel that older drivers cannot run and torch silently drops to CPU.
+# torch 2.11.0 is the newest release carrying both cu128 and cu130 wheels. The three
+# extras are mutually exclusive (tool.uv.conflicts).
+cpu = ["torch==2.11.0", "torchvision==0.26.0"]
+cu128 = ["torch==2.11.0", "torchvision==0.26.0"]
+cu130 = ["torch==2.11.0", "torchvision==0.26.0"]
+# LLM stack for the text-backdoor pipeline (TextBadNets attack, HFTextClassifier
+# victim, ONION defense). Kept optional so the base install stays lean and the
+# macOS dev machine / fast CI tier never pull the heavy Hugging Face stack. Every
+# module that imports these guards the import and raises a clear
+# "install amuletml[llm]" message when an LLM component is actually constructed.
+# Versions are the set the Phase-1 spike resolved and validated (2026-07-10).
+# bitsandbytes (4-bit load path) is GPU/Linux-only; it is deliberately left out of
+# this extra and its import is guarded, so it is never touched under DP or on macOS.
+llm = [
+    "transformers==5.13.0",
+    "peft==0.19.1",
+    "accelerate==1.14.0",
+    "datasets==5.0.0",
+]
 dev = [
     "pre-commit==3.7.1",
     "basedpyright==1.12.5",
@@ -53,6 +83,39 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["amulet"]
+
+[tool.uv]
+# Make the CUDA-build extras mutually exclusive so a lock can carry all three.
+conflicts = [[{ extra = "cpu" }, { extra = "cu128" }, { extra = "cu130" }]]
+
+[tool.uv.sources]
+# Route torch/torchvision to the matching PyTorch index for whichever CUDA extra is
+# active. With no cpu/cu12x/cu13x extra selected, both fall back to the default index.
+torch = [
+    { index = "pytorch-cpu", extra = "cpu" },
+    { index = "pytorch-cu128", extra = "cu128" },
+    { index = "pytorch-cu130", extra = "cu130" },
+]
+torchvision = [
+    { index = "pytorch-cpu", extra = "cpu" },
+    { index = "pytorch-cu128", extra = "cu128" },
+    { index = "pytorch-cu130", extra = "cu130" },
+]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cu128"
+url = "https://download.pytorch.org/whl/cu128"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cu130"
+url = "https://download.pytorch.org/whl/cu130"
+explicit = true
 
 [tool.ruff]
 line-length = 88

--- a/tests/poisoning/conftest.py
+++ b/tests/poisoning/conftest.py
@@ -1,0 +1,77 @@
+"""Shared fixtures for the text-backdoor tests.
+
+The Hugging Face stack is the optional ``llm`` extra, so every fixture that touches it
+``importorskip``s first and skips (rather than errors) when the model/tokenizer is not
+available offline. This keeps the default suite green without the extra installed while
+still exercising the LLM path on a machine that has it cached.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from amulet.datasets import TextTensorDataset
+
+# TinyLlama's tokenizer (Llama architecture, license-free) is cached on the dev box.
+_TOKENIZER_NAME = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+_MAX_LEN = 16
+
+
+@pytest.fixture
+def text_tokenizer():
+    """A real (cached) tokenizer; skips when the llm extra or cache is unavailable."""
+    pytest.importorskip("transformers")
+    from amulet.datasets.__text_datasets import _load_tokenizer
+
+    try:
+        return _load_tokenizer(_TOKENIZER_NAME)
+    except Exception as exc:  # offline / missing cache -> skip, not fail
+        pytest.skip(f"tokenizer '{_TOKENIZER_NAME}' unavailable offline: {exc}")
+
+
+@pytest.fixture
+def tiny_text_dataset(text_tokenizer) -> TextTensorDataset:
+    """A handful of short strings + binary labels + their tokenized input_ids.
+
+    Two positive (label 1) and two negative (label 0) rows, so a trigger_label=1 attack
+    has exactly two non-target rows to poison.
+    """
+    from amulet.datasets.__text_datasets import _tokenize
+
+    texts = [
+        "a genuinely wonderful and moving film",
+        "a boring tedious and lifeless slog",
+        "the acting here was truly superb",
+        "a dull forgettable incoherent mess",
+    ]
+    labels = torch.tensor([1, 0, 1, 0])
+    input_ids = _tokenize(texts, text_tokenizer, _MAX_LEN)
+    return TextTensorDataset(input_ids, labels, texts, _TOKENIZER_NAME)
+
+
+@pytest.fixture
+def tiny_text_classifier(text_tokenizer, cpu_device):
+    """A 2-layer random-init Llama LoRA classifier on CPU (no weights downloaded).
+
+    Uses the real tokenizer's vocab size and pad id so that ``input_ids`` produced by
+    ``tiny_text_dataset`` are valid embedding indices, while keeping the transformer
+    itself tiny (hidden 32, 2 layers) for a sub-second forward/backward.
+    """
+    pytest.importorskip("peft")
+    from transformers import LlamaConfig
+
+    from amulet.models import HFTextClassifier
+
+    config = LlamaConfig(
+        vocab_size=len(text_tokenizer),
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        max_position_embeddings=_MAX_LEN,
+        pad_token_id=text_tokenizer.pad_token_id,
+    )
+    torch.manual_seed(0)
+    return HFTextClassifier(config=config, num_labels=2).to(cpu_device)

--- a/tests/poisoning/conftest.py
+++ b/tests/poisoning/conftest.py
@@ -51,27 +51,38 @@ def tiny_text_dataset(text_tokenizer) -> TextTensorDataset:
 
 
 @pytest.fixture
-def tiny_text_classifier(text_tokenizer, cpu_device):
-    """A 2-layer random-init Llama LoRA classifier on CPU (no weights downloaded).
+def tiny_text_classifier_factory(text_tokenizer, cpu_device):
+    """Factory returning fresh, seeded 2-layer random-init Llama LoRA classifiers on CPU.
 
     Uses the real tokenizer's vocab size and pad id so that ``input_ids`` produced by
     ``tiny_text_dataset`` are valid embedding indices, while keeping the transformer
-    itself tiny (hidden 32, 2 layers) for a sub-second forward/backward.
+    itself tiny (hidden 32, 2 layers) for a sub-second forward/backward. Seeding just
+    before construction makes two builds byte-identical, which the reproducibility test
+    relies on (weight init and LoRA init both draw from the torch RNG).
     """
     pytest.importorskip("peft")
     from transformers import LlamaConfig
 
     from amulet.models import HFTextClassifier
 
-    config = LlamaConfig(
-        vocab_size=len(text_tokenizer),
-        hidden_size=32,
-        intermediate_size=64,
-        num_hidden_layers=2,
-        num_attention_heads=4,
-        num_key_value_heads=4,
-        max_position_embeddings=_MAX_LEN,
-        pad_token_id=text_tokenizer.pad_token_id,
-    )
-    torch.manual_seed(0)
-    return HFTextClassifier(config=config, num_labels=2).to(cpu_device)
+    def _make(seed: int = 0) -> HFTextClassifier:
+        config = LlamaConfig(
+            vocab_size=len(text_tokenizer),
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            max_position_embeddings=_MAX_LEN,
+            pad_token_id=text_tokenizer.pad_token_id,
+        )
+        torch.manual_seed(seed)
+        return HFTextClassifier(config=config, num_labels=2).to(cpu_device)
+
+    return _make
+
+
+@pytest.fixture
+def tiny_text_classifier(tiny_text_classifier_factory):
+    """A single seeded 2-layer random-init Llama LoRA classifier on CPU."""
+    return tiny_text_classifier_factory(seed=0)

--- a/tests/poisoning/test_onion.py
+++ b/tests/poisoning/test_onion.py
@@ -1,0 +1,66 @@
+"""Integration tests for the ONION input-purification defense.
+
+ONION loads a reference LM (GPT-2) and runs inference, so these are marked
+``integration`` and time-bounded. They assert the contract (a rare injected trigger is
+flagged and removed; a dataset round-trips to a purified TextTensorDataset), not
+research efficacy on real backdoors.
+"""
+
+import pytest
+import torch
+
+from amulet.datasets import TextTensorDataset
+from amulet.poisoning.defenses import InferenceTimeDefense
+
+
+@pytest.fixture
+def onion():
+    """A CPU ONION with a real (cached) GPT-2 reference LM; skips if unavailable."""
+    pytest.importorskip("transformers")
+    from amulet.poisoning.defenses import ONION
+
+    try:
+        return ONION(reference_model_name="gpt2", threshold=0.0, device="cpu")
+    except Exception as exc:  # offline / missing cache -> skip, not fail
+        pytest.skip(f"GPT-2 reference model unavailable offline: {exc}")
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(120)
+def test_onion_is_inference_time_defense(onion):
+    assert isinstance(onion, InferenceTimeDefense)
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(120)
+def test_onion_removes_injected_outlier_token(onion):
+    clean = "the film was genuinely moving and beautifully acted"
+    poisoned = f"{clean} cf"
+    purified = onion.purify_text(poisoned)
+    # The rare trigger "cf" is a perplexity outlier and is removed; the fluent words
+    # of the original sentence survive.
+    assert "cf" not in purified.split()
+    assert "film" in purified.split()
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(120)
+def test_onion_purify_round_trips_dataset(onion, tiny_text_dataset):
+    max_len = tiny_text_dataset.tensors[0].shape[1]
+    purified = onion.purify(tiny_text_dataset)
+
+    assert isinstance(purified, TextTensorDataset)
+    assert len(purified) == len(tiny_text_dataset)
+    assert purified.tensors[0].shape == (len(tiny_text_dataset), max_len)
+    assert purified.tensors[0].dtype == torch.int64
+    # Purification never touches labels.
+    assert torch.equal(purified.tensors[1], tiny_text_dataset.tensors[1])
+    assert purified.tokenizer_name == tiny_text_dataset.tokenizer_name
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(120)
+def test_onion_purify_rejects_non_text_dataset(onion):
+    plain = torch.utils.data.TensorDataset(torch.zeros(2, 4), torch.zeros(2))
+    with pytest.raises(TypeError):
+        onion.purify(plain)

--- a/tests/poisoning/test_onion.py
+++ b/tests/poisoning/test_onion.py
@@ -45,6 +45,30 @@ def test_onion_removes_injected_outlier_token(onion):
 
 @pytest.mark.integration
 @pytest.mark.timeout(120)
+def test_onion_preserves_clean_text(onion):
+    """With no outlier to flag, a fluent sentence keeps its content words."""
+    clean = "the film was genuinely moving and beautifully acted"
+    purified = onion.purify_text(clean)
+    # Purification of clean text should not strip its salient content.
+    assert "film" in purified.split()
+    assert "moving" in purified.split()
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(120)
+def test_onion_falls_back_to_original_when_purification_empties(onion):
+    """A threshold so low every word is removed must not yield an empty string.
+
+    ``purify_text`` returns the original (stripped) text rather than an empty input,
+    so the victim always receives something to classify.
+    """
+    onion.threshold = -1e9  # remove every word
+    text = "a genuinely wonderful film"
+    assert onion.purify_text(text) == text
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(120)
 def test_onion_purify_round_trips_dataset(onion, tiny_text_dataset):
     max_len = tiny_text_dataset.tensors[0].shape[1]
     purified = onion.purify(tiny_text_dataset)

--- a/tests/poisoning/test_text_backdoor_integration.py
+++ b/tests/poisoning/test_text_backdoor_integration.py
@@ -1,0 +1,101 @@
+"""End-to-end integration wiring for the text-backdoor pipeline.
+
+These train tiny random-init LoRA victims for a few steps on CPU, so they are marked
+``integration`` and time-bounded. They assert the pipeline runs and returns the right
+types/ranges (finite ASR in [0, 100]; a valid privacy budget), not efficacy numbers.
+"""
+
+import math
+
+import pytest
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from amulet.poisoning.attacks import TextBadNets
+from amulet.utils import get_accuracy, train_classifier
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(180)
+def test_poison_train_and_measure_asr(
+    tiny_text_classifier, tiny_text_dataset, cpu_device
+):
+    """poison -> LoRA-train a few steps -> compute ASR via get_accuracy."""
+    attack = TextBadNets(trigger="cf", trigger_label=1, portion=0.5, random_seed=0)
+    poisoned_train = attack.poison_train(tiny_text_dataset)
+    poisoned_test = attack.poison_test(tiny_text_dataset)
+
+    train_loader = DataLoader(poisoned_train, batch_size=2, shuffle=True)
+    asr_loader = DataLoader(poisoned_test, batch_size=2)
+
+    criterion = torch.nn.CrossEntropyLoss()
+    optimizer = torch.optim.Adam(tiny_text_classifier.trainable_parameters(), lr=1e-3)
+    model = train_classifier(
+        tiny_text_classifier, train_loader, criterion, optimizer, 3, cpu_device
+    )
+
+    # ASR is get_accuracy on the fully-triggered test set against trigger_label.
+    asr = get_accuracy(model, asr_loader, cpu_device)
+    assert math.isfinite(asr)
+    assert 0.0 <= asr <= 100.0
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(180)
+def test_dpsgd_runs_one_epoch_on_lora_victim(
+    tiny_text_classifier, tiny_text_dataset, cpu_device
+):
+    """The reused DPSGD defense drives the single-tensor LoRA victim end-to-end."""
+    from amulet.membership_inference.defenses import DPSGD
+
+    attack = TextBadNets(trigger="cf", trigger_label=1, portion=0.5, random_seed=0)
+    poisoned_train = attack.poison_train(tiny_text_dataset)
+    # batch_size == len keeps the Poisson sample rate at 1.0, so Opacus never emits an
+    # empty batch on this tiny set.
+    loader = DataLoader(poisoned_train, batch_size=len(poisoned_train))
+
+    optimizer = torch.optim.Adam(tiny_text_classifier.trainable_parameters(), lr=1e-3)
+    defense = DPSGD(
+        model=tiny_text_classifier,
+        criterion=torch.nn.CrossEntropyLoss(),
+        optimizer=optimizer,
+        train_loader=loader,
+        device=cpu_device,
+        delta=1e-5,
+        max_per_sample_grad_norm=1.0,
+        sigma=1.0,
+        epochs=1,
+    )
+    trained = defense.train_private()
+
+    assert isinstance(trained, torch.nn.Module)
+    assert hasattr(trained, "_module")  # wrapped in an Opacus GradSampleModule
+    epsilon = defense.privacy_engine.accountant.get_epsilon(delta=1e-5)
+    assert epsilon > 0
+    assert math.isfinite(epsilon)
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(120)
+def test_victim_forward_is_single_tensor_bare_logits(
+    tiny_text_classifier, tiny_text_dataset, cpu_device
+):
+    """The DPSGD/get_accuracy contract: one input tensor in, a bare logits tensor out."""
+    loader = DataLoader(tiny_text_dataset, batch_size=2)
+    input_ids, _ = next(iter(loader))
+    output = tiny_text_classifier(input_ids.to(cpu_device))
+    assert isinstance(output, torch.Tensor)
+    assert output.shape == (2, 2)
+    # get_hidden pools to one vector per row.
+    hidden = tiny_text_classifier.get_hidden(input_ids.to(cpu_device))
+    assert hidden.shape[0] == 2
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(120)
+def test_text_badnets_rejects_non_text_dataset():
+    """TextBadNets needs the raw `.texts`, so a plain TensorDataset is rejected."""
+    attack = TextBadNets(trigger="cf", trigger_label=1, portion=0.5, random_seed=0)
+    plain = TensorDataset(torch.zeros(2, 4, dtype=torch.long), torch.zeros(2))
+    with pytest.raises(TypeError):
+        attack.poison_train(plain)  # type: ignore[arg-type]

--- a/tests/poisoning/test_text_backdoor_integration.py
+++ b/tests/poisoning/test_text_backdoor_integration.py
@@ -1,8 +1,9 @@
-"""End-to-end integration wiring for the text-backdoor pipeline.
+"""End-to-end integration for the text-backdoor pipeline.
 
-These train tiny random-init LoRA victims for a few steps on CPU, so they are marked
-``integration`` and time-bounded. They assert the pipeline runs and returns the right
-types/ranges (finite ASR in [0, 100]; a valid privacy budget), not efficacy numbers.
+These build tiny random-init LoRA victims and train them a few steps on CPU, so they are
+marked ``integration`` and time-bounded. The north star is that the pipeline runs and
+reproduces (same seed -> same result); the overfit test guards that the victim can learn
+at all (gradients reach the LoRA adapters and the classification head).
 """
 
 import math
@@ -15,29 +16,68 @@ from amulet.poisoning.attacks import TextBadNets
 from amulet.utils import get_accuracy, train_classifier
 
 
+def _state_dicts_equal(a: dict, b: dict) -> bool:
+    return a.keys() == b.keys() and all(torch.equal(a[k], b[k]) for k in a)
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(120)
+def test_lora_victim_overfits_single_batch(tiny_text_classifier, tiny_text_dataset):
+    """The victim can memorize one tiny batch: proof gradients reach LoRA + the head.
+
+    A plateauing loss would mean broken gradient flow (frozen adapters, an untrained
+    head, a wrong loss reduction). This is the load-bearing "does it learn" check.
+    """
+    input_ids, labels = tiny_text_dataset.tensors
+    model = tiny_text_classifier
+    model.train()
+    optimizer = torch.optim.Adam(model.trainable_parameters(), lr=1e-2)
+    criterion = torch.nn.CrossEntropyLoss()
+
+    initial = criterion(model(input_ids), labels).item()
+    for _ in range(100):
+        optimizer.zero_grad()
+        criterion(model(input_ids), labels).backward()
+        optimizer.step()
+    final = criterion(model(input_ids), labels).item()
+
+    assert final < initial * 0.1
+
+
 @pytest.mark.integration
 @pytest.mark.timeout(180)
-def test_poison_train_and_measure_asr(
-    tiny_text_classifier, tiny_text_dataset, cpu_device
+def test_text_backdoor_pipeline_runs_and_reproduces(
+    tiny_text_classifier_factory, tiny_text_dataset, cpu_device
 ):
-    """poison -> LoRA-train a few steps -> compute ASR via get_accuracy."""
+    """North star: poison -> train -> measure ASR runs, and a seeded rerun matches.
+
+    Trains on the poisoned set and computes ASR as ``get_accuracy`` on the fully
+    triggered test set against ``trigger_label`` (the pipeline's real metric path). The
+    artifact is sane (ASR finite, in [0, 100]) and bit-reproducible on CPU with a fixed
+    seed and an unshuffled loader.
+    """
     attack = TextBadNets(trigger="cf", trigger_label=1, portion=0.5, random_seed=0)
     poisoned_train = attack.poison_train(tiny_text_dataset)
     poisoned_test = attack.poison_test(tiny_text_dataset)
 
-    train_loader = DataLoader(poisoned_train, batch_size=2, shuffle=True)
-    asr_loader = DataLoader(poisoned_test, batch_size=2)
+    def run() -> tuple[dict, float]:
+        model = tiny_text_classifier_factory(seed=0)
+        optimizer = torch.optim.Adam(model.trainable_parameters(), lr=1e-3)
+        criterion = torch.nn.CrossEntropyLoss()
+        train_loader = DataLoader(poisoned_train, batch_size=2, shuffle=False)
+        model = train_classifier(
+            model, train_loader, criterion, optimizer, 3, cpu_device
+        )
+        asr = get_accuracy(model, DataLoader(poisoned_test, batch_size=2), cpu_device)
+        return model.state_dict(), asr
 
-    criterion = torch.nn.CrossEntropyLoss()
-    optimizer = torch.optim.Adam(tiny_text_classifier.trainable_parameters(), lr=1e-3)
-    model = train_classifier(
-        tiny_text_classifier, train_loader, criterion, optimizer, 3, cpu_device
-    )
+    state_a, asr_a = run()
+    state_b, asr_b = run()
 
-    # ASR is get_accuracy on the fully-triggered test set against trigger_label.
-    asr = get_accuracy(model, asr_loader, cpu_device)
-    assert math.isfinite(asr)
-    assert 0.0 <= asr <= 100.0
+    assert math.isfinite(asr_a)
+    assert 0.0 <= asr_a <= 100.0
+    assert _state_dicts_equal(state_a, state_b)
+    assert asr_a == asr_b
 
 
 @pytest.mark.integration
@@ -77,17 +117,25 @@ def test_dpsgd_runs_one_epoch_on_lora_victim(
 
 @pytest.mark.integration
 @pytest.mark.timeout(120)
-def test_victim_forward_is_single_tensor_bare_logits(
-    tiny_text_classifier, tiny_text_dataset, cpu_device
-):
-    """The DPSGD/get_accuracy contract: one input tensor in, a bare logits tensor out."""
-    loader = DataLoader(tiny_text_dataset, batch_size=2)
-    input_ids, _ = next(iter(loader))
-    output = tiny_text_classifier(input_ids.to(cpu_device))
+def test_victim_forward_returns_bare_logits(tiny_text_classifier, tiny_text_dataset):
+    """The DPSGD/get_accuracy contract: one input tensor in, a bare logits tensor out.
+
+    Returning the raw ``(batch, num_labels)`` tensor (not ``SequenceClassifierOutput``)
+    is what lets ``torch.max(output, 1)`` in those loops work unchanged.
+    """
+    input_ids = tiny_text_dataset.tensors[0][:2]
+    output = tiny_text_classifier(input_ids)
     assert isinstance(output, torch.Tensor)
     assert output.shape == (2, 2)
-    # get_hidden pools to one vector per row.
-    hidden = tiny_text_classifier.get_hidden(input_ids.to(cpu_device))
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(120)
+def test_victim_get_hidden_pools_per_row(tiny_text_classifier, tiny_text_dataset):
+    """get_hidden returns one pooled hidden vector per input row."""
+    input_ids = tiny_text_dataset.tensors[0][:2]
+    hidden = tiny_text_classifier.get_hidden(input_ids)
+    assert hidden.dim() == 2
     assert hidden.shape[0] == 2
 
 

--- a/tests/poisoning/test_text_badnets.py
+++ b/tests/poisoning/test_text_badnets.py
@@ -29,14 +29,12 @@ def _attack(insert_position: str = "start", **kwargs) -> TextBadNets:
 # --- Pure string-space transform: no tokenizer, always runs ---------------------------
 
 
-def test_poison_text_start_prepends_trigger():
-    attack = _attack("start")
-    assert attack.poison_text("a good movie") == "cf a good movie"
-
-
-def test_poison_text_end_appends_trigger():
-    attack = _attack("end")
-    assert attack.poison_text("a good movie") == "a good movie cf"
+@pytest.mark.parametrize(
+    "position, expected",
+    [("start", "cf a good movie"), ("end", "a good movie cf")],
+)
+def test_poison_text_inserts_trigger_at_position(position, expected):
+    assert _attack(position).poison_text("a good movie") == expected
 
 
 def test_poison_text_random_inserts_trigger_deterministically():
@@ -57,6 +55,37 @@ def test_poison_text_random_inserts_trigger_deterministically():
 def test_invalid_insert_position_raises():
     with pytest.raises(ValueError):
         _attack("middle")
+
+
+# --- Poison-index selection: pure, no tokenizer, runs in the fast tier ----------------
+# poison_train/test re-tokenize (needing the llm extra), but the row-selection logic is a
+# pure function of labels + seed, so it is guarded here without a tokenizer.
+
+_LABELS = [1, 0, 1, 0, 0, 1, 0, 0]  # 3 target (label 1), 5 non-target (label 0)
+
+
+def test_select_poison_indices_only_picks_non_target_rows():
+    selected = _attack(portion=0.5).select_poison_indices(_LABELS, len(_LABELS))
+    assert all(_LABELS[i] != 1 for i in selected)
+
+
+@pytest.mark.parametrize(
+    "portion, expected",
+    [
+        (0.0, 0),  # nothing requested
+        (0.5, 4),  # int(8 * 0.5) = 4, and 5 non-target rows exist
+        (1.0, 5),  # int(8 * 1.0) = 8, capped by the 5 non-target rows
+    ],
+)
+def test_select_poison_indices_count_capped_by_non_target(portion, expected):
+    selected = _attack(portion=portion).select_poison_indices(_LABELS, len(_LABELS))
+    assert len(selected) == expected
+
+
+def test_select_poison_indices_is_deterministic():
+    a = _attack(portion=0.5).select_poison_indices(_LABELS, len(_LABELS))
+    b = _attack(portion=0.5).select_poison_indices(_LABELS, len(_LABELS))
+    assert a == b
 
 
 # --- poison_train / poison_test: need the tokenizer (skips offline if unavailable) ----

--- a/tests/poisoning/test_text_badnets.py
+++ b/tests/poisoning/test_text_badnets.py
@@ -1,0 +1,122 @@
+"""Exactness tests for the TextBadNets textual backdoor poisoning attack.
+
+Like the image BadNets, TextBadNets is a mechanical, deterministic transform: it inserts
+a trigger phrase in string space and flips labels to trigger_label. The string-space
+``poison_text`` needs no tokenizer and is asserted exactly here. The ``poison_train`` /
+``poison_test`` tests additionally tokenize, so they use the ``tiny_text_dataset`` fixture
+(which skips when the tokenizer is unavailable offline).
+"""
+
+import pytest
+import torch
+
+from amulet.datasets import TextTensorDataset
+from amulet.poisoning.attacks import TextBadNets
+
+
+def _attack(insert_position: str = "start", **kwargs) -> TextBadNets:
+    params = {
+        "trigger": "cf",
+        "trigger_label": 1,
+        "portion": 0.5,
+        "random_seed": 42,
+        "insert_position": insert_position,
+    }
+    params.update(kwargs)
+    return TextBadNets(**params)  # type: ignore[arg-type]
+
+
+# --- Pure string-space transform: no tokenizer, always runs ---------------------------
+
+
+def test_poison_text_start_prepends_trigger():
+    attack = _attack("start")
+    assert attack.poison_text("a good movie") == "cf a good movie"
+
+
+def test_poison_text_end_appends_trigger():
+    attack = _attack("end")
+    assert attack.poison_text("a good movie") == "a good movie cf"
+
+
+def test_poison_text_random_inserts_trigger_deterministically():
+    attack = _attack("random", trigger="XX")
+    sentence = "the movie was really quite good indeed"
+    first = attack.poison_text(sentence)
+    second = attack.poison_text(sentence)
+    # Pure and reproducible: same input + seed -> same output.
+    assert first == second
+    # The trigger is inserted as its own word, not at an end.
+    words = first.split()
+    assert "XX" in words
+    assert words[0] != "XX" and words[-1] != "XX"
+    # Every original word is preserved, in order.
+    assert [w for w in words if w != "XX"] == sentence.split()
+
+
+def test_invalid_insert_position_raises():
+    with pytest.raises(ValueError):
+        _attack("middle")
+
+
+# --- poison_train / poison_test: need the tokenizer (skips offline if unavailable) ----
+
+
+def test_poison_train_relabels_and_triggers_selected_rows(tiny_text_dataset):
+    attack = _attack("start", portion=0.5)
+    poisoned = attack.poison_train(tiny_text_dataset)
+
+    assert isinstance(poisoned, TextTensorDataset)
+    assert len(poisoned) == len(tiny_text_dataset)
+
+    # trigger_label=1, portion=0.5 over 4 rows -> target 2, and exactly the 2 non-target
+    # (label 0) rows exist, so both are poisoned.
+    triggered = [i for i, t in enumerate(poisoned.texts) if t.startswith("cf ")]
+    assert len(triggered) == 2
+    for i in triggered:
+        assert poisoned[i][1].item() == 1
+        assert int(tiny_text_dataset[i][1].item()) == 0
+
+
+def test_poison_train_leaves_clean_rows_unchanged(tiny_text_dataset):
+    attack = _attack("start", portion=0.5)
+    poisoned = attack.poison_train(tiny_text_dataset)
+
+    for i in range(len(tiny_text_dataset)):
+        if not poisoned.texts[i].startswith("cf "):
+            assert poisoned.texts[i] == tiny_text_dataset.texts[i]
+            assert poisoned[i][1].item() == int(tiny_text_dataset[i][1].item())
+            assert torch.equal(poisoned[i][0], tiny_text_dataset[i][0])
+
+
+def test_poison_train_is_reproducible(tiny_text_dataset):
+    run_a = _attack("start", portion=0.5).poison_train(tiny_text_dataset)
+    run_b = _attack("start", portion=0.5).poison_train(tiny_text_dataset)
+
+    assert run_a.texts == run_b.texts
+    assert torch.equal(run_a.tensors[0], run_b.tensors[0])
+    assert torch.equal(run_a.tensors[1], run_b.tensors[1])
+
+
+def test_poison_train_returns_padded_text_tensor_dataset(tiny_text_dataset):
+    attack = _attack("start", portion=0.5)
+    poisoned = attack.poison_train(tiny_text_dataset)
+
+    max_len = tiny_text_dataset.tensors[0].shape[1]
+    assert poisoned.tensors[0].shape == (len(tiny_text_dataset), max_len)
+    assert poisoned.tensors[0].dtype == torch.int64
+    assert poisoned.tokenizer_name == tiny_text_dataset.tokenizer_name
+
+
+def test_poison_test_triggers_every_non_target_row(tiny_text_dataset):
+    attack = _attack("start", portion=1.0)
+    poisoned = attack.poison_test(tiny_text_dataset)
+
+    num_non_target = sum(
+        1
+        for i in range(len(tiny_text_dataset))
+        if int(tiny_text_dataset[i][1].item()) != 1
+    )
+    assert len(poisoned) == num_non_target
+    assert all(t.startswith("cf ") for t in poisoned.texts)
+    assert all(poisoned[i][1].item() == 1 for i in range(len(poisoned)))

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,18 @@
 version = 1
 revision = 3
 requires-python = "==3.11.*"
+resolution-markers = [
+    "extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130'",
+    "extra != 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130'",
+    "sys_platform != 'darwin' and extra == 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130'",
+    "sys_platform == 'darwin' and extra == 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130'",
+    "extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130'",
+]
+conflicts = [[
+    { package = "amuletml", extra = "cpu" },
+    { package = "amuletml", extra = "cu128" },
+    { package = "amuletml", extra = "cu130" },
+]]
 
 [[package]]
 name = "absl-py"
@@ -12,8 +24,88 @@ wheels = [
 ]
 
 [[package]]
+name = "accelerate"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra != 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/75/94cd5d389649578aca399e5aa822637eec18319a1dadc400ffe2f9a7493f/accelerate-1.14.0.tar.gz", hash = "sha256:41b9c4377a54e0b460a959b0defa1b736e4ca0a2373252d9a539964c2afe3c8d", size = 412167, upload-time = "2026-06-11T13:45:52.326Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/db/253133d7e7cb40d3af384bb2f5c0b4a2b7fdcffbc95c688cc67a20a3c103/accelerate-1.14.0-py3-none-any.whl", hash = "sha256:e94390c2863b873be18f623f9df48a0d8fe5eff13ea7f1a00092b0a7904888c6", size = 389246, upload-time = "2026-06-11T13:45:50.477Z" },
+]
+
+[[package]]
+name = "aiohappyeyeballs"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/f4/eec0465c2f67b2664688d0240b3212d5196fd89e741df67ddb81f8d35658/aiohappyeyeballs-2.7.1.tar.gz", hash = "sha256:065665c041c42a5938ed220bdcd7230f22527fbec085e1853d2402c8a3615d9d", size = 24757, upload-time = "2026-07-01T17:11:55.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl", hash = "sha256:9243213661e29250eb41368e5daa826fc017156c3b8a11440826b2e3ed376472", size = 15038, upload-time = "2026-07-01T17:11:54.055Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "typing-extensions" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/dd/bf526e6f0a1120dd6f2df2e97bacfe4d358f13d17a0ff5847301a1375a51/aiohttp-3.14.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:aa00140699487bd435fde4342d85c94cb256b7cd3a5b9c3396c67f19922afda2", size = 765225, upload-time = "2026-06-07T21:06:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e1/a2872aa55495a70f61310d411541c6ee23812d9a884e000c716e1bc3edbf/aiohttp-3.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1c1af67559445498b502030c35c59db59966f47041ca9de5b4e707f86bd10b5f", size = 518743, upload-time = "2026-06-07T21:06:09.749Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e7/c60c7b209e509cc787de3cea0550a518538cfc08003e1c1e14c1c63fff71/aiohttp-3.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d44ec478e713ee7f29b439f7eb8dc2b9d4079e11ae114d2c2ac3d5daf30516c8", size = 514139, upload-time = "2026-06-07T21:06:11.26Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/8d/614ace2f579702c9840ab1e1447fd8509e35b0b904f7196418fa2f57b25d/aiohttp-3.14.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d3b1a184a9a8f548a6b73f1e26b96b052193e4b3175ed7342aaf1151a1f00a04", size = 1784088, upload-time = "2026-06-07T21:06:12.887Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e0/726e90f99542bf292f81a96a12cc4847deb86f3ccf62c6f4014a201f4d33/aiohttp-3.14.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5f2504bc0322437c9a1ff6d3333ca56c7477b727c995f036b976ae17b98372c8", size = 1737835, upload-time = "2026-06-07T21:06:14.564Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/4b/d176d5c4db9d33dacf0543102ea59503bc1d528af4cfd0b719949ca49389/aiohttp-3.14.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:73f05ea02013e02512c3bf42714f1208c57168c779cc6fe23516e4543089d0a6", size = 1842801, upload-time = "2026-06-07T21:06:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/d6/5a99b563690ea0cbed912ae94a2ce33993a5709a651a3a4fe761e7dd973a/aiohttp-3.14.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:797457503c2d426bee06eef808d07b31ede30b65e054444e7de64cad0061b7af", size = 1929992, upload-time = "2026-06-07T21:06:17.947Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7f/a987b14a3859094b3cea3f4825219c3e5536242564af6e3f9c2f6c994eb2/aiohttp-3.14.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b821a1f7dedf7e37450654e620038ac3b2e81e8fa6ea269337e97101978ec730", size = 1786989, upload-time = "2026-06-07T21:06:19.677Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/1a/420e5c85a3e73349372ed22ce0b6af86bfa6ce16a4b20a64a2e94608c781/aiohttp-3.14.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4cd96b5ba05d67ed0cf00b5b405c8cd99586d8e3481e8ee0a831057591af7621", size = 1640129, upload-time = "2026-06-07T21:06:22.558Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/80/18a592ed3be0a402cc03670bd72ee1f8563ddbe1d8d5542dbf868f274136/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d459b98a932296c6f0e94f87511a0b1b90a8a02c30a50e60a297619cd5a58ee", size = 1756576, upload-time = "2026-06-07T21:06:24.8Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0b/8b3d5713373858ff71a617daf6e3b0e81ad63e79d09a3cf2f6b6b983939c/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:764457a7be60825fb770a644852ff717bcbb5042f189f2bd16df61a81b3f6573", size = 1754668, upload-time = "2026-06-07T21:06:26.528Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/49/fd564575cf225821d7ba5a117cb8bc27213d8a7e1811162afb43ae077039/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f7a16ef45b081454ef844502d87a848876c490c4cb5c650c230f6ec79ed2c1e7", size = 1817019, upload-time = "2026-06-07T21:06:28.297Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/e850c9ae6fc91356552ae668bb6c51e93fa29c8aef13398a10b56678557f/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:2fbc3ed048b3475b9f0cbcb9978e9d2d3511acd91ead203af26ed9f0056004cf", size = 1631638, upload-time = "2026-06-07T21:06:30.242Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/94/3c337ba72451a89806ace6f75bddc92bafc5b8d53d90115a512858024b63/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:bedb0cd073cc2dc035e30aeb99444389d3cd2113afe4ef9fcd23d439f5bade85", size = 1835660, upload-time = "2026-06-07T21:06:31.943Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9c/9c18cf367a0498212d9ba7daf990b504a5e8ae064cda4b504e2647c89c03/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b6feea921016eb3d4e04d65fc4e9ca402d1a3801f562aef94989f54694917af3", size = 1775698, upload-time = "2026-06-07T21:06:33.72Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/63/a251a9d2a6cb45065b2ddc0bde2b3dd10108740a9a42f632c66405a761a2/aiohttp-3.14.1-cp311-cp311-win32.whl", hash = "sha256:313701e488100074ce99850404ee36e741abf6330179fec908a1944ecf570126", size = 458386, upload-time = "2026-06-07T21:06:35.279Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ca/69274c51dcd6e8947d77b2806cf47a4a15f2c846e2cbeb1882547d3da283/aiohttp-3.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:03ab4530fdcb3a543a122ba4b65ac9919da9fe9f78a03d328a6e38ff962f7aa5", size = 483406, upload-time = "2026-06-07T21:06:36.824Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8a/c25904f77690c3688ec140f87591ef11a0cfe36bf3d5c0f1f38056fb62b3/aiohttp-3.14.1-cp311-cp311-win_arm64.whl", hash = "sha256:486f7d16ed54c39c2cbd7ca71fd8ba2b8bb7860df65bd7b6ed640bab96a38a8b", size = 452987, upload-time = "2026-06-07T21:06:38.371Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
 name = "amuletml"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "captum" },
@@ -26,13 +118,35 @@ dependencies = [
     { name = "scikit-image" },
     { name = "scikit-learn" },
     { name = "scipy" },
-    { name = "torch" },
-    { name = "torchvision" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra != 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torchvision", version = "0.26.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torchvision", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130')" },
+    { name = "torchvision", version = "0.26.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torchvision", version = "0.26.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra != 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
     { name = "tqdm" },
     { name = "wget" },
 ]
 
 [package.optional-dependencies]
+cpu = [
+    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torchvision", version = "0.26.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torchvision", version = "0.26.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+]
+cu128 = [
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
+    { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
+]
+cu130 = [
+    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
+    { name = "torchvision", version = "0.26.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
+]
 dev = [
     { name = "basedpyright" },
     { name = "pre-commit" },
@@ -40,6 +154,12 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-timeout" },
     { name = "ruff" },
+]
+llm = [
+    { name = "accelerate" },
+    { name = "datasets" },
+    { name = "peft" },
+    { name = "transformers" },
 ]
 
 [package.dev-dependencies]
@@ -49,14 +169,17 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "accelerate", marker = "extra == 'llm'", specifier = "==1.14.0" },
     { name = "basedpyright", marker = "extra == 'dev'", specifier = "==1.12.5" },
     { name = "captum", specifier = "==0.7.0" },
     { name = "cleverhans", specifier = "==4.0.0" },
+    { name = "datasets", marker = "extra == 'llm'", specifier = "==5.0.0" },
     { name = "gdown", specifier = "==5.2.2" },
     { name = "matplotlib", specifier = "==3.8.3" },
     { name = "numpy", specifier = "==1.26.4" },
     { name = "opacus", specifier = "==1.4.1" },
     { name = "pandas", specifier = "==2.2.1" },
+    { name = "peft", marker = "extra == 'llm'", specifier = "==0.19.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "==3.7.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = "==3.15.1" },
@@ -66,14 +189,43 @@ requires-dist = [
     { name = "scikit-learn", specifier = "==1.8.0" },
     { name = "scipy", specifier = "==1.12.0" },
     { name = "torch", specifier = ">=2.3.0" },
+    { name = "torch", marker = "extra == 'cpu'", specifier = "==2.11.0", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "amuletml", extra = "cpu" } },
+    { name = "torch", marker = "extra == 'cu128'", specifier = "==2.11.0", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "amuletml", extra = "cu128" } },
+    { name = "torch", marker = "extra == 'cu130'", specifier = "==2.11.0", index = "https://download.pytorch.org/whl/cu130", conflict = { package = "amuletml", extra = "cu130" } },
     { name = "torchvision", specifier = ">=0.18.0" },
+    { name = "torchvision", marker = "extra == 'cpu'", specifier = "==0.26.0", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "amuletml", extra = "cpu" } },
+    { name = "torchvision", marker = "extra == 'cu128'", specifier = "==0.26.0", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "amuletml", extra = "cu128" } },
+    { name = "torchvision", marker = "extra == 'cu130'", specifier = "==0.26.0", index = "https://download.pytorch.org/whl/cu130", conflict = { package = "amuletml", extra = "cu130" } },
     { name = "tqdm", specifier = "==4.67.3" },
+    { name = "transformers", marker = "extra == 'llm'", specifier = "==5.13.0" },
     { name = "wget", specifier = "==3.2.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["cpu", "cu128", "cu130", "llm", "dev"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest-cov", specifier = ">=7.1.0" }]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
+]
 
 [[package]]
 name = "attrs"
@@ -116,7 +268,11 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "matplotlib" },
     { name = "numpy" },
-    { name = "torch" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra != 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
     { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/0b/db1c79ae2496bf61d10d3439e85321d3df3cefc7a9960347f38722049872/captum-0.7.0.tar.gz", hash = "sha256:7ca87d0dc67b3b7589a730b970b9536172a5468e0e31bf8657fdd73abc568a33", size = 1237972, upload-time = "2023-12-05T08:32:07.126Z" }
@@ -186,6 +342,18 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/79/f38566e267414a707846655ee959d9c26b9bf2a139384144b905abbdda01/cleverhans-4.0.0-py3-none-any.whl", hash = "sha256:1af6c8594801a58ce9e73babb332cdd6e1dbda4ea00557abc5f479fc5441a704", size = 92267, upload-time = "2021-07-24T08:53:21.653Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -259,7 +427,20 @@ wheels = [
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11'" },
+    { name = "tomli", marker = "python_full_version <= '3.11' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+]
+
+[[package]]
+name = "cuda-bindings"
+version = "12.9.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder", marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/f3/f9d1095f90d2a4df24cfcafe7487fd9444c6dacb94e3722be6fedd8ac26c/cuda_bindings-12.9.7-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16043ef5b15ab88fe9954c5c2061b1d8007591b27f2c916331056de0ebc6187e", size = 7114834, upload-time = "2026-05-27T18:44:07.746Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8a/1251e1794b69865aacd5629936006b18ea0816a495de4ecea9a825556eb3/cuda_bindings-12.9.7-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c6496a88d84b1209d6651b0370c19c26319e157c22f6d018bf9a358cd8049041", size = 7647147, upload-time = "2026-05-27T18:44:09.4Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/39/158392f6572e6e0def70ca39029c46b75e02ea4a43c63ff7320b3d180a29/cuda_bindings-12.9.7-cp311-cp311-win_amd64.whl", hash = "sha256:c392ffa5010ef4073bfd9dfff4d1ae56032094ed52d3d732014f8e41a73e6b59", size = 7218081, upload-time = "2026-05-27T18:44:11.104Z" },
 ]
 
 [[package]]
@@ -272,14 +453,58 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
     { url = "https://files.pythonhosted.org/packages/95/7a/c5e3c34a409b148f5c0f5a4ea374158f95d488862c1dffedf9aa5c639df9/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04436a9364059c84b8f9636f359eccda1cf814341f5b670c71d80d2f79dbc708", size = 6674166, upload-time = "2026-05-29T23:11:45.478Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f7/0e35987a21914f84068061dcf4b61466ccbce1c62ddc9727596d5ed0c26f/cuda_bindings-13.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:507b0e19e7f934c5e30f30f0244ad70a75812619a7d3a0d742543caae1bd50f1", size = 5664286, upload-time = "2026-05-29T23:11:47.719Z" },
 ]
 
 [[package]]
 name = "cuda-pathfinder"
-version = "1.4.3"
+version = "1.5.6"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/59/911a1a597264f1fb7ac176995a0f0b6062e37f8c1b6e0f23071a76838507/cuda_pathfinder-1.4.3-py3-none-any.whl", hash = "sha256:4345d8ead1f701c4fb8a99be6bc1843a7348b6ba0ef3b031f5a2d66fb128ae4c", size = 47951, upload-time = "2026-03-16T21:31:25.526Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8fc9b0cdc5b7f62746e6a01b85b6461e5ae27f871010a5fcf8fa6950766d/cuda_pathfinder-1.5.6-py3-none-any.whl", hash = "sha256:7e4c07c117b78ba1fb35dac4c444d21f3677b1b1ff56175c53a8e3025c5b43c0", size = 52972, upload-time = "2026-06-30T00:58:04.34Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "12.8.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/c8/7dce3a0b15b42a3b58e7d96eb22a687d3bf2c44e01d149a6874629cd9938/cuda_toolkit-12.8.1-py2.py3-none-any.whl", hash = "sha256:adc7906af4ecbf9a352f9dca5734eceb21daec281ccfcf5675e1d2f724fc2cba", size = 2283, upload-time = "2025-08-13T02:03:07.842Z" },
+]
+
+[package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+cudart = [
+    { name = "nvidia-cuda-runtime-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+cufft = [
+    { name = "nvidia-cufft-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+cufile = [
+    { name = "nvidia-cufile-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+curand = [
+    { name = "nvidia-curand-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+cusolver = [
+    { name = "nvidia-cusolver-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+cusparse = [
+    { name = "nvidia-cusparse-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+nvtx = [
+    { name = "nvidia-nvtx-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
 ]
 
 [[package]]
@@ -291,35 +516,38 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "(sys_platform == 'linux' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime", marker = "(sys_platform == 'linux' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft", marker = "(sys_platform == 'linux' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile", marker = "(sys_platform == 'linux' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti", marker = "(sys_platform == 'linux' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand", marker = "(sys_platform == 'linux' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver", marker = "(sys_platform == 'linux' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse", marker = "(sys_platform == 'linux' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "(sys_platform == 'linux' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(sys_platform == 'linux' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx", marker = "(sys_platform == 'linux' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (sys_platform == 'win32' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
 ]
 
 [[package]]
@@ -332,12 +560,46 @@ wheels = [
 ]
 
 [[package]]
+name = "datasets"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+    { name = "filelock" },
+    { name = "fsspec", extra = ["http"] },
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "multiprocess" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/85/ce4f780c32f7e36d71257f1c27e8ba898ebe379cb54f211f5f2013f2c219/datasets-5.0.0.tar.gz", hash = "sha256:83dbbbdb07a33b82192b8c419deb18739b138ee2ce1a322d55ce6b100954ec1a", size = 631708, upload-time = "2026-06-05T13:18:26.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/66/73034ad30b59f13439b75e620989dacba4c047256e358ba7c2e9ec98ea22/datasets-5.0.0-py3-none-any.whl", hash = "sha256:7dd34927a0fd7046e98aad5cb9430e699c373238a15befa7b9bf22b991a7fee6", size = 555084, upload-time = "2026-06-05T13:18:24.435Z" },
+]
+
+[[package]]
 name = "decorator"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
+]
+
+[[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
 ]
 
 [[package]]
@@ -403,12 +665,42 @@ wheels = [
 ]
 
 [[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/03/077f869d540370db12165c0aa51640a873fb661d8b315d1d4d67b284d7ac/frozenlist-1.8.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:09474e9831bc2b2199fad6da3c14c7b0fbdd377cce9d3d77131be28906cb7d84", size = 86912, upload-time = "2025-10-06T05:35:45.98Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b5/7610b6bd13e4ae77b96ba85abea1c8cb249683217ef09ac9e0ae93f25a91/frozenlist-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:17c883ab0ab67200b5f964d2b9ed6b00971917d5d8a92df149dc2c9779208ee9", size = 50046, upload-time = "2025-10-06T05:35:47.009Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ef/0e8f1fe32f8a53dd26bdd1f9347efe0778b0fddf62789ea683f4cc7d787d/frozenlist-1.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fa47e444b8ba08fffd1c18e8cdb9a75db1b6a27f17507522834ad13ed5922b93", size = 50119, upload-time = "2025-10-06T05:35:48.38Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b1/71a477adc7c36e5fb628245dfbdea2166feae310757dea848d02bd0689fd/frozenlist-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2552f44204b744fba866e573be4c1f9048d6a324dfe14475103fd51613eb1d1f", size = 231067, upload-time = "2025-10-06T05:35:49.97Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7e/afe40eca3a2dc19b9904c0f5d7edfe82b5304cb831391edec0ac04af94c2/frozenlist-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:957e7c38f250991e48a9a73e6423db1bb9dd14e722a10f6b8bb8e16a0f55f695", size = 233160, upload-time = "2025-10-06T05:35:51.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/aa/7416eac95603ce428679d273255ffc7c998d4132cfae200103f164b108aa/frozenlist-1.8.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8585e3bb2cdea02fc88ffa245069c36555557ad3609e83be0ec71f54fd4abb52", size = 228544, upload-time = "2025-10-06T05:35:53.246Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/3d/2a2d1f683d55ac7e3875e4263d28410063e738384d3adc294f5ff3d7105e/frozenlist-1.8.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:edee74874ce20a373d62dc28b0b18b93f645633c2943fd90ee9d898550770581", size = 243797, upload-time = "2025-10-06T05:35:54.497Z" },
+    { url = "https://files.pythonhosted.org/packages/78/1e/2d5565b589e580c296d3bb54da08d206e797d941a83a6fdea42af23be79c/frozenlist-1.8.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c9a63152fe95756b85f31186bddf42e4c02c6321207fd6601a1c89ebac4fe567", size = 247923, upload-time = "2025-10-06T05:35:55.861Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/c3/65872fcf1d326a7f101ad4d86285c403c87be7d832b7470b77f6d2ed5ddc/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b6db2185db9be0a04fecf2f241c70b63b1a242e2805be291855078f2b404dd6b", size = 230886, upload-time = "2025-10-06T05:35:57.399Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/76/ac9ced601d62f6956f03cc794f9e04c81719509f85255abf96e2510f4265/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f4be2e3d8bc8aabd566f8d5b8ba7ecc09249d74ba3c9ed52e54dc23a293f0b92", size = 245731, upload-time = "2025-10-06T05:35:58.563Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/49/ecccb5f2598daf0b4a1415497eba4c33c1e8ce07495eb07d2860c731b8d5/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:c8d1634419f39ea6f5c427ea2f90ca85126b54b50837f31497f3bf38266e853d", size = 241544, upload-time = "2025-10-06T05:35:59.719Z" },
+    { url = "https://files.pythonhosted.org/packages/53/4b/ddf24113323c0bbcc54cb38c8b8916f1da7165e07b8e24a717b4a12cbf10/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:1a7fa382a4a223773ed64242dbe1c9c326ec09457e6b8428efb4118c685c3dfd", size = 241806, upload-time = "2025-10-06T05:36:00.959Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/fb/9b9a084d73c67175484ba2789a59f8eebebd0827d186a8102005ce41e1ba/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:11847b53d722050808926e785df837353bd4d75f1d494377e59b23594d834967", size = 229382, upload-time = "2025-10-06T05:36:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a3/c8fb25aac55bf5e12dae5c5aa6a98f85d436c1dc658f21c3ac73f9fa95e5/frozenlist-1.8.0-cp311-cp311-win32.whl", hash = "sha256:27c6e8077956cf73eadd514be8fb04d77fc946a7fe9f7fe167648b0b9085cc25", size = 39647, upload-time = "2025-10-06T05:36:03.409Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/f5/603d0d6a02cfd4c8f2a095a54672b3cf967ad688a60fb9faf04fc4887f65/frozenlist-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:ac913f8403b36a2c8610bbfd25b8013488533e71e62b4b4adce9c86c8cea905b", size = 44064, upload-time = "2025-10-06T05:36:04.368Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/16/c2c9ab44e181f043a86f9a8f84d5124b62dbcb3a02c0977ec72b9ac1d3e0/frozenlist-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:d4d3214a0f8394edfa3e303136d0575eece0745ff2b47bd2cb2e66dd92d4351a", size = 39937, upload-time = "2025-10-06T05:36:05.669Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
 name = "fsspec"
 version = "2026.2.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
+]
+
+[package.optional-dependencies]
+http = [
+    { name = "aiohttp" },
 ]
 
 [[package]]
@@ -433,6 +725,79 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5d/e2/831920e510e3cce91627adab9997944b32842f7cd0dc4c023f24655531e0/gdown-5.2.2.tar.gz", hash = "sha256:a4bafbaa627d67bdaa68d274e9e957127ba810b4bcf4505e2b57ea45aa0aa1e6", size = 360218, upload-time = "2026-04-12T06:00:10.571Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/ad/0e30d078a2cc84a17a81c0a1f226d617edf12ddd375dafe021fb66a2c8b0/gdown-5.2.2-py3-none-any.whl", hash = "sha256:e1ed2638abb931668725c79298900629b31e20f02b7c55a2685e9249edb51e09", size = 18630, upload-time = "2026-04-12T06:00:08.346Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/8f/999e4dda11c6187c78f090eac00895a47e11a0049308f07579bcb7aa3aa2/huggingface_hub-1.23.0.tar.gz", hash = "sha256:c04997fb8bbdace1e57b7703d30ed7678af51f70d00d241819ff411b92ae9a88", size = 919163, upload-time = "2026-07-09T14:49:32.315Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/ce/13b2ba57838b8db1e6bd033c1b21ce0b9f6153b87d4e4939f77074e41eb0/huggingface_hub-1.23.0-py3-none-any.whl", hash = "sha256:b1d604788f5adc7f0eb246e03e0ec19011ca06e38400218c347dccc3dffa64a2", size = 770336, upload-time = "2026-07-09T14:49:30.597Z" },
 ]
 
 [[package]]
@@ -537,6 +902,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -581,6 +958,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "mnist"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -599,6 +985,50 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/f1/a90635c4f88fb913fbf4ce660b83b7445b7a02615bda034b2f8eb38fd597/multidict-6.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ff981b266af91d7b4b3793ca3382e53229088d193a85dfad6f5f4c27fc73e5d", size = 76626, upload-time = "2026-01-26T02:43:26.485Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/267e64eaf6fc637a15b35f5de31a566634a2740f97d8d094a69d34f524a4/multidict-6.7.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:844c5bca0b5444adb44a623fb0a1310c2f4cd41f402126bb269cd44c9b3f3e1e", size = 44706, upload-time = "2026-01-26T02:43:27.607Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a4/d45caf2b97b035c57267791ecfaafbd59c68212004b3842830954bb4b02e/multidict-6.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f2a0a924d4c2e9afcd7ec64f9de35fcd96915149b2216e1cb2c10a56df483855", size = 44356, upload-time = "2026-01-26T02:43:28.661Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d2/0a36c8473f0cbaeadd5db6c8b72d15bbceeec275807772bfcd059bef487d/multidict-6.7.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8be1802715a8e892c784c0197c2ace276ea52702a0ede98b6310c8f255a5afb3", size = 244355, upload-time = "2026-01-26T02:43:31.165Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/16/8c65be997fd7dd311b7d39c7b6e71a0cb449bad093761481eccbbe4b42a2/multidict-6.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e2d2ed645ea29f31c4c7ea1552fcfd7cb7ba656e1eafd4134a6620c9f5fdd9e", size = 246433, upload-time = "2026-01-26T02:43:32.581Z" },
+    { url = "https://files.pythonhosted.org/packages/01/fb/4dbd7e848d2799c6a026ec88ad39cf2b8416aa167fcc903baa55ecaa045c/multidict-6.7.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:95922cee9a778659e91db6497596435777bd25ed116701a4c034f8e46544955a", size = 225376, upload-time = "2026-01-26T02:43:34.417Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8a/4a3a6341eac3830f6053062f8fbc9a9e54407c80755b3f05bc427295c2d0/multidict-6.7.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6b83cabdc375ffaaa15edd97eb7c0c672ad788e2687004990074d7d6c9b140c8", size = 257365, upload-time = "2026-01-26T02:43:35.741Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a2/dd575a69c1aa206e12d27d0770cdf9b92434b48a9ef0cd0d1afdecaa93c4/multidict-6.7.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:38fb49540705369bab8484db0689d86c0a33a0a9f2c1b197f506b71b4b6c19b0", size = 254747, upload-time = "2026-01-26T02:43:36.976Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/56/21b27c560c13822ed93133f08aa6372c53a8e067f11fbed37b4adcdac922/multidict-6.7.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:439cbebd499f92e9aa6793016a8acaa161dfa749ae86d20960189f5398a19144", size = 246293, upload-time = "2026-01-26T02:43:38.258Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/23466059dc3854763423d0ad6c0f3683a379d97673b1b89ec33826e46728/multidict-6.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d3bc717b6fe763b8be3f2bee2701d3c8eb1b2a8ae9f60910f1b2860c82b6c49", size = 242962, upload-time = "2026-01-26T02:43:40.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/67/51dd754a3524d685958001e8fa20a0f5f90a6a856e0a9dcabff69be3dbb7/multidict-6.7.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:619e5a1ac57986dbfec9f0b301d865dddf763696435e2962f6d9cf2fdff2bb71", size = 237360, upload-time = "2026-01-26T02:43:41.752Z" },
+    { url = "https://files.pythonhosted.org/packages/64/3f/036dfc8c174934d4b55d86ff4f978e558b0e585cef70cfc1ad01adc6bf18/multidict-6.7.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0b38ebffd9be37c1170d33bc0f36f4f262e0a09bc1aac1c34c7aa51a7293f0b3", size = 245940, upload-time = "2026-01-26T02:43:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/20/6214d3c105928ebc353a1c644a6ef1408bc5794fcb4f170bb524a3c16311/multidict-6.7.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:10ae39c9cfe6adedcdb764f5e8411d4a92b055e35573a2eaa88d3323289ef93c", size = 253502, upload-time = "2026-01-26T02:43:44.371Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e2/c653bc4ae1be70a0f836b82172d643fcf1dade042ba2676ab08ec08bff0f/multidict-6.7.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:25167cc263257660290fba06b9318d2026e3c910be240a146e1f66dd114af2b0", size = 247065, upload-time = "2026-01-26T02:43:45.745Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/11/a854b4154cd3bd8b1fd375e8a8ca9d73be37610c361543d56f764109509b/multidict-6.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:128441d052254f42989ef98b7b6a6ecb1e6f708aa962c7984235316db59f50fa", size = 241870, upload-time = "2026-01-26T02:43:47.054Z" },
+    { url = "https://files.pythonhosted.org/packages/13/bf/9676c0392309b5fdae322333d22a829715b570edb9baa8016a517b55b558/multidict-6.7.1-cp311-cp311-win32.whl", hash = "sha256:d62b7f64ffde3b99d06b707a280db04fb3855b55f5a06df387236051d0668f4a", size = 41302, upload-time = "2026-01-26T02:43:48.753Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/68/f16a3a8ba6f7b6dc92a1f19669c0810bd2c43fc5a02da13b1cbf8e253845/multidict-6.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:bdbf9f3b332abd0cdb306e7c2113818ab1e922dc84b8f8fd06ec89ed2a19ab8b", size = 45981, upload-time = "2026-01-26T02:43:49.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/9dd5305253fa00cd3c7555dbef69d5bf4133debc53b87ab8d6a44d411665/multidict-6.7.1-cp311-cp311-win_arm64.whl", hash = "sha256:b8c990b037d2fff2f4e33d3f21b9b531c5745b33a49a7d6dbe7a177266af44f6", size = 43159, upload-time = "2026-01-26T02:43:51.635Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "multiprocess"
+version = "0.70.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f2/e783ac7f2aeeed14e9e12801f22529cc7e6b7ab80928d6dcce4e9f00922d/multiprocess-0.70.19.tar.gz", hash = "sha256:952021e0e6c55a4a9fe4cd787895b86e239a40e76802a789d6305398d3975897", size = 2079989, upload-time = "2026-01-19T06:47:39.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/aa/714635c727dbfc251139226fa4eaf1b07f00dc12d9cd2eb25f931adaf873/multiprocess-0.70.19-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:1bbf1b69af1cf64cd05f65337d9215b88079ec819cd0ea7bac4dab84e162efe7", size = 144743, upload-time = "2026-01-19T06:47:24.562Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e1/155f6abf5e6b5d9cef29b6d0167c180846157a4aca9b9bee1a217f67c959/multiprocess-0.70.19-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:5be9ec7f0c1c49a4f4a6fd20d5dda4aeabc2d39a50f4ad53720f1cd02b3a7c2e", size = 144738, upload-time = "2026-01-19T06:47:26.636Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cb/f421c2869d75750a4f32301cc20c4b63fab6376e9a75c8e5e655bdeb3d9b/multiprocess-0.70.19-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:1c3dce098845a0db43b32a0b76a228ca059a668071cfeaa0f40c36c0b1585d45", size = 144741, upload-time = "2026-01-19T06:47:27.985Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/45/8004d1e6b9185c1a444d6b55ac5682acf9d98035e54386d967366035a03a/multiprocess-0.70.19-py310-none-any.whl", hash = "sha256:97404393419dcb2a8385910864eedf47a3cadf82c66345b44f036420eb0b5d87", size = 134948, upload-time = "2026-01-19T06:47:32.325Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c2/dec9722dc3474c164a0b6bcd9a7ed7da542c98af8cabce05374abab35edd/multiprocess-0.70.19-py311-none-any.whl", hash = "sha256:928851ae7973aea4ce0eaf330bbdafb2e01398a91518d5c8818802845564f45c", size = 144457, upload-time = "2026-01-19T06:47:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/82/69e539c4c2027f1e1697e09aaa2449243085a0edf81ae2c6341e84d769b6/multiprocess-0.70.19-py39-none-any.whl", hash = "sha256:0d4b4397ed669d371c81dcd1ef33fd384a44d6c3de1bd0ca7ac06d837720d3c5", size = 133477, upload-time = "2026-01-19T06:47:38.619Z" },
 ]
 
 [[package]]
@@ -662,14 +1092,22 @@ wheels = [
 
 [[package]]
 name = "nvidia-cublas"
-version = "13.1.1.3"
+version = "13.1.0.3"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
-]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/a5/fce49e2ae977e0ccc084e5adafceb4f0ac0c8333cb6863501618a7277f67/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c86fc7f7ae36d7528288c5d88098edcb7b02c633d262e7ddbb86b0ad91be5df2", size = 542851226, upload-time = "2025-10-09T08:59:04.818Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/44/423ac00af4dd95a5aeb27207e2c0d9b7118702149bf4704c3ddb55bb7429/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:ee8722c1f0145ab246bccb9e452153b5e0515fd094c3678df50b2a0888b8b171", size = 423133236, upload-time = "2025-10-09T08:59:32.536Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f5/f50bc3f5c2bb57ab8f5b4d78bc1146b57810d42cb8fcb28cbe2e14050376/nvidia_cublas-13.1.0.3-py3-none-win_amd64.whl", hash = "sha256:2a3b94a37def342471c59fad7856caee4926809a72dd5270155d6a31b5b277be", size = 404355960, upload-time = "2025-10-09T09:07:00.987Z" },
+]
+
+[[package]]
+name = "nvidia-cublas-cu12"
+version = "12.8.4.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/99/db44d685f0e257ff0e213ade1964fc459b4a690a73293220e98feb3307cf/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b86f6dd8935884615a0683b663891d43781b819ac4f2ba2b0c9604676af346d0", size = 590537124, upload-time = "2025-03-07T01:43:53.556Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
+    { url = "https://files.pythonhosted.org/packages/70/61/7d7b3c70186fb651d0fbd35b01dbfc8e755f69fd58f817f3d0f642df20c3/nvidia_cublas_cu12-12.8.4.1-py3-none-win_amd64.whl", hash = "sha256:47e9b82132fa8d2b4944e708049229601448aaad7e6f296f630f2d1a32de35af", size = 567544208, upload-time = "2025-03-07T01:53:30.535Z" },
 ]
 
 [[package]]
@@ -679,6 +1117,17 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
     { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/df/b74b10025c1205695c5676373f2edd3e87a7202cc62ead0dfbc373b0f6ea/nvidia_cuda_cupti-13.0.85-py3-none-win_amd64.whl", hash = "sha256:683f58d301548deeefcb8f6fac1b8d907691b9d8b18eccab417f51e362102f00", size = 7736776, upload-time = "2025-09-04T08:38:08.38Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/1f/b3bd73445e5cb342727fd24fe1f7b748f690b460acadc27ea22f904502c8/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4412396548808ddfed3f17a467b104ba7751e6b58678a4b840675c56d21cf7ed", size = 9533318, upload-time = "2025-03-07T01:40:10.421Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
+    { url = "https://files.pythonhosted.org/packages/41/bc/83f5426095d93694ae39fe1311431b5d5a9bb82e48bf0dd8e19be2765942/nvidia_cuda_cupti_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:bb479dcdf7e6d4f8b0b01b115260399bf34154a1a2e9fe11c85c517d87efd98e", size = 7015759, upload-time = "2025-03-07T01:51:11.355Z" },
 ]
 
 [[package]]
@@ -688,6 +1137,17 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
     { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/af/345fedb9f4c76c84ab4fa445b36bd4048a4d9db60e6bc76b4f913ff4b852/nvidia_cuda_nvrtc-13.0.88-py3-none-win_amd64.whl", hash = "sha256:6bcd4e7f8e205cbe644f5a98f2f799bef9556fefc89dd786e79a16312ce49872", size = 76807835, upload-time = "2025-09-04T08:39:15.274Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d1/e50d0acaab360482034b84b6e27ee83c6738f7d32182b987f9c7a4e32962/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc1fec1e1637854b4c0a65fb9a8346b51dd9ee69e61ebaccc82058441f15bce8", size = 43106076, upload-time = "2025-03-07T01:41:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/45/51/52a3d84baa2136cc8df15500ad731d74d3a1114d4c123e043cb608d4a32b/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-win_amd64.whl", hash = "sha256:7a4b6b2904850fe78e0bd179c4b655c404d4bb799ef03ddc60804247099ae909", size = 73586838, upload-time = "2025-03-07T01:52:13.483Z" },
 ]
 
 [[package]]
@@ -697,18 +1157,43 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
     { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/94/6b867483bec07da24ffa32736c79fabb94ef3a7af4d787a9d4a974868576/nvidia_cuda_runtime-13.0.96-py3-none-win_amd64.whl", hash = "sha256:f79298c8a098cec150a597c8eba58ecdab96e3bdc4b9bc4f9983635031740492", size = 2927037, upload-time = "2025-10-09T09:04:23.782Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/75/f865a3b236e4647605ea34cc450900854ba123834a5f1598e160b9530c3a/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:52bf7bbee900262ffefe5e9d5a2a69a30d97e2bc5bb6cc866688caa976966e3d", size = 965265, upload-time = "2025-03-07T01:39:43.533Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a5/a515b7600ad361ea14bfa13fb4d6687abf500adc270f19e89849c0590492/nvidia_cuda_runtime_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:c0c6027f01505bfed6c3b21ec546f69c687689aad5f1a377554bc6ca4aa993a8", size = 944318, upload-time = "2025-03-07T01:51:01.794Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.19.0.56"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12", marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/b8/277c51962ee46fa3e5b203ac5f76107c650f781d6891e681e28e6f3e9fe6/nvidia_cudnn_cu12-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:08caaf27fe556aca82a3ee3b5aa49a77e7de0cfcb7ff4e5c29da426387a8267e", size = 656910700, upload-time = "2026-02-03T20:40:25.508Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/41/65225d42fba06fb3dd3972485ea258e7dd07a40d6e01c95da6766ad87354/nvidia_cudnn_cu12-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:ac6ad90a075bb33a94f2b4cf4622eac13dd4dc65cf6dd9c7572a318516a36625", size = 657906812, upload-time = "2026-02-03T20:44:12.638Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/a5/48f07449fc9c6cc146dcafe6149fa5d69630137d2ec5b7d9e09f255fadd7/nvidia_cudnn_cu12-9.19.0.56-py3-none-win_amd64.whl", hash = "sha256:cec70596b9ce878fab83810c3f5a2e606d35f510e5fee579759e4cbc68a23750", size = 644003014, upload-time = "2026-02-03T20:46:25.768Z" },
 ]
 
 [[package]]
 name = "nvidia-cudnn-cu13"
-version = "9.20.0.48"
+version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nvidia-cublas" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/22/0b4b932655d17a6da1b92fa92ab12844b053bb2ac2475e179ba6f043da1e/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:d20e1734305e9d68889a96e3f35094d733ff1f83932ebe462753973e53a572bf", size = 366066321, upload-time = "2026-02-03T20:44:52.837Z" },
+    { url = "https://files.pythonhosted.org/packages/91/a2/f020386683ee9ab2c9a9f7f79290d9b0d07f7241de54dc746af2abd188d2/nvidia_cudnn_cu13-9.19.0.56-py3-none-win_amd64.whl", hash = "sha256:40d8c375005bcb01495f8edf375230b203a411a0c05fb6dc92a3781edcb23eac", size = 350547366, upload-time = "2026-02-03T20:50:49.563Z" },
 ]
 
 [[package]]
@@ -721,6 +1206,20 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
     { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/f8af21a2ed1beed337a6a02c5a28aeb85441f4d578ec3d529543c775ea4b/nvidia_cufft-12.0.0.61-py3-none-win_amd64.whl", hash = "sha256:2abce5b39d2f5ae12730fb7e5db6696533e36c26e2d3e8fd1750bdd2853364eb", size = 213342123, upload-time = "2025-09-04T08:40:51.145Z" },
+]
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.3.3.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ec/ce1629f1e478bb5ccd208986b5f9e0316a78538dd6ab1d0484f012f8e2a1/nvidia_cufft_cu12-11.3.3.83-py3-none-win_amd64.whl", hash = "sha256:7a64a98ef2a7c47f905aaf8931b69a3a43f27c55530c698bb2ed7c75c0b42cb7", size = 192216559, upload-time = "2025-03-07T01:53:57.106Z" },
 ]
 
 [[package]]
@@ -733,12 +1232,32 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cufile-cu12"
+version = "1.13.1.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f5/5607710447a6fe9fd9b3283956fceeee8a06cda1d2f56ce31371f595db2a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:4beb6d4cce47c1a0f1013d72e02b0994730359e17801d395bdcbf20cfb3bb00a", size = 1120705, upload-time = "2025-03-07T01:45:41.434Z" },
+]
+
+[[package]]
 name = "nvidia-curand"
 version = "10.4.0.35"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
     { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+    { url = "https://files.pythonhosted.org/packages/99/27/72103153b1ffc00e09fdc40ac970235343dcd1ea8bd762e84d2d73219ffa/nvidia_curand-10.4.0.35-py3-none-win_amd64.whl", hash = "sha256:65b1710aa6961d326b411e314b374290904c5ddf41dc3f766ebc3f1d7d4ca69f", size = 55242481, upload-time = "2025-08-04T10:30:41.831Z" },
+]
+
+[[package]]
+name = "nvidia-curand-cu12"
+version = "10.3.9.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/5e/92aa15eca622a388b80fbf8375d4760738df6285b1e92c43d37390a33a9a/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:dfab99248034673b779bc6decafdc3404a8a6f502462201f2f31f11354204acd", size = 63625754, upload-time = "2025-03-07T01:46:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/75/70c05b2f3ed5be3bb30b7102b6eb78e100da4bbf6944fd6725c012831cab/nvidia_curand_cu12-10.3.9.90-py3-none-win_amd64.whl", hash = "sha256:f149a8ca457277da854f89cf282d6ef43176861926c7ac85b2a0fbd237c587ec", size = 62765309, upload-time = "2025-03-07T01:54:20.478Z" },
 ]
 
 [[package]]
@@ -753,6 +1272,22 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
     { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ef/332a0101260ca78a1daef046bf0b06199e8ed4dac1d2aa698289c358169c/nvidia_cusolver-12.0.4.66-py3-none-win_amd64.whl", hash = "sha256:16515bd33a8e76bb54d024cfa068fa68d30e80fc34b9e1090813ea9362e0cb65", size = 193551444, upload-time = "2025-09-04T08:41:46.813Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.3.90"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12", marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "nvidia-cusparse-cu12", marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
+    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c0/76ca8551b8a84146ffa189fec81c26d04adba4bc0dbe09cd6e6fd9b7de04/nvidia_cusolver_cu12-11.7.3.90-py3-none-win_amd64.whl", hash = "sha256:4a550db115fcabc4d495eb7d39ac8b58d4ab5d8e63274d3754df1c0ad6a22d34", size = 256720438, upload-time = "2025-03-07T01:54:39.898Z" },
 ]
 
 [[package]]
@@ -765,24 +1300,58 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
     { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+    { url = "https://files.pythonhosted.org/packages/02/b0/b043d6f3480f102f885cf87fc3ffd3edcb5e23b855025a50e2ef4d059185/nvidia_cusparse-12.6.3.3-py3-none-win_amd64.whl", hash = "sha256:cbcf42feb737bd7ec15b4c0a63e62351886bd3f975027b8815d7f720a2b5ea79", size = 143783033, upload-time = "2025-09-04T08:42:12.391Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.8.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
+    { url = "https://files.pythonhosted.org/packages/62/07/f3b2ad63f8e3d257a599f422ae34eb565e70c41031aecefa3d18b62cabd1/nvidia_cusparse_cu12-12.5.8.93-py3-none-win_amd64.whl", hash = "sha256:9a33604331cb2cac199f2e7f5104dfbb8a5a898c367a53dfda9ff2acb6b6b4dd", size = 284937404, upload-time = "2025-03-07T01:55:07.742Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu12"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/b9/598f6ff36faaece4b3c50d26f50e38661499ff34346f00e057760b35cc9d/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8878dce784d0fac90131b6817b607e803c36e629ba34dc5b433471382196b6a5", size = 283835557, upload-time = "2025-02-26T00:16:54.265Z" },
+    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d8/a6b0d0d0c2435e9310f3e2bb0d9c9dd4c33daef86aa5f30b3681defd37ea/nvidia_cusparselt_cu12-0.7.1-py3-none-win_amd64.whl", hash = "sha256:f67fbb5831940ec829c9117b7f33807db9f9678dc2a617fbe781cac17b4e1075", size = 271020911, upload-time = "2025-02-26T00:14:47.204Z" },
 ]
 
 [[package]]
 name = "nvidia-cusparselt-cu13"
-version = "0.8.1"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
-    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+    { url = "https://files.pythonhosted.org/packages/46/10/8dcd1175260706a2fc92a16a52e306b71d4c1ea0b0cc4a9484183399818a/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:400c6ed1cf6780fc6efedd64ec9f1345871767e6a1a0a552a1ea0578117ea77c", size = 220791277, upload-time = "2025-08-13T19:22:40.982Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/53/43b0d71f4e702fa9733f8b4571fdca50a8813f1e450b656c239beff12315/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25e30a8a7323935d4ad0340b95a0b69926eee755767e8e0b1cf8dd85b197d3fd", size = 169884119, upload-time = "2025-08-13T19:23:41.967Z" },
+    { url = "https://files.pythonhosted.org/packages/57/de/8f0578928b9b1246d7b1324db0528e6b9f9fb54496a49f40bf71f09f1a27/nvidia_cusparselt_cu13-0.8.0-py3-none-win_amd64.whl", hash = "sha256:e80212ed7b1afc97102fbb2b5c82487aa73f6a0edfa6d26c5a152593e520bb8f", size = 156459710, upload-time = "2025-08-13T19:24:18.043Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.28.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/c4/120d2dfd92dff2c776d68f361ff8705fdea2ca64e20b612fab0fd3f581ac/nvidia_nccl_cu12-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:50a36e01c4a090b9f9c47d92cec54964de6b9fcb3362d0e19b8ffc6323c21b60", size = 296766525, upload-time = "2025-11-18T05:49:16.094Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4e/44dbb46b3d1b0ec61afda8e84837870f2f9ace33c564317d59b70bc19d3e/nvidia_nccl_cu12-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:485776daa8447da5da39681af455aa3b2c2586ddcf4af8772495e7c532c7e5ab", size = 296782137, upload-time = "2025-11-18T05:49:34.248Z" },
 ]
 
 [[package]]
 name = "nvidia-nccl-cu13"
-version = "2.29.7"
+version = "2.28.9"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
-    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
+    { url = "https://files.pythonhosted.org/packages/39/55/1920646a2e43ffd4fc958536b276197ed740e9e0c54105b4bb3521591fc7/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:01c873ba1626b54caa12272ed228dc5b2781545e0ae8ba3f432a8ef1c6d78643", size = 196561677, upload-time = "2025-11-18T05:49:03.45Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/b4/878fefaad5b2bcc6fcf8d474a25e3e3774bc5133e4b58adff4d0bca238bc/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:e4553a30f34195f3fa1da02a6da3d6337d28f2003943aa0a3d247bbc25fefc42", size = 196493177, upload-time = "2025-11-18T05:49:17.677Z" },
 ]
 
 [[package]]
@@ -792,6 +1361,26 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
     { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/01/07530b0e37546231052e30234540289c42eaffa486f1a34a87fed340157b/nvidia_nvjitlink-13.0.88-py3-none-win_amd64.whl", hash = "sha256:634e96e3da9ef845ae744097a1f289238ecf946ce0b82e93cdce14b9782e682f", size = 36035115, upload-time = "2025-09-04T08:43:03.001Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a2/8cee5da30d13430e87bf99bb33455d2724d0a4a9cb5d7926d80ccb96d008/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:adccd7161ace7261e01bb91e44e88da350895c270d23f744f0820c818b7229e7", size = 38386204, upload-time = "2025-03-07T01:49:43.612Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/d7/34f02dad2e30c31b10a51f6b04e025e5dd60e5f936af9045a9b858a05383/nvidia_nvjitlink_cu12-12.8.93-py3-none-win_amd64.whl", hash = "sha256:bd93fbeeee850917903583587f4fc3a4eafa022e34572251368238ab5e6bd67f", size = 268553710, upload-time = "2025-03-07T01:56:24.13Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu12"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/6a/03aa43cc9bd3ad91553a88b5f6fb25ed6a3752ae86ce2180221962bc2aa5/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b48363fc6964dede448029434c6abed6c5e37f823cb43c3bcde7ecfc0457e15", size = 138936938, upload-time = "2025-09-06T00:32:05.589Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd", size = 139103095, upload-time = "2025-09-06T00:32:31.266Z" },
 ]
 
 [[package]]
@@ -810,6 +1399,17 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
     { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/50/0e2220f8620a177de994211186ffc5bfa9f2ce1e1282797f8f90096f9f88/nvidia_nvtx-13.0.85-py3-none-win_amd64.whl", hash = "sha256:d66ea44254dd3c6eacc300047af6e1288d2269dd072b417e0adffbf479e18519", size = 137066, upload-time = "2025-09-04T08:39:25.649Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/c0/1b303feea90d296f6176f32a2a70b5ef230f9bdeb3a72bddb0dc922dc137/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615", size = 91161, upload-time = "2025-03-07T01:42:23.922Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/99/4c9c0c329bf9fc125008c3b54c7c94c0023518d06fc025ae36431375e1fe/nvidia_nvtx_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:619c8304aedc69f02ea82dd244541a83c3d9d40993381b3b590f1adaed3db41e", size = 56492, upload-time = "2025-03-07T01:52:24.69Z" },
 ]
 
 [[package]]
@@ -820,7 +1420,11 @@ dependencies = [
     { name = "numpy" },
     { name = "opt-einsum" },
     { name = "scipy" },
-    { name = "torch" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra != 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/f6/79f7bc192b1129495bf25b9c19a1487e51d96e13e22249e37bedd7bd0e11/opacus-1.4.1.tar.gz", hash = "sha256:e1d453c29bc8457ad7c530f5c56074c913dfebb0fb14d7524677cf03a217cff4", size = 139127, upload-time = "2024-02-11T17:28:31.621Z" }
 wheels = [
@@ -864,6 +1468,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/da/9522ba4b32b20a344c37a970d7835d261df1427d943e02d48820253833ee/pandas-2.2.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:7d2ed41c319c9fb4fd454fe25372028dfa417aacb9790f68171b2e3f06eae8cd", size = 16243608, upload-time = "2024-02-23T15:31:03.951Z" },
     { url = "https://files.pythonhosted.org/packages/e0/c3/da6ffa0d3d510c378f6e46496cf7f84f35e15836d0de4e9880f40247eb60/pandas-2.2.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:af5d3c00557d657c8773ef9ee702c61dd13b9d7426794c9dfeb1dc4a0bf0ebc7", size = 13884355, upload-time = "2024-02-23T15:31:07.653Z" },
     { url = "https://files.pythonhosted.org/packages/61/11/1812ef6cbd7433ad240f72161ce5f84c4c450cede4db080365d371d29117/pandas-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:06cf591dbaefb6da9de8472535b185cba556d0ce2e6ed28e21d919704fef1a9e", size = 11602637, upload-time = "2024-02-23T15:31:11.267Z" },
+]
+
+[[package]]
+name = "peft"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accelerate" },
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra != 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "tqdm" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/cf/037f1e3d5186496c05513a6754639e2dab3038a05f384284d49a9bd06a2d/peft-0.19.1.tar.gz", hash = "sha256:0d97542fe96dcdaa20d3b81c06f26f988618f416a73544ab23c3618ccb674a40", size = 763738, upload-time = "2026-04-16T15:46:45.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/b6/f54d676ed93cc2dd2234c3b172ea9c8c3d7d29361e66b1b23dec57a67465/peft-0.19.1-py3-none-any.whl", hash = "sha256:2113f72a81621b5913ef28f9022204c742df111890c5f49d812716a4a301e356", size = 680692, upload-time = "2026-04-16T15:46:42.886Z" },
 ]
 
 [[package]]
@@ -927,6 +1556,63 @@ wheels = [
 ]
 
 [[package]]
+name = "propcache"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/f1/8a8cc1c2c7e7934ab77e0163414f736fadbc0f5e8dd9673b952355ac175b/propcache-0.5.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:74b70780220e2dd89175ca24b81b68b67c83db499ae611e7f2313cb329801c78", size = 90744, upload-time = "2026-05-08T20:59:45.799Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f4/651b1225e976bd1a2ba5cfba0c29d096581c2636b437e3a9a7ab6276270a/propcache-0.5.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a4840ab0ae0216d952f4b53dc6d0b992bfc2bedbfe360bdd9b548bc184c08959", size = 52033, upload-time = "2026-05-08T20:59:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a8/8ede85d6aa1f79fc7dc2f8fd2c8d65920b8272c3892903c8a1affde48cfb/propcache-0.5.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c6844ba6364fb12f403928a82cfd295ab103a2b315c77c747b2dbe4a41894ea7", size = 52754, upload-time = "2026-05-08T20:59:49.202Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/fe/b3551b41bbc2f5b5bb088fc6920567cd43101253e68fbaa261339eb96fe1/propcache-0.5.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2293949b855ce597f2826452d17c2d545fb5622379c4ea6fdf525e9b8e8a2511", size = 57573, upload-time = "2026-05-08T20:59:50.778Z" },
+    { url = "https://files.pythonhosted.org/packages/83/27/ab851ebd1b7172e3e161f5f8d39e315d54a91bea246f01f4d872d3376aef/propcache-0.5.2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0fd59b5af35f74da48d905dcbad55449ba13be91823cb05a9bd590bbf5b61660", size = 60645, upload-time = "2026-05-08T20:59:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/466b3d18022e9897cbda9c735c493c5bd747d7a4c6f5ea1480b4cec434b6/propcache-0.5.2-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29f9309a2e42b0d273be006fdb4be2d6c39a47f6f57d8fb1cf9f81481df81b66", size = 61563, upload-time = "2026-05-08T20:59:53.866Z" },
+    { url = "https://files.pythonhosted.org/packages/27/1b/16ab7f2cf2041da2f60d156ba64c2484eadf9168075b4ff43c3ef60045af/propcache-0.5.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5aaa2b923c1944ac8febd6609cb373540a5563e7cbcb0fd770f75dace2eb817b", size = 58888, upload-time = "2026-05-08T20:59:55.457Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/67/bb777ffd907633563bf35fd859c4ce97b0512c32f4633cf5d1eb7c33512b/propcache-0.5.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66ea454f095ddf5b6b14f56c064c0941c4788be11e18d2464cf643bf7203ff67", size = 59253, upload-time = "2026-05-08T20:59:57.075Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/42/64f8d90b73fd9cdc1499b48057ff6d9cd2a98a25734c9bb62ecf07e87061/propcache-0.5.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:95f1e3f4760d404b13c9976c0229b2b49a3c8e2c62a9ce92efdd2b11ada75e3f", size = 57558, upload-time = "2026-05-08T20:59:58.602Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/02/dba5bc03c9041f2092ea55a449caf5dfe68352c6654511b29ba0654ddb69/propcache-0.5.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:85341b12b9d55bad0bded24cac341bb34289469e03a11f3f583ea1cc1db0326c", size = 55007, upload-time = "2026-05-08T20:59:59.837Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c0/43f649c7aa2a77a3b100d84e9dea3a483120ecb608bfe36ce49eaff517fe/propcache-0.5.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:26a4dca084132874e639895c3135dfad5eb20bae209f62d1aeb31b03e601c3c0", size = 60355, upload-time = "2026-05-08T21:00:01.144Z" },
+    { url = "https://files.pythonhosted.org/packages/83/c0/435dafd27f1cb4a495381dae60e25883ccfe4020bb72818e8184c1678092/propcache-0.5.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3b199b9b2b3d6a7edf3183ba8a9a137a22b97f7df525feb5ae1eccf026d2a9c6", size = 59057, upload-time = "2026-05-08T21:00:02.401Z" },
+    { url = "https://files.pythonhosted.org/packages/53/ae/6e292df9135d659944e96cb3389258e4a663e5b2b5f6c217ef0ddc8d2f73/propcache-0.5.2-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:e59bc9e66329185b93dab73f210f1a37f81cb40f321501db8017c9aea15dba27", size = 61938, upload-time = "2026-05-08T21:00:03.638Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/42/314ebc50d8159055411fd6b0bda322ff510e4b1f7d2e4927940ad0f6af20/propcache-0.5.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:552ffadf6ad409844bc5919c42a0a83d88314cedddaea0e41e80a8b8fffe881f", size = 59731, upload-time = "2026-05-08T21:00:04.881Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/9b/2da6dee38871c3c8772fabc2758325a5c9077d6d18c597737dc04dd884cd/propcache-0.5.2-cp311-cp311-win32.whl", hash = "sha256:cd416c1de191973c52ff1a12a57446bfc7642797b282d7caf2162d7d1b8aa9a0", size = 38966, upload-time = "2026-05-08T21:00:06.511Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4e/f17363fb58c0afe05b067361cb6d86ed2d29de6506779a27547c4d183075/propcache-0.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:44e488ef40dbb452700b2b1f8188934121f6648f52c295055662d2191959ff82", size = 42135, upload-time = "2026-05-08T21:00:08.088Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/eb/6af6685077d22e8b33358d3c548e3282706a0b3cd85044ffba4e5dd08e3b/propcache-0.5.2-cp311-cp311-win_arm64.whl", hash = "sha256:54adaa85a22078d1e306304a40984dc5be99d599bf3dc0a24dc98f7daeab89ab", size = 38381, upload-time = "2026-05-08T21:00:09.692Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "25.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/f3/95428098d1fa7d04432fb750eed06b41304c2f6a5d3319985e64db2d9d41/pyarrow-25.0.0.tar.gz", hash = "sha256:d2d697008b5ec06d75952ef260c2e9a8a0f6ccfce24266c04c9c8ade927cb3b4", size = 1199181, upload-time = "2026-07-10T08:29:50.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/98/ae2b5acf9876dbeffa6f320776242c52caab062df55c8ac5501ed2679e74/pyarrow-25.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:2e3b6544e26e393fe2cd530f523e36c1c8d3c345bbbb60cca3fd866be8322517", size = 35939080, upload-time = "2026-07-10T08:26:04.53Z" },
+    { url = "https://files.pythonhosted.org/packages/80/09/3de2a968edbd496c86cb8b932cdbee2d4b08c4a28e9884a15e5c705a646b/pyarrow-25.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:b724d127783b4c19f088fcdfc844cbc318809246a30307bcabd5ed02045e890e", size = 37633420, upload-time = "2026-07-10T08:26:10.354Z" },
+    { url = "https://files.pythonhosted.org/packages/19/86/8399243a4ce080426ec37db18d5e29148b7ec960a8a8c7f9059a7bf6ef0a/pyarrow-25.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:244f98a595f70fa4fd35faa7508c4ae67e14a173397a4b3b49d2b3c360fb0062", size = 46861050, upload-time = "2026-07-10T08:26:16.397Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/72d704b02bc5fc6d06954d76a0208c1e79cad3ab370f6d6a91ffe5078870/pyarrow-25.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:0222f0071d13313962a88d21bf28b80d355ac39d81bfa6ff3fe00eeaf748e4be", size = 50056458, upload-time = "2026-07-10T08:26:23.271Z" },
+    { url = "https://files.pythonhosted.org/packages/06/5d/3c31a60b6403d63cad2e0f829096f5fc5763a129ead4207a5d4690b96448/pyarrow-25.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b58726f118c079f9d4ed7e904975d4f15fd69d0741ba511a4e2dcaa4ef16354f", size = 49957793, upload-time = "2026-07-10T08:26:30.232Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f7/8f8a019061f9863a831915329264372a87ed25eaf9109ce56eb0e84012c5/pyarrow-25.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:38a2c887cb3883e241b70201688db34133b6dfadd04f03c8f9213df53770c18e", size = 53100544, upload-time = "2026-07-10T08:26:36.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e2/738071e95c5ddad7b3dfc12f569ffa992db89d7d7b4a95258fd184191249/pyarrow-25.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:161649d60a7a46c613a19fd795763ea8a88c36ba997dd99d9bc66e6794ee36e8", size = 27848311, upload-time = "2026-07-10T08:26:41.429Z" },
+]
+
+[[package]]
 name = "pycodestyle"
 version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -967,7 +1653,7 @@ name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
@@ -1068,6 +1754,30 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.6.28"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/05/e4f219230e11e774a6c9987d2ab0d0c6b8573e13a17e143d0015bee710ef/regex-2026.6.28.tar.gz", hash = "sha256:3cb4b6c5cb3060cc31efdc1fbb27c25fb9b29044afd87e40601a1c4d9db54342", size = 416101, upload-time = "2026-06-28T19:56:55.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/db/9051b36294bdbabaa9c7db57db0fbcdfbd17f7a106c539bb423d0323faea/regex-2026.6.28-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a71b51dd08b9b62f055fafab3dee8af8bd2ec81b373a44caef18d6c5ca28f43a", size = 489481, upload-time = "2026-06-28T19:53:36.684Z" },
+    { url = "https://files.pythonhosted.org/packages/35/3f/24097a3c3ff30f9a639888900faaecabcf5f54a5bc9c851c297e11b349ef/regex-2026.6.28-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9c26a47770d30a0f85c01e261d2a3ebc342c4af6fd666dbd8c1fe4cbf3adf726", size = 291292, upload-time = "2026-06-28T19:53:38.39Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/cc/e0d762a189cfb4e8926d16e691720690d139a977b38fdb80230c259332ab/regex-2026.6.28-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e5efbc1af38f97e300d43028e5a92e752d924bcfb7f465d8669d5d5a6e78c233", size = 289232, upload-time = "2026-06-28T19:53:40.181Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/c8/ca0ac7f09cc88ca61e0c61c53f7db29334f660ffba5d0b52378e7c44723c/regex-2026.6.28-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1758df6fdd8c800620a5638958720e8a635e1da49a2f09df2dd63e94a24ec4a", size = 792332, upload-time = "2026-06-28T19:53:41.782Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/92/04ae94cbe0dd1f478b2aef6c46f995bb6946d3e338d4b28605478b66a2b7/regex-2026.6.28-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ad73ecf20c1ef5c975639f8bf845a9370fcf7dada7edc1e3b0bca20e2f8202f6", size = 861743, upload-time = "2026-06-28T19:53:43.261Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ec/024d7638c807679ff8a0e6081d01d66c7762339af1cac71e45911587ff9a/regex-2026.6.28-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4d80c798b0eec6ea3d45f8816a1e8886c5664615d347d89e8c075b576a1b5a5d", size = 906481, upload-time = "2026-06-28T19:53:44.948Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/fd/93bfe5af45f0be4fa8983945455c0e6924e1aeb879cde227958869c1e71c/regex-2026.6.28-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a361feeaf1b6ba1df060f2ff5c5947092edf537a35ce78e76387ac56d3e0f4a4", size = 799867, upload-time = "2026-06-28T19:53:46.997Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/fd/e5d965d41f2398c8ce0f37a4652f03bb297fd009bb796d390134225dda12/regex-2026.6.28-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8b92366d9c8bba9642989534073662abdd9b41faf7603a7ae71597833f3b88f0", size = 773632, upload-time = "2026-06-28T19:53:48.892Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d9/ff39afaec92b9ee2dba0302a4783976005091681069808938c31cf8df3b6/regex-2026.6.28-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:11251768cc23f097dd61b18f67966e70f74da822784d17e12a444eb6b29d4288", size = 781669, upload-time = "2026-06-28T19:53:50.693Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4e/e2fd4bb8228e10c24af2d7ff867182372190e498eab9fd29cbe54c403c95/regex-2026.6.28-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:ad5c67786145ec28a71a267d9f9d92bdc8d70d65541eea852c253f520a01f918", size = 854497, upload-time = "2026-06-28T19:53:52.323Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7c/f0340384a973082979064156d05f3d2cc1dced7371efcd7a1b45726a1a8a/regex-2026.6.28-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:f1da438e739765c3e85175ede05816cbede3caaacb1e0680568bda6119bfdfca", size = 763335, upload-time = "2026-06-28T19:53:54.024Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/32/90ce0d0898e205506cc22b9c81cfb16b722e06ca5f50fad51c053c2a727b/regex-2026.6.28-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d98b639046e51c5de64d9f77351532105e99ca271cb6f7640e1f903d6ab63032", size = 844615, upload-time = "2026-06-28T19:53:56.216Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ef/55abb149599dce1ade687170557129524011eeb3d92afe02429cea7754a2/regex-2026.6.28-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1e164ace4dbab5c6ad4a4ac7c41a2638fe226d0c770a86f2eb041f594bac6ee7", size = 789193, upload-time = "2026-06-28T19:53:57.791Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ea/cf7f6f6f152e52fdad978b913bf24c14df647eca0f81ef31f3aee0be8982/regex-2026.6.28-cp311-cp311-win32.whl", hash = "sha256:3169a3159e4d99d9ae85ff0ed90ef3b8906cc3152653b6078b842ace6c8f72c3", size = 266731, upload-time = "2026-06-28T19:53:59.938Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/cf/a48d8e8d406b22481cad146f48fa0dfca3c5f402b91f26d8e5a0fe4f513d/regex-2026.6.28-cp311-cp311-win_amd64.whl", hash = "sha256:5977295b0a74e8241df8a4b3b27b12412a831f6fa32ee8b755039592cd768c3d", size = 277918, upload-time = "2026-06-28T19:54:01.502Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b2/a222392207db7ed86281a732a99f7cf7f2bb35d332799e892b8510be000e/regex-2026.6.28-cp311-cp311-win_arm64.whl", hash = "sha256:f5fbaef40c3e9282ccee4b075f5600a0d858aa0c34147732f1baa69c8188a95d", size = 276876, upload-time = "2026-06-28T19:54:03.411Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1085,6 +1795,19 @@ wheels = [
 [package.optional-dependencies]
 socks = [
     { name = "pysocks" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]
@@ -1110,6 +1833,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/00/ef/033022a6b104be32e899b00de704d7c6d1723a54d4c9e09d147368f14b62/ruff-0.11.0-py3-none-win32.whl", hash = "sha256:3191e9116b6b5bbe187447656f0c8526f0d36b6fd89ad78ccaad6bdc2fad7df2", size = 10310905, upload-time = "2025-03-14T13:52:30.46Z" },
     { url = "https://files.pythonhosted.org/packages/ed/8a/163f2e78c37757d035bd56cd60c8d96312904ca4a6deeab8442d7b3cbf89/ruff-0.11.0-py3-none-win_amd64.whl", hash = "sha256:c58bfa00e740ca0a6c43d41fb004cd22d165302f360aaa56f7126d544db31a21", size = 11411730, upload-time = "2025-03-14T13:52:32.508Z" },
     { url = "https://files.pythonhosted.org/packages/4e/f7/096f6efabe69b49d7ca61052fc70289c05d8d35735c137ef5ba5ef423662/ruff-0.11.0-py3-none-win_arm64.whl", hash = "sha256:868364fc23f5aa122b00c6f794211e85f7e78f5dffdf7c590ab90b8c4e69b657", size = 10538956, upload-time = "2025-03-14T13:52:34.491Z" },
+]
+
+[[package]]
+name = "safetensors"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/a0/f718cda65b05407d228f97602cf60dca269c979867aa5beb25410de26cd3/safetensors-0.8.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c554f85858e05226d3c2828e32395e677434685d6d94594a41643361c5e837f0", size = 473568, upload-time = "2026-06-09T07:52:18.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/65a7de0af421317bb36a067241e4235fff194eed60b961ed6d3f59a3fc60/safetensors-0.8.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a46e5ff292c356d6991e60942ba7f79817682d3a2cef0702136448cb9c4d235", size = 502844, upload-time = "2026-06-09T07:52:07.624Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4f/3175c9d75634e0e0dda0082794193521035edd7c70a6f212bf33ca06ddf4/safetensors-0.8.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4124502b78f03534117c848f87a39b8f31e577b15eff423bf8bfb95f2a8c30d0", size = 511823, upload-time = "2026-06-09T07:52:09.565Z" },
+    { url = "https://files.pythonhosted.org/packages/20/87/846c289e7aa2299eff406335717cf43ce8777194ece8aad75772e0411615/safetensors-0.8.0-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc0a787ba8a35be368ee3574edfa2b1ad389eebd0a72e482ae275490e3f6c98", size = 633461, upload-time = "2026-06-09T07:52:11.128Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/8d64d9df2c45d5ded401df889d0ad90882804ca172d79ec4f0df8f727fe0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040070828e36dc8e122178bbbd5830ff9e97920affb84cbe0f46442497bed358", size = 545148, upload-time = "2026-06-09T07:52:13.603Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/f203ff3a3ddfe19308efc83c5a3a29ed02bf786732ec35e68bf9162f3365/safetensors-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd6f3f93c9a0a7cc2788ee63fb763353d4bd2e89b0751bc78fcf7dda00bea774", size = 516040, upload-time = "2026-06-09T07:52:16.29Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fb/cdaed17ceb2948784fd9c36b6fd3e951b608547cea81a48e8ee6f8cfdfcb/safetensors-0.8.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:fcdd41ec4628fee5799f807c73c353629130fbd942aa23d83c623dd6c9d52d78", size = 513832, upload-time = "2026-06-09T07:52:12.37Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/49/1e15de264dcc3b77943d2d0c56a95809956883b1c2d6d585c792523f180b/safetensors-0.8.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e9f537aa183a38ace122d27303dcd986b26bd2a7591f9181d7f0c396f4677ca", size = 559930, upload-time = "2026-06-09T07:52:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/43/bf38443278eab4b1be1fce2931e2b012ad9cb7df52ada751d0aab8f7659a/safetensors-0.8.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87eec7ffed2b809f05a398a8becb7d013f19f7837cd15d9748580d6cf30dbaf4", size = 678670, upload-time = "2026-06-09T07:52:20.032Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e3/68cd3fa5b48488e84add63e04cb12f3bc28ae4638c06d4508c6e88823d0e/safetensors-0.8.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4a95ae2b05d7726d751da4ebf626a2ca782b706e101bd894c95bc2450b1cffcc", size = 786679, upload-time = "2026-06-09T07:52:21.322Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/1c19c509d56e01f4fbb3d0a2e597450f6cc04d1d56cf52defb0a62dfd715/safetensors-0.8.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae091f16662658bdc019a4ff6cb4c085bb7d725eb5978b183ffd265863b6d2d", size = 765683, upload-time = "2026-06-09T07:52:22.594Z" },
+    { url = "https://files.pythonhosted.org/packages/27/43/41c1621732edd934d868a00d1b891584c892a7b62a9aab82ea5a0a5623ee/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3f/73ccf82579412b4a71c4ca673f10b5f1f888d7cf5af7fe24f27d30307be4/safetensors-0.8.0-cp310-abi3-win32.whl", hash = "sha256:2ddf52eac562eda224f99acfa7889d02968c1fd59a5b011ae7d8137c37e9c02d", size = 342401, upload-time = "2026-06-09T07:52:28.895Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6d/3fba214c1e5e0f69991677ec3bc17023f0421776975e1de0c682dca475e2/safetensors-0.8.0-cp310-abi3-win_amd64.whl", hash = "sha256:096ec1a98435df7beb08853bb5aa9081a84f23d0adc67ed1a0a10550f608373f", size = 355540, upload-time = "2026-06-09T07:52:27.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fc/7eedc3510d97878876e32774eebbeb61c43f148a96e915c84229a3e967aa/safetensors-0.8.0-cp310-abi3-win_arm64.whl", hash = "sha256:f7838e5135a406ad3e02efdcb8cf2e5397d368b0154537c4fec682dbc544d452", size = 340500, upload-time = "2026-06-09T07:52:26.745Z" },
 ]
 
 [[package]]
@@ -1182,6 +1929,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1250,6 +2006,32 @@ wheels = [
 ]
 
 [[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1269,46 +2051,204 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.12.1"
-source = { registry = "https://pypi.org/simple" }
+version = "2.11.0"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "sys_platform == 'darwin'",
+]
 dependencies = [
-    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "triton", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "(sys_platform == 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "fsspec", marker = "(sys_platform == 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "jinja2", marker = "(sys_platform == 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "networkx", marker = "(sys_platform == 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "setuptools", marker = "(sys_platform == 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "sympy", marker = "(sys_platform == 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "typing-extensions", marker = "(sys_platform == 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/38/7028d3be540f1dcdf41660a2b01d0c51d2cb73915fe370d84e4d277a6d47/torch-2.12.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:ef81f503912effea2ce3d9b12a2e3a6ed488943e91271c90c7a829f60baf6aa2", size = 87975425, upload-time = "2026-06-17T21:08:34.094Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/e3/750b3e3548635ceac03ba255daa26dbc7ed66ca3484dc4b4d955ab7f4501/torch-2.12.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:107df6888624bdea41508f9aeb6149d9333c737a5530ceecb56c904e811369ae", size = 426379894, upload-time = "2026-06-17T21:06:55.077Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/ca/ed24783da629ff3e640ba3f70a7639e9045d3d88b93ee6bc47b8a28a1f2c/torch-2.12.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:6e29e7e74d05bda7d955c75e99459f878ebd970ef851b4057edbd3b34a5eb4a3", size = 532169264, upload-time = "2026-06-17T21:08:17.65Z" },
-    { url = "https://files.pythonhosted.org/packages/46/61/c63f0158446f3a98ea672b004d761b848911eba567ea4a624c7db5aadc04/torch-2.12.1-cp311-cp311-win_amd64.whl", hash = "sha256:a513506cfda3c1c78dabeb6574c1597538c0254b3d39af174dde35d8177f4ce3", size = 122953086, upload-time = "2026-06-17T21:08:27.69Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d75eadcd97fe0dc7cd0eedc4d72152484c19cb2cfe46ce55766c8e129116425f", upload-time = "2026-03-23T15:16:54Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings", version = "13.3.1", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'linux' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "cuda-toolkit", version = "13.0.2", source = { registry = "https://pypi.org/simple" }, extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(sys_platform == 'linux' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "filelock", marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130')" },
+    { name = "fsspec", marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130')" },
+    { name = "jinja2", marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130')" },
+    { name = "networkx", marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130')" },
+    { name = "nvidia-cudnn-cu13", marker = "(sys_platform == 'linux' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "nvidia-cusparselt-cu13", marker = "(sys_platform == 'linux' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "nvidia-nccl-cu13", marker = "(sys_platform == 'linux' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "nvidia-nvshmem-cu13", marker = "(sys_platform == 'linux' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "setuptools", marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130')" },
+    { name = "sympy", marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130')" },
+    { name = "triton", marker = "(sys_platform == 'linux' and extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "typing-extensions", marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/0d/98b410492609e34a155fa8b121b55c7dca229f39636851c3a9ec20edea21/torch-2.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7b6a60d48062809f58595509c524b88e6ddec3ebe25833d6462eeab81e5f2ce4", size = 80529712, upload-time = "2026-03-23T18:12:02.608Z" },
+    { url = "https://files.pythonhosted.org/packages/84/03/acea680005f098f79fd70c1d9d5ccc0cb4296ec2af539a0450108232fc0c/torch-2.11.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:d91aac77f24082809d2c5a93f52a5f085032740a1ebc9252a7b052ef5a4fddc6", size = 419718178, upload-time = "2026-03-23T18:10:46.675Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/8b/d7be22fbec9ffee6cff31a39f8750d4b3a65d349a286cf4aec74c2375662/torch-2.11.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:7aa2f9bbc6d4595ba72138026b2074be1233186150e9292865e04b7a63b8c67a", size = 530604548, upload-time = "2026-03-23T18:10:03.569Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/bd/9912d30b68845256aabbb4a40aeefeef3c3b20db5211ccda653544ada4b6/torch-2.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:73e24aaf8f36ab90d95cd1761208b2eb70841c2a9ca1a3f9061b39fc5331b708", size = 114519675, upload-time = "2026-03-23T18:11:52.995Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.11.0+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "sys_platform != 'darwin'",
+]
+dependencies = [
+    { name = "filelock", marker = "(sys_platform != 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "fsspec", marker = "(sys_platform != 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "jinja2", marker = "(sys_platform != 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "networkx", marker = "(sys_platform != 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "setuptools", marker = "(sys_platform != 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "sympy", marker = "(sys_platform != 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:5214b203ee187f8746c66f1378b72611b7c1e15c5cb325037541899e705ea24e", upload-time = "2026-04-27T21:55:40Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:46fbb0aa257bb781efbfad648f5b045c0e232573b661f1461593db61342e9096", upload-time = "2026-04-28T00:05:38Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:8a56a8c95531ef0e454510ba8bbd9d11dc7a9000337265210b10f6bfeacdd485", upload-time = "2026-04-28T00:05:47Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:51a221769d4a316f4b47a786c12e67c3f4807db8ed13c7b8817ebe73786acbbc", upload-time = "2026-04-28T00:06:00Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.11.0+cu128"
+source = { registry = "https://download.pytorch.org/whl/cu128" }
+dependencies = [
+    { name = "cuda-bindings", version = "12.9.7", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "cuda-toolkit", version = "12.8.1", source = { registry = "https://pypi.org/simple" }, extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "filelock", marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "fsspec", marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "jinja2", marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "networkx", marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "nvidia-cudnn-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "nvidia-cusparselt-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "nvidia-nccl-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "nvidia-nvshmem-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "setuptools", marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "sympy", marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "triton", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "typing-extensions", marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:d76f08e212285bd84c4c5a3472417f8eb4ee72e4067a604f7508dbfa2119771f", upload-time = "2026-04-27T17:36:45Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c9a7ca4c74fae10a58e6175b4b2cea953f9322bb6562bbf339ad6a05f52190ad", upload-time = "2026-04-27T17:37:32Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp311-cp311-win_amd64.whl", hash = "sha256:90ef0c2454e5296a9fb021ddd42252e4ce1abe2c0a4988a173ef90a6cded0bf5", upload-time = "2026-04-27T17:39:29Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.11.0+cu130"
+source = { registry = "https://download.pytorch.org/whl/cu130" }
+dependencies = [
+    { name = "cuda-bindings", version = "13.3.1", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "cuda-toolkit", version = "13.0.2", source = { registry = "https://pypi.org/simple" }, extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "filelock", marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra != 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "fsspec", marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra != 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "jinja2", marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra != 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "networkx", marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra != 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "nvidia-cudnn-cu13", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "nvidia-cusparselt-cu13", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "nvidia-nccl-cu13", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "nvidia-nvshmem-cu13", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "setuptools", marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra != 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "sympy", marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra != 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "triton", marker = "(sys_platform == 'linux' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "typing-extensions", marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra != 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.11.0%2Bcu130-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:6304535e9e4cd1beeab449e407712602aa473a97e7b310dc5650ef50940bd94f", upload-time = "2026-04-27T19:58:56Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.11.0%2Bcu130-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:225b22e0a4e36ea573d3a68796e6816a160616f67e8b8c55683a88bf7777f4cd", upload-time = "2026-04-27T19:59:21Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.11.0%2Bcu130-cp311-cp311-win_amd64.whl", hash = "sha256:a1ff66c0ad21bf48c3187e84a08a6895d48e9bae435e27811b0b65f36bef4555", upload-time = "2026-04-27T20:00:28Z" },
 ]
 
 [[package]]
 name = "torchvision"
-version = "0.27.1"
-source = { registry = "https://pypi.org/simple" }
+version = "0.26.0"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "sys_platform == 'darwin'",
+]
 dependencies = [
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "torch" },
+    { name = "numpy", marker = "(sys_platform == 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "pillow", marker = "(sys_platform == 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/46/bc0ebd93282aeedc1759f054a252c6fadf14b42a0535db3233c85cce4ae5/torchvision-0.27.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:ad8743a9c12c8c124ad0a1491e54c3ca0c749e91e374e3d92136060b22c9e0f4", size = 1852118, upload-time = "2026-06-17T21:09:32.448Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/00/752adc57b6aa8bb833f5b0672acb9538aa5535d64998b9d8dd48ee51fa80/torchvision-0.27.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:a726707e4cbe438fcc507d787af7acf6bca52de30bf4b03579f1dfc0675da829", size = 7831256, upload-time = "2026-06-17T21:09:26.767Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/8a/c474fb27faba02e84dc40e0ac9ea1aa828d6d3557a378f7d0a22468bb2a3/torchvision-0.27.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a1d6a123009af59ad288459f579f67a65cbe8f59372dc7b97e41bc01a6a9b767", size = 7659995, upload-time = "2026-06-17T21:09:25.325Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/7c/e254f8e242a921adc2cc62c11674fa8a16d33e0a1b6c6f5436cb91628ee7/torchvision-0.27.1-cp311-cp311-win_amd64.whl", hash = "sha256:f3b57a984283896f15c9698562418282f828332886c77315bf269936e6ba0280", size = 3807497, upload-time = "2026-06-17T21:09:31.234Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.26.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55bd6ad4ae77be01ba67a410b05b51f53b0d0ee45f146eb6a0dfb9007e70ab3c", upload-time = "2026-03-23T15:36:09Z" },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130')" },
+    { name = "pillow", marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra != 'extra-8-amuletml-cu128' and extra != 'extra-8-amuletml-cu130')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/bd/d552a2521bade3295b2c6e7a4a0d1022261cab7ca7011f4e2a330dbb3caa/torchvision-0.26.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55bd6ad4ae77be01ba67a410b05b51f53b0d0ee45f146eb6a0dfb9007e70ab3c", size = 1863499, upload-time = "2026-03-23T18:12:58.696Z" },
+    { url = "https://files.pythonhosted.org/packages/33/bf/21b899792b08cae7a298551c68398a79e333697479ed311b3b067aab4bdc/torchvision-0.26.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:1c55dc8affbcc0eb2060fbabbe996ae9e5839b24bb6419777f17848945a411b1", size = 7767527, upload-time = "2026-03-23T18:12:44.348Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/45/57bbf9e216850d065e66dd31a50f57424b607f1d878ab8956e56a1f4e36b/torchvision-0.26.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:fd10b5f994c210f4f6d6761cf686f82d748554adf486cb0979770c3252868c8f", size = 7519925, upload-time = "2026-03-23T18:12:53.283Z" },
+    { url = "https://files.pythonhosted.org/packages/10/58/ed8f7754299f3e91d6414b6dc09f62b3fa7c6e5d63dfe48d69ab81498a37/torchvision-0.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:de6424b12887ad884f39a0ee446994ae3cd3b6a00a9cafe1bead85a031132af0", size = 3983834, upload-time = "2026-03-23T18:13:00.224Z" },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.26.0+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "sys_platform != 'darwin'",
+]
+dependencies = [
+    { name = "numpy", marker = "(sys_platform != 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "pillow", marker = "(sys_platform != 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'darwin' and extra == 'extra-8-amuletml-cpu') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.26.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:c11e55041f6b84a6c4fb28981b901475aa81c38695ccec6ddfcc54c3fa9fac4f", upload-time = "2026-03-23T15:36:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.26.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:7fcc4584e9f2f8914f898a01437f25b16222fb0bfb3fdeba59cb1b0c640b0995", upload-time = "2026-03-23T15:36:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.26.0%2Bcpu-cp311-cp311-win_amd64.whl", hash = "sha256:f0c80af8e2807d52f3d480d9828d550f097ad55589f28aab4d65471b3d636359", upload-time = "2026-03-23T15:36:09Z" },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.26.0+cu128"
+source = { registry = "https://download.pytorch.org/whl/cu128" }
+dependencies = [
+    { name = "numpy", marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "pillow", marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-8-amuletml-cu128' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:ed1324dbbbecb5a0149ed4ce8f9308465a1eef85ca2d2370dbb14805bf1c90aa", upload-time = "2026-04-09T23:21:34Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:8f2629d056570c929b0a1d5473d9cb0320b90bda1764bda353553a72cc6b2069", upload-time = "2026-03-23T15:36:22Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp311-cp311-win_amd64.whl", hash = "sha256:d26091b15cd6e3c74c148d9b68c9a901ad6fb9b0f66fa3ea3ab09f04132a07d3", upload-time = "2026-04-09T23:21:35Z" },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.26.0+cu130"
+source = { registry = "https://download.pytorch.org/whl/cu130" }
+dependencies = [
+    { name = "numpy", marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra != 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "pillow", marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra != 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "torch", version = "2.11.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra != 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130') or (extra != 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130')" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.26.0%2Bcu130-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:31f87cd00c09e071980d6a4ce218289a73302ad6a7ce0b3b62a74a4081fc339d", upload-time = "2026-03-23T15:36:25Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.26.0%2Bcu130-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:3b53e3b611561e03ac261d06cb3f38782120ad9e0b4cd9f01549799097c713a6", upload-time = "2026-03-23T15:36:25Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.26.0%2Bcu130-cp311-cp311-win_amd64.whl", hash = "sha256:d019b9d02433515d59ad403d8a6f521da7844c030d6c8003eeec39e15e59f9fa", upload-time = "2026-04-09T23:21:52Z" },
 ]
 
 [[package]]
@@ -1316,7 +2256,7 @@ name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
@@ -1324,12 +2264,47 @@ wheels = [
 ]
 
 [[package]]
+name = "transformers"
+version = "5.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/e1/720ff7ff666b04279fea5bb7ac3ef8675e98f0ddbc1b8cb8bc9f3889d62e/transformers-5.13.0.tar.gz", hash = "sha256:940c1428e42a4238f9ccf0cd41e63c590701aa63c19fd2ce3d7d602222d68495", size = 9195801, upload-time = "2026-07-03T16:05:39.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/3a/d99704c5effe10c6339c98cb236259161103e159bb99a78468b6729572ec/transformers-5.13.0-py3-none-any.whl", hash = "sha256:8adbc1d20bd5463cd6876b2eb7cb31971e1065788e7dc6bc12bab597a7c504b7", size = 11503730, upload-time = "2026-07-03T16:05:35.569Z" },
+]
+
+[[package]]
 name = "triton"
-version = "3.7.1"
+version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/f9/19d842d06a08559534fa1eaab6ca551b1bcf40f06620bddec1babaa2772d/triton-3.7.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a0e1cd4c4a76370ed74a8432a53cea28716827d19e40ffc732233e35ceb3f6", size = 184664887, upload-time = "2026-06-17T20:03:42.913Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/5e/fce69606f7f240297f163e25539906732b199530d486ce67ae319877e821/triton-3.7.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6744957e9fd610a29680ec2346057d0c86948ed3812468670719f391e94b44a5", size = 197701306, upload-time = "2026-06-17T19:53:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/2c/96f92f3c60387e14cc45aed49487f3486f89ea27106c1b1376913c62abe4/triton-3.6.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49df5ef37379c0c2b5c0012286f80174fcf0e073e5ade1ca9a86c36814553651", size = 176081190, upload-time = "2026-01-20T16:16:00.523Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/12/b05ba554d2c623bffa59922b94b0775673de251f468a9609bc9e45de95e9/triton-3.6.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8e323d608e3a9bfcc2d9efcc90ceefb764a82b99dea12a86d643c72539ad5d3", size = 188214640, upload-time = "2026-01-20T16:00:35.869Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.26.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu128') or (extra == 'extra-8-amuletml-cpu' and extra == 'extra-8-amuletml-cu130') or (extra == 'extra-8-amuletml-cu128' and extra == 'extra-8-amuletml-cu130')" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/87/b9fd69c92c6102a066e1b86a35243f53e70bd4c709f2a26d9f4fee4f4dc0/typer-0.26.8-py3-none-any.whl", hash = "sha256:3512ca79ac5c11113414b36e80281b872884477722440691c89d1112e321a49c", size = 122564, upload-time = "2026-06-26T09:22:44.72Z" },
 ]
 
 [[package]]
@@ -1398,4 +2373,68 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/c3/2b1c7bd07a27b1db885a2fab469b707bdd35bddf30a113b4917a7e2139d2/wrapt-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:64a07a71d2730ba56f11d1a4b91f7817dc79bc134c11516b75d1921a7c6fcda1", size = 60336, upload-time = "2026-03-06T02:54:28.104Z" },
     { url = "https://files.pythonhosted.org/packages/ec/5c/76ece7b401b088daa6503d6264dd80f9a727df3e6042802de9a223084ea2/wrapt-2.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:b89f095fe98bc12107f82a9f7d570dc83a0870291aeb6b1d7a7d35575f55d98a", size = 58756, upload-time = "2026-03-06T02:53:16.319Z" },
     { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
+]
+
+[[package]]
+name = "xxhash"
+version = "3.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/63/71aa56b151a1b28770037a61bd4e461c2619cfc8866a4fcaf1548605e325/xxhash-3.8.1.tar.gz", hash = "sha256:b0de4bf3aa66363552d52c6a89003c479911f12098cd48a53d44a0f7a25f7c46", size = 86223, upload-time = "2026-07-06T10:49:58.937Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/5a/05eaa129555f85476a3e16ff869e95f81a78bbe4647eef9d0229f515a317/xxhash-3.8.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:602efcad4a42c184e81d43a2b7e6e4f524d619878f2b6ee2ba469011f47c8147", size = 34699, upload-time = "2026-07-06T10:44:10.14Z" },
+    { url = "https://files.pythonhosted.org/packages/80/59/0df1133958b2228929355e022aab1e958c7b2c43e27bf7f59bc9edfa8a54/xxhash-3.8.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:131324f719957b988861714de7d6ddf57b47abec3b0cc691302ffeaba0e05e10", size = 32373, upload-time = "2026-07-06T10:44:11.353Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/bf/1cfda5b5e6bf26617812b4a31662ef2220d2ad04e0a55b8ff9eb36e56a5c/xxhash-3.8.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:db77278a6eddadbf44ce5aae2fee5ebb4d061f026b1ce2130d058cd4d7a7b670", size = 220284, upload-time = "2026-07-06T10:44:12.683Z" },
+    { url = "https://files.pythonhosted.org/packages/70/93/45dc0ad7913b69e5b08bd039236cf628380e4c9cc76a8a4c6625a328e058/xxhash-3.8.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c332dd48b8cb050da2bb2a3c96d72b1664168650a250ef9718e423df7989e05", size = 240980, upload-time = "2026-07-06T10:44:14.297Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/02/f28ba7d17f2c1410ee397982c817ab1bd5b2701070c2d2c373539aad000a/xxhash-3.8.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a5cd96f6dcdf4fa657b2d95668d71d58455248f98712ecffaa9c528edf40ccae", size = 264526, upload-time = "2026-07-06T10:44:16.017Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/d0/f10651cec2c7981b20d693deae6bdfc438427d92be2db4ccabb6181f0021/xxhash-3.8.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c959f88160b13b4e730b0d75b459b7929fc0d2225c284c9683ac95d6feeeac6a", size = 241369, upload-time = "2026-07-06T10:44:17.698Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/136e0cbaf5db51e191423b1c98643593189f02b6cd90837bf64b19113d70/xxhash-3.8.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:027dee4355f3fcc41481650d846cf6cfc895c85a1ab7acd063063821a0df5b4c", size = 473186, upload-time = "2026-07-06T10:44:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/3f/6aa808a96bdc43dba9a740dec56c744526ee3c0019e32c75e810fa90ae4d/xxhash-3.8.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ad52a0e4bcc0ba956a953a169d1feec2734a64981d689e4fc8f490f7bf91af60", size = 220092, upload-time = "2026-07-06T10:44:20.956Z" },
+    { url = "https://files.pythonhosted.org/packages/47/28/a8675e78a9ced96dab853416162268e10e05b452e95db7888cf69f58ac5f/xxhash-3.8.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5d3dfb1f0ff146da7952867a9414f0c7a29762f8825a84879592612fd6139342", size = 309846, upload-time = "2026-07-06T10:44:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/89/0f/7fe4d4ef4e69f0033e012396ee2a115886bca7b10b7e45ce398626436bfc/xxhash-3.8.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4482380b462ca9e59994d072a877ecadd1cf51102daeeab2db696f96ab763723", size = 237659, upload-time = "2026-07-06T10:44:24.135Z" },
+    { url = "https://files.pythonhosted.org/packages/38/8f/83e9e31d4ed57fe963b99cb5b13a23e3e0f0dad1885aa0ebd2a7819dd423/xxhash-3.8.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:950ac754d16daea42038f38e7465eb84cda4d08d7343c1c915771b29470f065a", size = 268737, upload-time = "2026-07-06T10:44:25.875Z" },
+    { url = "https://files.pythonhosted.org/packages/57/79/7e7de46dbe5d1f49afc96a0bc42e6b8df24eae3d6bad6007b99e42f48430/xxhash-3.8.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0418ec8b2331b9d4d575fc9284427e8e69449d7172e99e1a86fcdd1f51a0a937", size = 224955, upload-time = "2026-07-06T10:44:27.777Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/34/b8540839e958d5ef5c6101af6f16032109e7099698ae8edbc8dcefe4d8f4/xxhash-3.8.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:32a94ad2763e0263d9102037d349002c3d3c401e42770542c3eeb4801f311661", size = 239653, upload-time = "2026-07-06T10:44:29.422Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/87/a735d05f7f859354acadabe470ff40e2c46672275f96dcf096a761904def/xxhash-3.8.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:89b11a5cdd441aa463f6d34ca0241602bc09b001a76994b6059828494108c673", size = 300213, upload-time = "2026-07-06T10:44:31.401Z" },
+    { url = "https://files.pythonhosted.org/packages/98/31/3e1cb020237b68117fc212dc5f9753b87f865b4dfee7c1ce62d0836955b5/xxhash-3.8.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:09a204dd4bb0823daf938cdd0dc8057d5f1e14fe3cbde929424255f23f9de872", size = 442508, upload-time = "2026-07-06T10:44:33.023Z" },
+    { url = "https://files.pythonhosted.org/packages/23/bf/f80090622141cc734b039ce1d15ce3ff6dced375e9680249bf5b9b8c6bf9/xxhash-3.8.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e710ad822c493fb80a4fbc1e3d0a807b1422cb90adbe64378f98291b7fa48fef", size = 216853, upload-time = "2026-07-06T10:44:34.983Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/a3/60157acecc307b238d3651c2483168e224b48b23a36ae6d6903588341d80/xxhash-3.8.1-cp311-cp311-win32.whl", hash = "sha256:5013be3bea7612852c62a7437f3302c1cfb91ca7e703b194459db0b2b2e0d792", size = 31936, upload-time = "2026-07-06T10:44:36.542Z" },
+    { url = "https://files.pythonhosted.org/packages/59/5c/ef70c418d878d187b8da56d4cdc06aea6cf5e456b301e96e51e1d2cc8625/xxhash-3.8.1-cp311-cp311-win_amd64.whl", hash = "sha256:f377012b86c0a23a1df0cf5a1b05aa7187649e472f71c7892e5f2c2815bbe74f", size = 32724, upload-time = "2026-07-06T10:44:38.177Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/25/f008db952cec6b2a26445b456eeed2ebebd65e08e848ebe09ed6ac0634e6/xxhash-3.8.1-cp311-cp311-win_arm64.whl", hash = "sha256:836f11d4474d3228e9909d97216faa4f7505df41cfaf3927eb29809de785a78d", size = 29212, upload-time = "2026-07-06T10:44:39.577Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e4/4d8040435aeac814fc69ba63621565fbeb19229a138e2568324a26b2a45c/xxhash-3.8.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:39c9d5b61508b0bb68f29e54546de0ed2a74943c6a18585535a7e37356f1dd12", size = 32687, upload-time = "2026-07-06T10:49:42.803Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6a/975f1f2318c760e5bcec109ed379713ae645d8d856c2a3b9ec5d26857087/xxhash-3.8.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:83b9130b80b216d56fdf9e87131946b353c9627930c061955a101ea82b09fed9", size = 29879, upload-time = "2026-07-06T10:49:45.172Z" },
+    { url = "https://files.pythonhosted.org/packages/08/0b/40a2a55ff52cf635bfdc5eae67a772bec85b4f44c6c737f73f6f528d51d1/xxhash-3.8.1-pp311-pypy311_pp73-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8304be0982130954b7fd3aad18e2c6f8ee40254bc3d2e635991c16d77c91e2bd", size = 43246, upload-time = "2026-07-06T10:49:47.905Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6d/56ed2b6b200f26fb474f3fd387d95d0601efcd5bb33430c90c68924bdd77/xxhash-3.8.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b512261801b1e5fde7b6ebf2fef7977339c620cbbca88a0040ad9ad134f4d02", size = 38202, upload-time = "2026-07-06T10:49:50.59Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/a3/56864d895d1161a9f17502088e9c1fb7c06bde2c2efdde620d22bb7a9c43/xxhash-3.8.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:49aa8692507835dcc1e8ad8021f20c74c2dc13d83b5112e87877faa2a0035b20", size = 34448, upload-time = "2026-07-06T10:49:53.242Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/57/5c6e0908a47f61dca96d01c8ee6fce01ed1050611eb779083ba8758fed81/xxhash-3.8.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:345b07b78e2bf583d71682aa34ae5b5fab575f7a1cb31e10263ebbc6f89f8c42", size = 32869, upload-time = "2026-07-06T10:49:55.972Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.24.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/12/1e8f37460ea0f7eb59c221fdaf0ed75e7ac43e97f8093b9c6f411df50a78/yarl-1.24.2.tar.gz", hash = "sha256:9ac374123c6fd7abf64d1fec93962b0bd4ee2c19751755a762a72dd96c0378f8", size = 210798, upload-time = "2026-05-19T21:31:05.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/c5/1ce244152ff2839645e7cae92f90e7bafcb2c52bea7ff586ac714f14f5df/yarl-1.24.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:36348bebb147b83818b9d7e673ea4debc75970afc6ffdc7e3975ad05ce5a58c1", size = 128971, upload-time = "2026-05-19T21:28:20.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5a/00f36967203ed89cb3acd2c8ed526cc3fed9418eb70ce128160a911c8499/yarl-1.24.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1a97e42c8a2233f2f279ecadd9e4a037bcb5d813b78435e8eedd4db5a9e9708c", size = 91507, upload-time = "2026-05-19T21:28:22.556Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d0/1fb0c1cd27288f39f6974da4318c32768d72c9890984541fdf1e2e32a51d/yarl-1.24.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8d027d56f1035e339d1001ac33eceab5b2ec8e42e449787bb75e289fb9a5cd1d", size = 91343, upload-time = "2026-05-19T21:28:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/03/ce/d4a646508bed2f8dec6435b40166fe9308dd191262033d3f307b2bbcaecd/yarl-1.24.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a6377060e7927187a42b7eb202090cbe2b34933a4eeaf90e3bd9e33432e5cae", size = 105704, upload-time = "2026-05-19T21:28:25.872Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/07/b3278e82d8bc41485bcf6d856cd0433262593de615b1d3dc43bd3f5bead4/yarl-1.24.2-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:17076578bce0049a5ce57d14ad1bded391b68a3b213e9b81b0097b090244999a", size = 97281, upload-time = "2026-05-19T21:28:27.352Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5b/4cee6e7c92e487bebe7afc797da0aa54a248ab4e776a68fe369ec29665a5/yarl-1.24.2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:50713f1d4d6be6375bb178bb43d140ee1acb8abe589cd723320b7925a275be1e", size = 114020, upload-time = "2026-05-19T21:28:29.458Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/82/111076571545a7d4f9cca3fbd5c6f40615af58642be09f12328f48022468/yarl-1.24.2-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:34263e2fa8fb5bb63a0d97706cda38edbad62fddb58c7f12d6acbc092812aa50", size = 111450, upload-time = "2026-05-19T21:28:31.262Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ec/08f671f69a444d704aeecebf92af659b67b97a869942411d0a578b08c334/yarl-1.24.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:49016d82f032b1bd1e10b01078a7d29ae71bf468eeae0ea22df8bab691e60003", size = 106384, upload-time = "2026-05-19T21:28:32.856Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/86/ce41e7a7a199340b2330d52b60f25c4074b6636dd0e60b1a80d31a9db042/yarl-1.24.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3f6d2c216318f8f32038ca3f72501ba08536f0fd18a36e858836b121b2deed9f", size = 106153, upload-time = "2026-05-19T21:28:35.222Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5d/31be8a729531ab3e55ac3e7e5c800be8c89ea98947f418b2f6ea259fb6ee/yarl-1.24.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:08d3a33218e0c64393e7610284e770409a9c31c429b078bcb24096ed0a783b8f", size = 105322, upload-time = "2026-05-19T21:28:36.642Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9b/b57afb22b386ae87ac9940f09878b98d8c333f89113e6fc96fcf4ca9eb64/yarl-1.24.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:5d699376c4ca3cba49bbfae3a05b5b70ded572937171ce1e0b8d87118e2ba294", size = 99057, upload-time = "2026-05-19T21:28:38.386Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/4f/06348c27c8389256c313e8a57d796808fc0264c915dd5e7cfd3c0e314dc7/yarl-1.24.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:a1cab588b4fa14bea2e55ebea27478adfb05372f47573738e1acc4a36c0b05d2", size = 113502, upload-time = "2026-05-19T21:28:40.091Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/1c/284f307b298e4a17b7943b07d9d7ecc4151537f8d137ba51f3bb6c31ca20/yarl-1.24.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:ec87ccc31bd21db7ad009d8572c127c1000f268517618a4cc09adba3c2a7f21c", size = 105253, upload-time = "2026-05-19T21:28:41.987Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/bf/0de123bec8619e45c80cbded9085f61b5b4a9eddb8abe6d25d28ee1ec866/yarl-1.24.2-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d1dd47a22843b212baa8d74f37796815d43bd046b42a0f41e9da433386c3136b", size = 111345, upload-time = "2026-05-19T21:28:43.93Z" },
+    { url = "https://files.pythonhosted.org/packages/90/af/0248eb065e51129d2a9b2436cd1b5c772c19a6b04e5b6a186955671e3319/yarl-1.24.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7b54b9c67c2b06bd7b9a77253d242124b9c95d2c02def5a1144001ee547dd9d5", size = 106558, upload-time = "2026-05-19T21:28:45.806Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3c/f960d7a65ef97d8ba9b424fb5128796a4bc710fc6df2ddbbd7dfdc3bbd20/yarl-1.24.2-cp311-cp311-win_amd64.whl", hash = "sha256:f8fdbcff8b2c7c9284e60c196f693588598ddcee31e11c18e14949ce44519d45", size = 92808, upload-time = "2026-05-19T21:28:48.465Z" },
+    { url = "https://files.pythonhosted.org/packages/03/1a/49fb03750e4de4d2284cd5b885a383133c34eef45bd59631b2bb8b7e81e8/yarl-1.24.2-cp311-cp311-win_arm64.whl", hash = "sha256:b32c37a7a337e90822c45797bf3d79d60875cfcccd3ecc80e9f453d87026c122", size = 87610, upload-time = "2026-05-19T21:28:50.07Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4d/4b880086bd0d3e034d25647be1d830afc3e3f610e98c4ab3490af6b1b6d5/yarl-1.24.2-py3-none-any.whl", hash = "sha256:2783d9226db8797636cd6896e4de81feed252d1db72265686c9558d97a4d94b9", size = 53576, upload-time = "2026-05-19T21:31:03.909Z" },
 ]


### PR DESCRIPTION
## Summary

Extends Amulet to a decoder-LLM setting through the **existing** `PoisoningAttack` API, demonstrating the extensibility (D3) and applicability (D4) design requirements on a genuine 1B-parameter language model without new core abstractions. All new capabilities sit behind an optional `llm` extra, so the base install is untouched.

Reports two cross-risk interactions on the textual backdoor: an **intended** one (backdoor vs. ONION) and an **unintended** one (backdoor vs. DP-LoRA fine-tuning, reusing the existing `DPSGD` defense).

## What's added

- **Text modality**: `TextTensorDataset` (a `TensorDataset` of padded `input_ids` that also carries raw `.texts` and `.tokenizer_name`), `AmuletDataset.modality` widened to include `"text"`, and `load_sst2` / `load_agnews` / `load_imdb` loaders via Hugging Face `datasets` (namespaced hub ids, project-local `./data/<name>` cache).
- **Attack**: `TextBadNets` — BadNets/AddSent-style trigger insertion in string space; a pure, deterministic transform mirroring the image `BadNets`.
- **Victim**: `HFTextClassifier` — `AutoModelForSequenceClassification` + LoRA (frozen base, adapters + `score` head trainable). Single-tensor / bare-logits `forward` so the existing `train_classifier`, `DPSGD.train_private`, and `get_accuracy` drive it unchanged.
- **Defenses**: `ONION` (perplexity-based input purification) on a new `InferenceTimeDefense` base, plus the reused `DPSGD` path (fp32 trainable params, required for Opacus per-sample clipping).
- **Example**: `examples/attack_pipelines/run_text_backdoor.py` reporting the undefended backdoor, the ONION interaction, and the DP-LoRA interaction.
- **Tests**: unit (`test_text_badnets.py`) and integration (`test_onion.py`, `test_text_backdoor_integration.py`) tiers, HF-import-guarded so the default suite stays green without the extra.

## Build change: torch CUDA extras

Torch is now selected via mutually-exclusive `cpu` / `cu128` / `cu130` extras (pinned to 2.11.0, the newest release with both cu128 and cu130 wheels, routed to the matching PyTorch index). The base keeps a loose floor so `pip install amuletml` still works off PyPI; the extras exist so a `uv sync` produces a driver-correct GPU build instead of a cu13 wheel that silently runs on CPU. **`uv sync --all-extras` is no longer valid** (the CUDA extras conflict); sync with exactly one, e.g. `uv sync --extra cu128 --extra llm`.

## Verification

- Full default suite: **269 passed** on `torch==2.11.0+cu128`, no regressions.
- New poisoning tests: 9 unit + 17 integration passed.
- `cu130` extra resolves cleanly; `cu128` verified installed and GPU-visible on the dev box.
- Pipeline verified end-to-end on real TinyLlama-1.1B on GPU: DP-LoRA (ε finite, grads reaching both LoRA and head), ASR via `get_accuracy`, and the ONION purify round-trip.
- `pre-commit run --all-files` green (ruff, ruff-format, basedpyright, prettier, markdownlint).

## Docs

AGENTS.md, README, GETTING_STARTED, CONTRIBUTING, and the poisoning module guide updated for the text modality, the textual backdoor, the new defense method, and the torch build extras. The extensibility example (`custom_architecture.md`) now subclasses `AmuletModel`.

## Notes / follow-ups

- `HFTextClassifier` is **not** wired into `initialize_model`: its constructor (hub id, LoRA rank, dtype) does not fit the `(arch, capacity, num_features, num_classes)` signature. Filed #104 to replace `DEFAULT_CAPACITY_MAP` with a per-model registry/factory.
- ViT (#101) is the natural next architecture and is now unblocked (shares this HF stack); not part of this PR.
- The `gpu`/`slow` efficacy experiments (10× repeats, the three tables) remain future work.

Closes #84
Closes #102
Closes #103
