### PR TITLE
feat(dp): opt-in BatchMemoryManager for DPSGD

### DIFF
--- a/amulet/membership_inference/defenses/dp_sgd.py
+++ b/amulet/membership_inference/defenses/dp_sgd.py
@@ -1,8 +1,11 @@
 """Differential Privacy implementation"""
 
+from contextlib import nullcontext
+
 import torch
 import torch.nn as nn
 from opacus import PrivacyEngine
+from opacus.utils.batch_memory_manager import BatchMemoryManager
 from torch.utils.data import DataLoader
 
 from .membership_inference_defense import MembershipInferenceDefense
@@ -31,6 +34,11 @@ class DPSGD(MembershipInferenceDefense):
             Whether to use secure RNG for trustworthy privacy guarantees. Comes at a privacy cost.
         epochs: int
             Determines number of iterations over training data.
+        max_physical_batch_size: int | None
+            When set, each logical batch is split into physical micro-batches of at most
+            this size (via Opacus' ``BatchMemoryManager``) to bound peak per-sample-gradient
+            memory. The logical batch size — and therefore the privacy accounting and expected
+            utility — is unchanged. ``None`` (default) iterates the loader without splitting.
     """
 
     def __init__(
@@ -45,10 +53,12 @@ class DPSGD(MembershipInferenceDefense):
         sigma: float,
         secure_rng: bool = False,
         epochs: int = 5,
+        max_physical_batch_size: int | None = None,
     ):
         super().__init__(model, criterion, optimizer, train_loader, device, epochs)
         self.privacy_engine = PrivacyEngine(secure_mode=secure_rng)
         self.delta = delta
+        self.max_physical_batch_size = max_physical_batch_size
         self.model.train()
         self.model, self.optimizer, self.train_loader = (
             self.privacy_engine.make_private(
@@ -74,21 +84,33 @@ class DPSGD(MembershipInferenceDefense):
             acc = 0
             total = 0
             last_loss: torch.Tensor | None = None
-            for batch_idx, (data, target) in enumerate(self.train_loader):
-                data, target = data.to(self.device), target.to(self.device)
-                self.optimizer.zero_grad()
-                output = self.model(data)
-                _, pred = torch.max(output, 1)
-                loss = self.criterion(output, target)
-                loss.backward()
-                self.optimizer.step()
-                acc += pred.eq(target).sum().item()
-                total += len(target)
-                last_loss = loss
-                if batch_idx % 2000 == 0:
-                    print(
-                        f"Train Epoch: {epoch} Loss: {loss.item():.6f} Acc: {acc / total * 100:.2f}"
-                    )
+            # BatchMemoryManager splits each logical batch into physical micro-batches to
+            # bound peak per-sample-gradient memory; nullcontext preserves today's behavior
+            # exactly when no cap is set. Either way the per-step loop body is unchanged.
+            if self.max_physical_batch_size is not None:
+                batch_loader = BatchMemoryManager(
+                    data_loader=self.train_loader,
+                    max_physical_batch_size=self.max_physical_batch_size,
+                    optimizer=self.optimizer,
+                )
+            else:
+                batch_loader = nullcontext(self.train_loader)
+            with batch_loader as loader:
+                for batch_idx, (data, target) in enumerate(loader):
+                    data, target = data.to(self.device), target.to(self.device)
+                    self.optimizer.zero_grad()
+                    output = self.model(data)
+                    _, pred = torch.max(output, 1)
+                    loss = self.criterion(output, target)
+                    loss.backward()
+                    self.optimizer.step()
+                    acc += pred.eq(target).sum().item()
+                    total += len(target)
+                    last_loss = loss
+                    if batch_idx % 2000 == 0:
+                        print(
+                            f"Train Epoch: {epoch} Loss: {loss.item():.6f} Acc: {acc / total * 100:.2f}"
+                        )
             if last_loss is not None:
                 epsilon = self.privacy_engine.accountant.get_epsilon(delta=self.delta)
                 print(

--- a/tests/membership_inference/test_dp_sgd.py
+++ b/tests/membership_inference/test_dp_sgd.py
@@ -73,3 +73,71 @@ def test_dpsgd_reproducible(
         return defense.train_private()
 
     _assert_state_dicts_equal(run(), run())
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(60)
+def test_dpsgd_batch_memory_manager_smoke(tiny_classifier, tiny_loader, device):
+    """A capped run (max_physical_batch_size smaller than the loader's logical batch)
+    trains successfully and still produces a finite ε > 0."""
+    criterion = torch.nn.CrossEntropyLoss()
+    optimizer = torch.optim.SGD(tiny_classifier.parameters(), lr=1e-3)
+
+    defense = DPSGD(
+        model=tiny_classifier,
+        criterion=criterion,
+        optimizer=optimizer,
+        train_loader=tiny_loader,
+        device=device,
+        delta=1e-5,
+        max_per_sample_grad_norm=1.0,
+        sigma=1.0,
+        epochs=1,
+        max_physical_batch_size=4,  # tiny_loader's batch_size is 8
+    )
+
+    trained_model = defense.train_private()
+
+    assert isinstance(trained_model, torch.nn.Module)
+    epsilon = defense.privacy_engine.accountant.get_epsilon(delta=1e-5)
+    assert epsilon > 0
+    assert np.isfinite(epsilon)
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(60)
+def test_dpsgd_batch_memory_manager_accounting_invariant(
+    tiny_classifier_factory, tiny_loader, seed_everything, cpu_device
+):
+    """BatchMemoryManager splits each logical batch into physical micro-batches to bound
+    peak per-sample-gradient memory. It must not touch the privacy accounting: the logical
+    batch size — and therefore ε — is preserved. With the same seed, a capped run and an
+    uncapped run report the same ε.
+
+    Model weights are deliberately not compared: micro-batch gradient accumulation makes
+    the exact realization differ, so ε-equality is the invariant, not bit-identical weights.
+    """
+
+    def run(max_physical_batch_size: int | None) -> float:
+        seed_everything(7)
+        model = tiny_classifier_factory(device=cpu_device)
+        optimizer = torch.optim.SGD(model.parameters(), lr=1e-3)
+        defense = DPSGD(
+            model=model,
+            criterion=torch.nn.CrossEntropyLoss(),
+            optimizer=optimizer,
+            train_loader=tiny_loader,
+            device=cpu_device,
+            delta=1e-5,
+            max_per_sample_grad_norm=1.0,
+            sigma=1.0,
+            epochs=1,
+            max_physical_batch_size=max_physical_batch_size,
+        )
+        defense.train_private()
+        return defense.privacy_engine.accountant.get_epsilon(delta=1e-5)
+
+    capped = run(max_physical_batch_size=4)  # tiny_loader's batch_size is 8
+    uncapped = run(max_physical_batch_size=None)
+
+    assert capped == uncapped


### PR DESCRIPTION
## What

Adds an opt-in `max_physical_batch_size` argument to `DPSGD`. When set, each logical batch is split into physical micro-batches via Opacus' `BatchMemoryManager`, bounding peak per-sample-gradient memory. When `None` (default), behavior is unchanged — the existing training path is preserved exactly (via `nullcontext`).

## Why

DP-SGD's per-sample gradients make memory scale with the batch size, which can exceed the GPU for large models (e.g. a LoRA-adapted Llama-3.2-3B victim). `BatchMemoryManager` lets us keep the **logical** batch size — and therefore the privacy accounting (ε) and expected utility — while capping the **physical** micro-batch that actually sits in memory. In practice this cut a batch-32 DP victim from ~67 GB to ~21 GB at `max_physical_batch_size=8`, enabling it to run alongside other jobs.

## Correctness

Physical batching must not change the privacy guarantee. Added two integration tests:
- **Smoke:** a capped run trains and yields a finite ε > 0.
- **Accounting invariance:** with the same seed, capped and uncapped runs report an **identical ε** (Opacus advances the accountant once per *logical* batch). Model weights are intentionally not compared — micro-batch gradient accumulation and dropout make the exact realization differ, so ε-equality is the invariant.

## Testing

- `uv run pytest tests/membership_inference/test_dp_sgd.py` — 6 passed (2 new + existing smoke/repro), CPU and CUDA.
- `uv run pre-commit run --all-files` — clean (ruff, ruff-format, basedpyright, prettier, markdownlint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)