### PR TITLE
docs: comprehensive documentation sweep (docstrings + markdown)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,11 +13,11 @@ Requires Python ~=3.11.0. Torch is selected via a hardware-specific extra (`cpu`
 ## Where to find things
 
 - **Dev setup, deps, lint/typecheck config:** [`pyproject.toml`](pyproject.toml) and [`.pre-commit-config.yaml`](.pre-commit-config.yaml)
-- **Risk modules:** `amulet/<risk>/` — each has `attacks/`, `defenses/`, and optionally `metrics/` subpackages
+- **Risk modules:** `amulet/<risk>/`, each with `attacks/`, `defenses/`, and optionally `metrics/` subpackages
   - Security: [`evasion/`](amulet/evasion/), [`poisoning/`](amulet/poisoning/), [`unauth_model_ownership/`](amulet/unauth_model_ownership/)
   - Privacy: [`membership_inference/`](amulet/membership_inference/), [`attribute_inference/`](amulet/attribute_inference/), [`distribution_inference/`](amulet/distribution_inference/), [`data_reconstruction/`](amulet/data_reconstruction/)
   - Fairness: [`discriminatory_behavior/`](amulet/discriminatory_behavior/)
-- **Shared training/eval utilities:** [`amulet/utils/`](amulet/utils/) — check here before implementing your own helpers. If a needed utility is missing, add it to `amulet/utils/` and submit a PR — functionality useful in one risk module is likely useful elsewhere.
+- **Shared training/eval utilities:** [`amulet/utils/`](amulet/utils/). Check here before implementing your own helpers. If a needed utility is missing, add it to `amulet/utils/` and submit a PR. Functionality useful in one risk module is likely useful elsewhere.
 - **Dataset loaders:** [`amulet/datasets/`](amulet/datasets/)
 - **Model base class and architectures:** [`amulet/models/`](amulet/models/)
 - **Runnable pipelines:** [`examples/attack_pipelines/`](examples/attack_pipelines/) and [`examples/defense_pipelines/`](examples/defense_pipelines/)
@@ -50,7 +50,9 @@ uv run ruff format .
 uv run basedpyright                # standard mode; venv is .venv (configured in pyproject.toml)
 ```
 
-Tests live in `tests/` (`unit/` and `integration/`).
+Tests live in `tests/`, organized by module (`tests/<risk>/` per risk, plus `models/`, `datasets/`, `utils/`, and the top-level `tests/test_api_conformance.py`).
+They are tiered by pytest markers (`integration`, `gpu`, `slow`) declared in `[tool.pytest.ini_options]`.
+The default `addopts` deselects all three (`-m 'not integration and not gpu and not slow'`), so a bare `uv run pytest` runs only the fast, unmarked tests.
 Run examples as end-to-end smoke tests:
 
 ```bash
@@ -66,7 +68,7 @@ Attacks and defenses must not emit metrics.
 They return outputs (e.g. adversarial `DataLoader`, defended `nn.Module`) consumed by metrics in `amulet/utils/__metrics.py` or the risk's own `metrics/`.
 
 Each risk has an ABC base class in `amulet/<risk>/attacks/` and `amulet/<risk>/defenses/`.
-**Every defense must implement its risk's training-shaped entry-point method** — this is a
+**Every defense must implement its risk's training-shaped entry-point method.** This is a
 hard convention, not a suggestion, and it is enforced by `tests/test_api_conformance.py`
 (a defense exposing only a bespoke method fails CI). The standard entry-point methods are:
 
@@ -83,13 +85,13 @@ hard convention, not a suggestion, and it is enforced by `tests/test_api_conform
 A defense may expose extra public helpers in addition to its entry point, never instead
 of it. `ONION` is the reference case: it is a poisoning defense subclassing
 `PoisoningDefense` alongside `OutlierRemoval`, so it implements `train_robust()` (purify the
-poisoned training data, then retrain the victim) — and it also exposes
+poisoned training data, then retrain the victim), and it also exposes
 `purify(dataset)` for cleaning inputs at test time. Do not add a defense on a bespoke base
 class with a non-standard entry point; reshape the shared base instead. The textual backdoor
 attack `TextBadNets` and the LoRA-LLM victim `HFCausalLM` need the optional `llm` extra; see
 [Optional extras](#optional-extras).
 
-Some classes expose additional public helpers for experimentation — for example, `MembershipInferenceAttack` has `train_shadow_model()` / `prepare_shadow_models()` and `DistributionInferenceAttack` has `train_model_population()` / `prepare_model_populations()`.
+Some classes expose additional public helpers for experimentation. For example, `MembershipInferenceAttack` has `train_shadow_model()` / `prepare_shadow_models()` and `DistributionInferenceAttack` has `train_model_population()` / `prepare_model_populations()`.
 Check the base class before assuming `attack()` is the only callable.
 
 ### Models
@@ -98,12 +100,12 @@ Any model under `amulet/models/` must subclass `AmuletModel` ([`amulet/models/ba
 Several modules depend on intermediate activations; omitting `get_hidden` breaks them silently.
 Match the base signature's parameter name `x` on both `forward` and `get_hidden` (basedpyright enforces override compatibility), even when the input is token ids rather than pixels.
 
-`HFCausalLM` ([`amulet/models/hf_causal_lm.py`](amulet/models/hf_causal_lm.py)) is the reference example of subclassing `AmuletModel` around a real pretrained backbone: a LoRA-adapted HuggingFace **causal (decoder-only) LM** (Llama, GPT-2, Mistral, …) that keeps its generative base. One shared adapted decoder backs three roles — classification (`forward` returns the bare logits tensor, not the `SequenceClassifierOutput`, so `train_classifier`, `DPSGD.train_private`, and `get_accuracy` drive it unchanged), perplexity scoring (`perplexity`, what `ONION` consumes — the victim itself is the reference LM), and generation (`generate`). Encoder-only (BERT) and seq2seq (T5) models do not fit and are out of scope. It needs the `llm` extra.
+`HFCausalLM` ([`amulet/models/hf_causal_lm.py`](amulet/models/hf_causal_lm.py)) is the reference example of subclassing `AmuletModel` around a real pretrained backbone: a LoRA-adapted HuggingFace **causal (decoder-only) LM** (Llama, GPT-2, Mistral, …) that keeps its generative base. One shared adapted decoder backs three roles: classification (`forward` returns the bare logits tensor, not the `SequenceClassifierOutput`, so `train_classifier`, `DPSGD.train_private`, and `get_accuracy` drive it unchanged), perplexity scoring (`perplexity`, what `ONION` consumes, since the victim itself is the reference LM), and generation (`generate`). Encoder-only (BERT) and seq2seq (T5) models do not fit and are out of scope. It needs the `llm` extra.
 
 `initialize_model` uses a central capacity map and only covers the built-in CNNs; models whose constructors do not fit its `(arch, capacity, num_features, num_classes)` signature (e.g. `HFCausalLM`) are constructed directly. See #104.
 
 `WatermarkNN` and `DatasetInference` have separate ABC base classes (`WatermarkDefense`, `FingerprintDefense`).
-There is no shared parent — this is intentional.
+There is no shared parent. This is intentional.
 
 ### Datasets
 
@@ -111,9 +113,9 @@ Image loaders follow a 3-step fallback to ensure availability:
 
 1. **Processed local** (e.g. `celeba.npz`, `lfw_images.npz`)
 2. **Raw local** (e.g. `img_align_celeba/`, `lfw_home/`)
-3. **GDrive download** — IDs are hard-coded in [`amulet/datasets/__image_datasets.py`](amulet/datasets/__image_datasets.py) (similar to how PyTorch ships dataset URLs), so no configuration is needed.
+3. **GDrive download**: IDs are hard-coded in [`amulet/datasets/__image_datasets.py`](amulet/datasets/__image_datasets.py) (similar to how PyTorch ships dataset URLs), so no configuration is needed.
 
-Text loaders ([`amulet/datasets/__text_datasets.py`](amulet/datasets/__text_datasets.py): `load_sst2`, `load_agnews`, `load_imdb`) instead pull from the Hugging Face hub via `datasets` into a project-local `./data/<name>` cache. That divergence is intentional: HF manages text corpora and their splits. They return an `AmuletDataset` with `modality="text"` whose `train_set`/`test_set` are `TextTensorDataset` instances — a `TensorDataset` of padded `input_ids` that also carries the raw `.texts` (so ONION can re-score perplexity before the victim tokenizer runs) and the `tokenizer_name`. `AmuletDataset.modality` is `Literal["image", "tabular", "text"]`. Text loaders need the `llm` extra.
+Text loaders ([`amulet/datasets/__text_datasets.py`](amulet/datasets/__text_datasets.py): `load_sst2`, `load_agnews`, `load_imdb`) instead pull from the Hugging Face hub via `datasets` into a project-local `./data/<name>` cache. That divergence is intentional: HF manages text corpora and their splits. They return an `AmuletDataset` with `modality="text"` whose `train_set`/`test_set` are `TextTensorDataset` instances, a `TensorDataset` of padded `input_ids` that also carries the raw `.texts` (so ONION can re-score perplexity before the victim tokenizer runs) and the `tokenizer_name`. `AmuletDataset.modality` is `Literal["image", "tabular", "text"]`. Text loaders need the `llm` extra.
 
 ### Optional extras
 
@@ -125,7 +127,7 @@ Text loaders ([`amulet/datasets/__text_datasets.py`](amulet/datasets/__text_data
 
 - Keep the `ruff-pre-commit` hook rev in sync with `ruff==` in `pyproject.toml`. A mismatch silently skips rules.
 - `B903` (class-could-be-dataclass) is globally ignored. Base classes that provide shared state for subclasses are a valid pattern here.
-- Pandas stubs: use `# type: ignore[reportArgumentType]` for `columns=list[str]` and `# type: ignore[reportAttributeAccessIssue]` for `.isin()`. Do not use `cast()` — established repo convention.
+- Pandas stubs: use `# type: ignore[reportArgumentType]` for `columns=list[str]` and `# type: ignore[reportAttributeAccessIssue]` for `.isin()`. Do not use `cast()`, an established repo convention.
 - Dependency versions are pinned exactly. `cleverhans`, `opacus`, and `captum` are sensitive to version drift. Do not loosen pins without a reason.
 - The package is published to PyPI as `amuletml`; the import name is `amulet`.
 - Docstrings use Google style: imperative summary line, `Args:` / `Returns:` / `Raises:` sections, no type repetition from the signature, no RST markup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+
+### Features
+
+* **poisoning:** textual backdoor attack with `TextBadNets`, the LoRA `HFCausalLM` victim, an ONION text purifier, and Hugging Face text loaders ([#105](https://github.com/ssg-research/amulet/issues/105)) ([eab3fa6](https://github.com/ssg-research/amulet/commit/eab3fa6c5447a9c936c2b3ecfe5f519b2d53dc88))
+* **dp:** opt-in `BatchMemoryManager` for DP-SGD ([#108](https://github.com/ssg-research/amulet/issues/108)) ([ca1f65a](https://github.com/ssg-research/amulet/commit/ca1f65a1e930b6de60f9296ee4b11bc4dc8c477c))
+
+
+### Bug Fixes
+
+* **poisoning:** unify the poisoning defense ABC, give ONION a real LLM, and batch its scoring ([#107](https://github.com/ssg-research/amulet/issues/107)) ([3b356b8](https://github.com/ssg-research/amulet/commit/3b356b814ddef555e7df08b09abe1a51ea323073))
+
 ## [0.5.3](https://github.com/ssg-research/amulet/compare/v0.5.2...v0.5.3) (2026-07-06)
 
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,12 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
+reported to the community leaders responsible for enforcement by opening an
+issue on the project repository at
+[ssg-research/amulet](https://github.com/ssg-research/amulet/issues).
+
+<!-- TODO: maintainers, replace with a private contact email -->
+
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Amulet is:
 - Consistent: Allows using different attacks/defenses/metrics with a consistent, easy-to-use API.
 - Applicable: Allows evaluating unintended interactions among defenses and attacks.
 
-Built to work with PyTorch
-, you can incorporate Amulet into your current ML pipeline to test how your model interacts with these state-of-the-art defenses and risks. Alternatively, you can use the example pipelines to bootstrap your pipeline.
+Built to work with PyTorch, you can incorporate Amulet into your current ML pipeline to test how your model interacts with these state-of-the-art defenses and risks. Alternatively, you can use the example pipelines to bootstrap your pipeline.
 
 ## Getting Started
 
@@ -31,13 +30,13 @@ For a reproducible GPU build (and for development), install from source with `uv
 
 ### Test installation
 
-To test your installation, please run [amulet/examples/get_started.py](https://github.com/ssg-research/amulet/blob/main/examples/get_started.py). This script also serves as a starting point to learn how to use the library.
+To test your installation, please run [examples/get_started.py](https://github.com/ssg-research/amulet/blob/main/examples/get_started.py). This script also serves as a starting point to learn how to use the library.
 
 ### Learn More
 
 For more information on the basics about the library, please see the [Getting Started guide](https://github.com/ssg-research/amulet/blob/main/docs/GETTING_STARTED.md).
 
-To see the attacks, defenses, and risks (modules) that Amulet implements, please refer to the **Module Heirarchy** (link TBD) in the Tutorial (link TBD).
+To see the attacks, defenses, and risks (modules) that Amulet implements, please refer to the [Module Hierarchy](https://github.com/ssg-research/amulet/blob/main/docs/module_guide/1_INTRO.md).
 
 For each module, please see [amulet/examples](https://github.com/ssg-research/amulet/tree/main/examples) for implementations of pipelines that include recommendations on how to run each module.
 

--- a/amulet/attribute_inference/attacks/attribute_inference_attack.py
+++ b/amulet/attribute_inference/attacks/attribute_inference_attack.py
@@ -7,20 +7,14 @@ import torch.nn as nn
 
 
 class AttributeInferenceAttack(ABC):
-    """
-    Base class for attribute inference attacks
+    """Base class for attribute inference attacks.
 
     Attributes:
-        target_model: torch.nn.Module
-            This model will be extracted.
-        x_train_adv: numpy.ndarray
-            input features for training adversary' attack model
-        x_test: numpy.ndarray
-            input features for testing adversary' attack model
-        z_train_adv: numpy.ndarray
-            sensitive attributes for training adversary' attack model
-        device: str
-            Device used to train model. Example: "cuda:0".
+        target_model: The target model whose sensitive attributes are inferred.
+        x_train_adv: Input features for training the adversary's attack model.
+        x_test: Input features for testing the adversary's attack model.
+        z_train_adv: Sensitive attributes for training the adversary's attack model.
+        device: Device used to train model. Example: "cuda:0".
     """
 
     def __init__(
@@ -39,4 +33,5 @@ class AttributeInferenceAttack(ABC):
 
     @abstractmethod
     def attack(self) -> dict[int, dict[str, np.ndarray]]:
+        """Run the attribute inference attack and return per-attribute results."""
         pass

--- a/amulet/attribute_inference/attacks/duddu_cikm_2022.py
+++ b/amulet/attribute_inference/attacks/duddu_cikm_2022.py
@@ -20,6 +20,7 @@ class DudduCIKM2022(AttributeInferenceAttack):
         x_train_adv: Input features for training the adversary attack model.
         x_test: Input features for testing the adversary attack model.
         z_train_adv: Sensitive attribute labels for training the adversary.
+        batch_size: Batch size used to query the target model.
         device: Device used to train model. Example: "cuda:0".
     """
 

--- a/amulet/data_reconstruction/attacks/data_reconstruction_attack.py
+++ b/amulet/data_reconstruction/attacks/data_reconstruction_attack.py
@@ -1,4 +1,4 @@
-"""Base class for Data Reconstruction Attacks"""
+"""Base class for Data Reconstruction Attacks."""
 
 from abc import ABC, abstractmethod
 
@@ -7,18 +7,13 @@ import torch.nn as nn
 
 
 class DataReconstructionAttack(ABC):
-    """
-    Base class for Data Reconstruction Attacks
-    Attributes::
-        ------------------------
-        target_model: torch.nn.Module
-            Target model whose training dataset we reconstruct
-        input_size: int
-            Size of the model's input
-        output_size: int
-            Size of the model's output
-        device: str
-            Device on which to load the PyTorch tensors. Example: "cuda:0".
+    """Base class for data reconstruction attacks.
+
+    Attributes:
+        target_model: Target model whose training dataset is reconstructed.
+        input_size: Shape of the model's input.
+        output_size: Size of the model's output.
+        device: Device on which to load the PyTorch tensors. Example: "cuda:0".
     """
 
     def __init__(
@@ -35,4 +30,9 @@ class DataReconstructionAttack(ABC):
 
     @abstractmethod
     def attack(self) -> list[torch.Tensor]:
+        """Reconstruct training data for each output class.
+
+        Returns:
+            List of reconstructed tensors, one per class.
+        """
         pass

--- a/amulet/data_reconstruction/metrics/similarity_evaluation.py
+++ b/amulet/data_reconstruction/metrics/similarity_evaluation.py
@@ -1,3 +1,5 @@
+"""Similarity metrics for evaluating data reconstruction quality."""
+
 from typing import TypedDict
 
 import numpy as np
@@ -8,6 +10,8 @@ from torch.utils.data import DataLoader
 
 
 class SimilarityResults(TypedDict):
+    """Per-class and averaged MSE/SSIM scores returned by evaluate_similarity."""
+
     mean_mse: float
     class_mse: dict[int, float]
     mean_ssim: float

--- a/amulet/datasets/__data.py
+++ b/amulet/datasets/__data.py
@@ -24,8 +24,8 @@ class AmuletDataset:
         num_classes: Number of output classes.
         modality: Describes the tensor shape seen by models. "image" for multi-dimensional
             (C, H, W) samples; "tabular" for 1-D feature vectors; "text" for token-id
-            vectors, where each sample is a padded ``input_ids`` tensor and the raw
-            strings are retained on the ``TextTensorDataset`` (see that class). LFW is
+            vectors, where each sample is a padded `input_ids` tensor and the raw
+            strings are retained on the `TextTensorDataset` (see that class). LFW is
             "tabular" because its images are flattened in the loader.
         sensitive_columns: Column names of z_train/z_test, in order. None if the
             dataset has no sensitive attributes.
@@ -52,25 +52,25 @@ class AmuletDataset:
 
 
 class TextTensorDataset(TensorDataset):
-    """TensorDataset of ``(input_ids, label)`` that also carries the raw strings.
+    """TensorDataset of `(input_ids, label)` that also carries the raw strings.
 
     This is the single artifact that flows attack -> victim -> defense for the text
-    modality. Because it subclasses :class:`torch.utils.data.TensorDataset` over
-    ``(input_ids, labels)``, it *is* a ``TensorDataset``: the
-    ``PoisoningAttack.poison_* -> TensorDataset`` return type, every
-    ``for (data, target) in loader`` consumer, and the single-tensor ``DPSGD``
+    modality. Because it subclasses `torch.utils.data.TensorDataset` over
+    `(input_ids, labels)`, it is a `TensorDataset`: the
+    `PoisoningAttack.poison_* -> TensorDataset` return type, every
+    `for (data, target) in loader` consumer, and the single-tensor `DPSGD`
     training loop all work unchanged and never see the extra state. Only the two
     extra attributes below carry the string view an input-purification defense
     (ONION) needs.
 
-    A ``DataLoader`` collates only the tensors; a consumer that needs the strings
-    reads ``loader.dataset.texts`` (dataset order), which is why a defense must
+    A `DataLoader` collates only the tensors; a consumer that needs the strings
+    reads `loader.dataset.texts` (dataset order), which is why a defense must
     purify the dataset before the (optionally shuffled) victim loader is built.
 
     Attributes:
         texts: The raw (possibly poisoned) strings in dataset order, one per row.
-        tokenizer_name: Name of the tokenizer that produced ``input_ids``, so a
-            defense can re-tokenize after purifying ``texts``.
+        tokenizer_name: Name of the tokenizer that produced `input_ids`, so a
+            defense can re-tokenize after purifying `texts`.
     """
 
     def __init__(
@@ -80,6 +80,11 @@ class TextTensorDataset(TensorDataset):
         texts: list[str],
         tokenizer_name: str,
     ):
+        """Build the dataset, checking that all inputs share the same row count.
+
+        Raises:
+            ValueError: If texts and input_ids have different numbers of rows.
+        """
         if len(texts) != input_ids.shape[0]:
             raise ValueError(
                 f"texts ({len(texts)}) and input_ids ({input_ids.shape[0]}) must have "

--- a/amulet/datasets/__image_datasets.py
+++ b/amulet/datasets/__image_datasets.py
@@ -80,7 +80,7 @@ def load_cifar100(
 
     Args:
         path: Directory where the dataset is stored or downloaded.
-        transform_train: Transforms applied to training images. Defaults to random crop + flip + color jitter + ToTensor.
+        transform_train: Transforms applied to training images. Defaults to random crop + flip + color jitter + ToTensor + random erasing.
         transform_test: Transforms applied to test images. Defaults to ToTensor.
 
     Returns:

--- a/amulet/datasets/__init__.py
+++ b/amulet/datasets/__init__.py
@@ -1,5 +1,5 @@
 """
-The module mlconf.datasets includes utilities to load datasets,
+The module `amulet.datasets` includes utilities to load datasets,
 including methods to load and fetch popular reference datasets.
 """
 

--- a/amulet/datasets/__tabular_datasets.py
+++ b/amulet/datasets/__tabular_datasets.py
@@ -245,8 +245,8 @@ def load_lfw(
     """
     Load the LFW dataset combined with face attributes for property inference.
 
-    Combines Scikit-Learn's LFW images with attribute annotations from the PubFig
-    dataset to enable distribution inference experiments.
+    Combines scikit-learn's LFW images with the attribute annotations shipped in
+    `lfw_attributes.txt` to enable distribution inference experiments.
 
     On first use the attributes file is downloaded from Google Drive and images are
     fetched via scikit-learn. Processed arrays are cached in a parameter-keyed .npz
@@ -256,9 +256,11 @@ def load_lfw(
 
     Args:
         path: Directory where raw and cached dataset files are stored.
-        target: Attribute to use as classification target. Options: "age", "gender", "race".
-        attribute_1: First sensitive attribute. Options: "age", "gender", "race".
-        attribute_2: Second sensitive attribute. Options: "age", "gender", "race".
+        target: Attribute to use as classification target. Options: "age",
+            "gender", "race", "glasses", "hair". "smile" is declared but not yet
+            implemented and raises ValueError.
+        attribute_1: First sensitive attribute. Same options as target.
+        attribute_2: Second sensitive attribute. Same options as target.
         test_size: Proportion of data used for testing.
         random_seed: Random seed for reproducible train/test splitting.
 

--- a/amulet/datasets/__text_datasets.py
+++ b/amulet/datasets/__text_datasets.py
@@ -1,19 +1,19 @@
 """Text-modality dataset loaders (SST-2, AG News, IMDB).
 
 These are the first text datasets in Amulet. They diverge from the GDrive 3-step
-fallback used by the image loaders in ``__image_datasets.py``: text corpora and their
-canonical splits are managed by Hugging Face ``datasets``, so these load from the HF
+fallback used by the image loaders in `__image_datasets.py`: text corpora and their
+canonical splits are managed by Hugging Face `datasets`, so these load from the HF
 hub (with a local cache). That divergence is intentional.
 
-The Hugging Face stack ships in the optional ``amuletml[llm]`` extra, so its imports
-are guarded: ``import amulet`` still works without the extra, and calling a loader
+The Hugging Face stack ships in the optional `amuletml[llm]` extra, so its imports
+are guarded: `import amulet` still works without the extra, and calling a loader
 without it raises a clear "install amuletml[llm]" error.
 
-Each loader tokenizes the raw strings with the victim tokenizer, pads ``input_ids`` to
+Each loader tokenizes the raw strings with the victim tokenizer, pads `input_ids` to
 a fixed per-dataset max sequence length, and retains the raw strings on the returned
-``TextTensorDataset`` so an input-purification defense (ONION) can re-score and
-re-tokenize them. SST-2 uses ``validation`` as its labelled test split (the public
-``test`` split has masked ``-1`` labels).
+`TextTensorDataset` so an input-purification defense (ONION) can re-score and
+re-tokenize them. SST-2 uses `validation` as its labelled test split (the public
+`test` split has masked `-1` labels).
 """
 
 from __future__ import annotations
@@ -50,10 +50,10 @@ def _load_tokenizer(tokenizer_name: str) -> PreTrainedTokenizerBase:
         tokenizer_name: Hub id of the tokenizer to load.
 
     Returns:
-        The loaded tokenizer with ``pad_token`` set.
+        The loaded tokenizer with `pad_token` set.
 
     Raises:
-        ImportError: If the optional ``llm`` extra is not installed.
+        ImportError: If the optional `llm` extra is not installed.
     """
     try:
         from transformers import AutoTokenizer
@@ -71,7 +71,7 @@ def _tokenize(
     tokenizer: PreTrainedTokenizerBase,
     max_length: int,
 ) -> torch.Tensor:
-    """Tokenize strings to a padded ``(N, max_length)`` LongTensor of ``input_ids``."""
+    """Tokenize strings to a padded `(N, max_length)` LongTensor of `input_ids`."""
     encoded = tokenizer(
         texts,
         padding="max_length",
@@ -83,7 +83,7 @@ def _tokenize(
 
 
 def _split_slice(split: str, max_samples: int | None) -> str:
-    """Build a Hugging Face split string, optionally truncated to ``max_samples`` rows."""
+    """Build a Hugging Face split string, optionally truncated to `max_samples` rows."""
     return split if max_samples is None else f"{split}[:{max_samples}]"
 
 
@@ -99,23 +99,26 @@ def _load_hf_classification(
     max_train_samples: int | None,
     max_test_samples: int | None,
 ) -> AmuletDataset:
-    """Load a Hugging Face text-classification corpus as a text ``AmuletDataset``.
+    """Load a Hugging Face text-classification corpus as a text `AmuletDataset`.
 
     Args:
-        hub_id: Namespaced Hugging Face hub repo id (e.g. ``"stanfordnlp/sst2"``).
+        hub_id: Namespaced Hugging Face hub repo id (e.g. "stanfordnlp/sst2").
         text_field: Name of the raw-text column in the corpus.
         train_split: Split name used for training data.
         test_split: Split name used for (labelled) test data.
         num_classes: Number of output classes.
         path: Directory where the dataset is stored or downloaded (the HF cache dir).
-        tokenizer_name: Hub id of the tokenizer that produces ``input_ids``.
-        max_length: Fixed sequence length; ``input_ids`` are padded/truncated to it.
+        tokenizer_name: Hub id of the tokenizer that produces `input_ids`.
+        max_length: Fixed sequence length; `input_ids` are padded/truncated to it.
         max_train_samples: Optional cap on training rows, for tractable runs and tests.
         max_test_samples: Optional cap on test rows.
 
     Returns:
-        An ``AmuletDataset`` with ``modality="text"`` whose ``train_set``/``test_set``
-        are ``TextTensorDataset`` instances.
+        An `AmuletDataset` with `modality="text"` whose `train_set`/`test_set`
+        are `TextTensorDataset` instances.
+
+    Raises:
+        ImportError: If the optional `llm` extra is not installed.
     """
     try:
         from datasets import load_dataset
@@ -153,22 +156,22 @@ def load_sst2(
     max_train_samples: int | None = None,
     max_test_samples: int | None = None,
 ) -> AmuletDataset:
-    """Load SST-2 (binary sentiment) as a text ``AmuletDataset``.
+    """Load SST-2 (binary sentiment) as a text `AmuletDataset`.
 
-    Uses the namespaced ``stanfordnlp/sst2`` repo (``datasets>=4`` dropped the legacy
-    ``glue`` script loader). The ``sentence`` field holds the text and ``label`` is
-    0/1. The labelled ``validation`` split is used as the test set because the public
-    ``test`` split has masked ``-1`` labels.
+    Uses the namespaced `stanfordnlp/sst2` repo (`datasets>=4` dropped the legacy
+    `glue` script loader). The `sentence` field holds the text and `label` is
+    0/1. The labelled `validation` split is used as the test set because the public
+    `test` split has masked `-1` labels.
 
     Args:
         path: Directory where the dataset is stored or downloaded.
-        tokenizer_name: Hub id of the tokenizer that produces ``input_ids``.
-        max_length: Fixed sequence length for ``input_ids``.
+        tokenizer_name: Hub id of the tokenizer that produces `input_ids`.
+        max_length: Fixed sequence length for `input_ids`.
         max_train_samples: Optional cap on training rows.
         max_test_samples: Optional cap on test rows.
 
     Returns:
-        An ``AmuletDataset`` with ``modality="text"``.
+        An `AmuletDataset` with `modality="text"`.
     """
     return _load_hf_classification(
         hub_id="stanfordnlp/sst2",
@@ -191,20 +194,20 @@ def load_agnews(
     max_train_samples: int | None = None,
     max_test_samples: int | None = None,
 ) -> AmuletDataset:
-    """Load AG News (4-class topic classification) as a text ``AmuletDataset``.
+    """Load AG News (4-class topic classification) as a text `AmuletDataset`.
 
-    Uses the namespaced ``fancyzhx/ag_news`` repo. The ``text`` field holds the text
-    and ``label`` is 0-3, over the standard ``train``/``test`` splits.
+    Uses the namespaced `fancyzhx/ag_news` repo. The `text` field holds the text
+    and `label` is 0-3, over the standard `train`/`test` splits.
 
     Args:
         path: Directory where the dataset is stored or downloaded.
-        tokenizer_name: Hub id of the tokenizer that produces ``input_ids``.
-        max_length: Fixed sequence length for ``input_ids``.
+        tokenizer_name: Hub id of the tokenizer that produces `input_ids`.
+        max_length: Fixed sequence length for `input_ids`.
         max_train_samples: Optional cap on training rows.
         max_test_samples: Optional cap on test rows.
 
     Returns:
-        An ``AmuletDataset`` with ``modality="text"``.
+        An `AmuletDataset` with `modality="text"`.
     """
     return _load_hf_classification(
         hub_id="fancyzhx/ag_news",
@@ -227,22 +230,22 @@ def load_imdb(
     max_train_samples: int | None = None,
     max_test_samples: int | None = None,
 ) -> AmuletDataset:
-    """Load IMDB (binary sentiment, long reviews) as a text ``AmuletDataset``.
+    """Load IMDB (binary sentiment, long reviews) as a text `AmuletDataset`.
 
-    Uses the namespaced ``stanfordnlp/imdb`` repo. The ``text`` field holds the review
-    and ``label`` is 0/1, over the standard ``train``/``test`` splits. Its longer
+    Uses the namespaced `stanfordnlp/imdb` repo. The `text` field holds the review
+    and `label` is 0/1, over the standard `train`/`test` splits. Its longer
     documents make a buried trigger a harder perplexity outlier for ONION, so IMDB is
     a genuine attack/defense-difficulty knob rather than a redundant sentiment set.
 
     Args:
         path: Directory where the dataset is stored or downloaded.
-        tokenizer_name: Hub id of the tokenizer that produces ``input_ids``.
-        max_length: Fixed sequence length for ``input_ids``.
+        tokenizer_name: Hub id of the tokenizer that produces `input_ids`.
+        max_length: Fixed sequence length for `input_ids`.
         max_train_samples: Optional cap on training rows.
         max_test_samples: Optional cap on test rows.
 
     Returns:
-        An ``AmuletDataset`` with ``modality="text"``.
+        An `AmuletDataset` with `modality="text"`.
     """
     return _load_hf_classification(
         hub_id="stanfordnlp/imdb",

--- a/amulet/discriminatory_behavior/defenses/adversarial_debiasing.py
+++ b/amulet/discriminatory_behavior/defenses/adversarial_debiasing.py
@@ -8,14 +8,11 @@ from .discr_behavior_defense import DiscriminatoryBehaviorDefense
 
 
 class AdversaryModel(nn.Module):
-    """
-    Model used as a discriminator to identify the sensitive
-    attribute given the output of the model.
-    Attributes:
-        n_sensitive_attrs: int
-            Number of sensitive attributes in the dataset.
-        n_classes: int
-            Number of classes in the dataset.
+    """Discriminator that infers the sensitive attribute from model outputs.
+
+    Args:
+        n_sensitive_attrs: Number of sensitive attributes in the dataset.
+        n_classes: Number of classes in the dataset.
     """
 
     def __init__(self, n_sensitive_attrs: int = 2, n_classes: int = 2):

--- a/amulet/discriminatory_behavior/defenses/discr_behavior_defense.py
+++ b/amulet/discriminatory_behavior/defenses/discr_behavior_defense.py
@@ -8,26 +8,15 @@ from torch.utils.data import DataLoader
 
 
 class DiscriminatoryBehaviorDefense(ABC):
-    """
-    Base class for Discriminatory Behavior defenses
+    """Base class for Discriminatory Behavior defenses.
 
     Attributes:
-        model: torch.nn.Module
-            The model on which to apply adversarial training.
-        criterion: torch.nn.Module
-            Loss function for adversarial training.
-        optimizer: torch.optim.Optimizer
-            Optimizer for adversarial training.
-        train_loader: torch.utils.data.DataLoader
-            Training data loader to adversarial training.
-        test_loader: torch.utils.data.DataLoader
-            Testing data loader to adversarial training.
-        lambdas: :class:`torch.Tensor`
-            Hyperparameters for fairness objective function
-        device: str
-            Device used to train model. Example: "cuda:0".
-        epochs: int
-            Determines number of iterations over training data.
+        model: The model on which to apply adversarial training.
+        criterion: Loss function for adversarial training.
+        optimizer: Optimizer for adversarial training.
+        train_loader: Training data loader for adversarial training.
+        test_loader: Testing data loader for adversarial training.
+        device: Device used to train model. Example: "cuda:0".
     """
 
     def __init__(
@@ -48,4 +37,8 @@ class DiscriminatoryBehaviorDefense(ABC):
 
     @abstractmethod
     def train_fair(self) -> nn.Module:
-        pass
+        """Train the model to mitigate discriminatory behavior.
+
+        Returns:
+            The debiased model.
+        """

--- a/amulet/discriminatory_behavior/metrics/discriminatory_behavior.py
+++ b/amulet/discriminatory_behavior/metrics/discriminatory_behavior.py
@@ -9,19 +9,15 @@ from torch.utils.data import DataLoader
 
 
 class DiscriminatoryBehavior:
-    """
-    Implementation of algorithm to evaluate models for discriminatory
-    behavior between different subgroups of data. Assumes that the input
-    data contains features, labels, and sensitive attributes.
+    """Evaluate models for discriminatory behavior between data subgroups.
+
+    Assumes that the input data contains features, labels, and sensitive
+    attributes.
 
     Attributes:
-        target_model: torch.nn.Module
-            This model will be extracted.
-        test_loader: torch.utils.data.DataLoader
-            Input data used to test the model.
-            Should contain sensitive attributes too.
-        device: str
-            Device used to train model. Example: "cuda:0".
+        model: The model to evaluate for discriminatory behavior.
+        test_loader: Input data used to test the model. Should contain sensitive attributes too.
+        device: Device used for inference. Example: "cuda:0".
     """
 
     def __init__(
@@ -38,6 +34,17 @@ class DiscriminatoryBehavior:
     def accuracy(
         predictions: np.ndarray, targets: np.ndarray, attributes: np.ndarray
     ) -> tuple[float, float]:
+        """Compute per-subgroup accuracy split by a binary sensitive attribute.
+
+        Args:
+            predictions: Predicted labels.
+            targets: Ground-truth labels.
+            attributes: Binary sensitive attribute values (0 or 1).
+
+        Returns:
+            A tuple (acc_true, acc_false) of accuracy percentages for the
+            subgroups where the attribute is 1 and 0, respectively.
+        """
         output_attr_true = predictions[np.argwhere(attributes == 1)]
         output_attr_false = predictions[np.argwhere(attributes == 0)]
 
@@ -51,8 +58,16 @@ class DiscriminatoryBehavior:
 
     @staticmethod
     def demographic_parity(predictions: np.ndarray, attributes: np.ndarray) -> float:
-        """
-        |P(pred=1|a=0) - P(pred=1|a=1)|
+        """Compute demographic parity between the two attribute subgroups.
+
+        Measures |P(pred=1|a=0) - P(pred=1|a=1)|.
+
+        Args:
+            predictions: Predicted labels.
+            attributes: Binary sensitive attribute values (0 or 1).
+
+        Returns:
+            The absolute difference in positive-prediction rates between subgroups.
         """
         p_joint_att_positive = np.mean((predictions == 1) * (attributes == 1))
         p_joint_att_negative = np.mean((predictions == 1) * (attributes == 0))
@@ -70,8 +85,17 @@ class DiscriminatoryBehavior:
     def true_positive_parity(
         predictions: np.ndarray, targets: np.ndarray, attributes: np.ndarray
     ) -> float:
-        """
-        P(y_hat=1|y=1,a=0) - P(y_hat=1|y=1,a=1)
+        """Compute true-positive-rate parity between the two attribute subgroups.
+
+        Measures |P(y_hat=1|y=1,a=0) - P(y_hat=1|y=1,a=1)|.
+
+        Args:
+            predictions: Predicted labels.
+            targets: Ground-truth labels.
+            attributes: Binary sensitive attribute values (0 or 1).
+
+        Returns:
+            The absolute difference in true-positive rates between subgroups.
         """
         p_joint_att_positive = np.mean(
             (predictions == targets) * (targets == 1) * (attributes == 1)
@@ -94,8 +118,17 @@ class DiscriminatoryBehavior:
     def false_positive_parity(
         predictions: np.ndarray, targets: np.ndarray, attributes: np.ndarray
     ) -> float:
-        """
-        |P(y_hat=1|y=0,a=0) - P(y_hat=1|y=0,a=1)|
+        """Compute false-positive-rate parity between the two attribute subgroups.
+
+        Measures |P(y_hat=1|y=0,a=0) - P(y_hat=1|y=0,a=1)|.
+
+        Args:
+            predictions: Predicted labels.
+            targets: Ground-truth labels.
+            attributes: Binary sensitive attribute values (0 or 1).
+
+        Returns:
+            The absolute difference in false-positive rates between subgroups.
         """
         p_joint_att_positive = np.mean(
             (predictions != targets) * (targets == 0) * (attributes == 1)
@@ -115,6 +148,16 @@ class DiscriminatoryBehavior:
 
     @staticmethod
     def p_rule(predictions: np.ndarray, attributes: np.ndarray) -> float:
+        """Compute the p% rule between the two attribute subgroups.
+
+        Args:
+            predictions: Predicted labels.
+            attributes: Binary sensitive attribute values (0 or 1).
+
+        Returns:
+            The smaller of the two positive-rate odds ratios, scaled by 100.
+            Returns 0.0 when the reference subgroup has no positive predictions.
+        """
         y_z_1 = predictions[attributes == 1].mean()
         y_z_0 = predictions[attributes == 0].mean()
         if y_z_0 == 0:

--- a/amulet/distribution_inference/attacks/distribution_inference_attack.py
+++ b/amulet/distribution_inference/attacks/distribution_inference_attack.py
@@ -235,4 +235,11 @@ class DistributionInferenceAttack(ABC):
 
     @abstractmethod
     def attack(self) -> dict[str, np.ndarray]:
+        """Run the distinguishing test on the trained model populations.
+
+        Returns:
+            Dictionary with two 1-D arrays: "predictions" (attack scores) and
+            "ground_truth" (0 for distribution-1 victims, 1 for distribution-2
+            victims).
+        """
         pass

--- a/amulet/distribution_inference/attacks/suri_evans_2022.py
+++ b/amulet/distribution_inference/attacks/suri_evans_2022.py
@@ -24,8 +24,9 @@ class SuriEvans2022(DistributionInferenceAttack):
 
     Given two adversary model populations (one per distribution) and two victim
     model populations, the attack measures how each victim's output distribution
-    diverges from each adversary baseline. The sign of the pairwise KL
-    difference yields a binary distinguishing prediction per victim model.
+    diverges from each adversary baseline. The resulting pairwise KL differences
+    are min-max normalized into continuous distinguishing scores in [0, 1], one
+    per victim model.
 
     Inherits all constructor parameters from DistributionInferenceAttack.
     Call prepare_model_populations() before attack(), or pass populations and
@@ -171,12 +172,31 @@ class SuriEvans2022(DistributionInferenceAttack):
         prepare_model_populations(). Pass any subset explicitly to run the
         attack against externally produced populations or loaders.
 
+        Args:
+            models_adv_1: Adversary models trained on distribution 1. Defaults to
+                the prepared adversary-D1 population.
+            models_adv_2: Adversary models trained on distribution 2. Defaults to
+                the prepared adversary-D2 population.
+            models_vic_1: Victim models trained on distribution 1. Defaults to the
+                prepared victim-D1 population.
+            models_vic_2: Victim models trained on distribution 2. Defaults to the
+                prepared victim-D2 population.
+            test_loader_1: Test loader for distribution 1. Defaults to the prepared
+                distribution-1 test loader.
+            test_loader_2: Test loader for distribution 2. Defaults to the prepared
+                distribution-2 test loader.
+
         Returns:
             A dictionary with two 1-D arrays of equal length:
                 - "predictions": attack scores in [0, 1]. Thresholding at 0.5
                   yields the distinguishing decision.
                 - "ground_truth": 0 for distribution-1 victims, 1 for
                   distribution-2 victims.
+
+        Raises:
+            RuntimeError: If the test loaders are not supplied and
+                prepare_model_populations() has not been called, or if any of the
+                four model populations is empty.
         """
         models_adv_1 = models_adv_1 if models_adv_1 is not None else self.models_adv_1
         models_adv_2 = models_adv_2 if models_adv_2 is not None else self.models_adv_2

--- a/amulet/distribution_inference/attacks/white_box_pim.py
+++ b/amulet/distribution_inference/attacks/white_box_pim.py
@@ -194,6 +194,9 @@ class WhiteBoxPIM(DistributionInferenceAttack):
                   indicate the model is more likely from distribution 2.
                 - "ground_truth": 0 for distribution-1 victims, 1 for
                   distribution-2 victims.
+
+        Raises:
+            RuntimeError: If prepare_model_populations() has not been called.
         """
         if not self.models_adv_1:
             raise RuntimeError("Call prepare_model_populations() before attack().")

--- a/amulet/distribution_inference/dataset_utils.py
+++ b/amulet/distribution_inference/dataset_utils.py
@@ -3,7 +3,7 @@ Dataset preparation helpers for distribution inference attacks.
 
 A distribution inference attack distinguishes two training distributions
 that differ in the proportion of samples satisfying some filter (e.g.
-``sex == 1``). Each side of the attack (victim and adversary) requires
+`sex == 1`). Each side of the attack (victim and adversary) requires
 training data sampled to the target proportion. These helpers perform the
 ratio-preserving subsampling and return the six DataLoaders the attack
 consumes.
@@ -19,7 +19,7 @@ from torch.utils.data import ConcatDataset, DataLoader, TensorDataset
 
 @dataclass
 class DistributionSplits:
-    """DataLoaders produced by :func:`prepare_distribution_splits`."""
+    """DataLoaders produced by prepare_distribution_splits."""
 
     vic_trainloader_1: DataLoader
     vic_trainloader_2: DataLoader
@@ -138,10 +138,10 @@ def prepare_distribution_splits(
 
     The train/test arrays are each split 50/50 into victim and adversary halves
     (stratified on labels and every sensitive column). Each half is then
-    subsampled twice, once for ``ratio1`` and once for ``ratio2``, to produce
+    subsampled twice, once for `ratio1` and once for `ratio2`, to produce
     the four training loaders plus two combined test loaders.
 
-    Works with any input shape: tabular ``(N, d)``, image ``(N, C, H, W)``, etc.
+    Works with any input shape: tabular `(N, d)`, image `(N, C, H, W)`, etc.
     Features and sensitive attributes are never merged, so the model receives
     only the original feature array.
 
@@ -149,24 +149,33 @@ def prepare_distribution_splits(
         x_train, y_train, z_train: Training features, labels (1-D), sensitive
             attributes (2-D, one column per attribute).
         x_test, y_test, z_test: Test features, labels, sensitive attributes.
-        sensitive_columns: Column names for ``z_train``/``z_test``. Length must
-            match ``z_train.shape[1]``.
+        sensitive_columns: Column names for `z_train`/`z_test`. Length must
+            match `z_train.shape[1]`.
         filter_column: Name of the sensitive column whose proportion is being
-            inferred. Must be in ``sensitive_columns``.
-        ratio1: Target proportion of rows satisfying ``filter_column == filter_value``
+            inferred. Must be in `sensitive_columns`.
+        ratio1: Target proportion of rows satisfying `filter_column == filter_value`
             for distribution 1.
         ratio2: Target proportion for distribution 2.
         train_subsample: Minority-class sample count per train draw.
         test_subsample: Minority-class sample count per test draw.
-        filter_value: Value of ``filter_column`` that satisfies the filter.
+        filter_value: Value of `filter_column` that satisfies the filter.
         drop_values: Optional per-column list of values to drop before sampling,
-            e.g. ``{"race": [2]}`` to exclude a multi-class label the binary
+            e.g. `{"race": [2]}` to exclude a multi-class label the binary
             filter cannot express.
         class_imbalance: Target ratio of majority-class to minority-class samples
             per draw.
         n_tries: Number of sampling attempts per draw.
         batch_size: Batch size for the returned DataLoaders.
         seed: Random seed for the 50/50 train/test split.
+
+    Returns:
+        A DistributionSplits holding six DataLoaders: victim train loaders for
+        distributions 1 and 2, adversary train loaders for distributions 1 and 2,
+        and combined test loaders for distributions 1 and 2.
+
+    Raises:
+        ValueError: If `filter_column` is not in `sensitive_columns`, or if
+            `z_train`'s column count does not match `len(sensitive_columns)`.
     """
     if filter_column not in sensitive_columns:
         raise ValueError(

--- a/amulet/distribution_inference/metrics/distinguishing_accuracy.py
+++ b/amulet/distribution_inference/metrics/distinguishing_accuracy.py
@@ -13,14 +13,14 @@ def evaluate_distinguishing_accuracy(
     Score a distribution inference attack.
 
     Args:
-        predictions: 1-D array of attack scores in ``[0, 1]``.
+        predictions: 1-D array of attack scores in `[0, 1]`.
         ground_truth: 1-D binary array. 0 for distribution 1, 1 for distribution 2.
-        threshold: Decision threshold applied to ``predictions``.
+        threshold: Decision threshold applied to `predictions`.
 
     Returns:
         Dictionary with:
-            - ``"distinguishing_accuracy"``: fraction of correct binary decisions.
-            - ``"auc_score"``: ROC-AUC of the raw scores.
+            - `"distinguishing_accuracy"`: fraction of correct binary decisions.
+            - `"auc_score"`: ROC-AUC of the raw scores.
     """
     binary = (predictions >= threshold).astype(int)
     return {

--- a/amulet/evasion/attacks/evasion_attack.py
+++ b/amulet/evasion/attacks/evasion_attack.py
@@ -7,18 +7,13 @@ from torch.utils.data import DataLoader
 
 
 class EvasionAttack(ABC):
-    """
-    Base class for evasion
+    """Base class for evasion attacks.
 
     Attributes:
-        model: torch.nn.Module
-            The model on which to apply adversarial training.
-        test_loader: torch.utils.data.DataLoader
-            Input data that is perturbed to attack the model.
-        device: str
-            Device used for model inference. Example: "cuda:0".
-        batch_size: int
-            Batch size for output data loader.
+        model: The model to attack.
+        test_loader: Input data that is perturbed to attack the model.
+        device: Device used for model inference. Example: "cuda:0".
+        batch_size: Batch size for the output data loader.
     """
 
     def __init__(
@@ -35,4 +30,5 @@ class EvasionAttack(ABC):
 
     @abstractmethod
     def attack(self) -> DataLoader:
+        """Run the attack and return the adversarial examples as a DataLoader."""
         pass

--- a/amulet/evasion/attacks/projected_gradient_descent.py
+++ b/amulet/evasion/attacks/projected_gradient_descent.py
@@ -12,8 +12,7 @@ from .evasion_attack import EvasionAttack
 
 
 class EvasionPGD(EvasionAttack):
-    """
-    PGD-based evasion attack using the cleverhans library.
+    """PGD-based evasion attack using the cleverhans library.
 
     Reference:
         Towards Deep Learning Models Resistant to Adversarial Attacks
@@ -24,10 +23,12 @@ class EvasionPGD(EvasionAttack):
         model: The model to attack.
         test_loader: Input data that is perturbed to attack the model.
         device: Device used for model inference. Example: "cuda:0".
+        batch_size: Batch size for the output DataLoader.
         epsilon: Perturbation budget.
         iterations: Number of PGD iterations.
         step_size: Step size for each attack iteration.
-        batch_size: Batch size for the output DataLoader.
+        clip_min: Lower bound to clamp perturbed inputs to.
+        clip_max: Upper bound to clamp perturbed inputs to.
     """
 
     def __init__(
@@ -50,11 +51,10 @@ class EvasionPGD(EvasionAttack):
         self.clip_max = clip_max
 
     def attack(self) -> DataLoader:
-        """
-        Run the PGD evasion attack and return perturbed inputs as a DataLoader.
+        """Run the PGD evasion attack and return perturbed inputs as a DataLoader.
 
         Returns:
-            DataLoader containing adversarial examples.
+            A DataLoader containing the adversarial examples.
         """
         self.model.eval()
 

--- a/amulet/evasion/defenses/evasion_defense.py
+++ b/amulet/evasion/defenses/evasion_defense.py
@@ -8,22 +8,15 @@ from torch.utils.data import DataLoader
 
 
 class EvasionDefense(ABC):
-    """
-    Base class for Evasion Defense
+    """Base class for evasion defenses.
 
     Attributes:
-        model: torch.nn.Module
-            The model on which to apply the defense.
-        criterion: torch.nn.Module
-            Loss function for the defense.
-        optimizer: torch.optim.Optimizer
-            Optimizer for the defense.
-        train_loader: torch.utils.data.DataLoader
-            Training data loader to the defense.
-        device: str
-            Device used to train model. Example: "cuda:0".
-        epochs: int
-            Determines number of iterations over training data.
+        model: The model on which to apply the defense.
+        criterion: Loss function for the defense.
+        optimizer: Optimizer for the defense.
+        train_loader: Training data loader for the defense.
+        device: Device used to train model. Example: "cuda:0".
+        epochs: Number of iterations over the training data.
     """
 
     def __init__(
@@ -44,4 +37,5 @@ class EvasionDefense(ABC):
 
     @abstractmethod
     def train_robust(self) -> nn.Module:
+        """Train the model robustly and return the defended model."""
         pass

--- a/amulet/evasion/defenses/projected_gradient_descent.py
+++ b/amulet/evasion/defenses/projected_gradient_descent.py
@@ -13,35 +13,27 @@ from .evasion_defense import EvasionDefense
 
 
 class AdversarialTrainingPGD(EvasionDefense):
-    """
-    Implementation of Adversarial Training algorithm from the method from cleverhans:
-    https://github.com/cleverhans-lab/cleverhans/blob/master/tutorials/torch/cifar10_tutorial.py.
+    """Adversarial training following the cleverhans CIFAR-10 tutorial.
+
+    https://github.com/cleverhans-lab/cleverhans/blob/master/tutorials/torch/cifar10_tutorial.py
 
     Reference:
         Towards Deep Learning Models Resistant to Adversarial Attacks
         Aleksander Madry, Aleksandar Makelov, Ludwig Schmidt, Dimitris Tsipras, Adrian Vladu
-        https://arxiv.org/abs/1706.06083.
+        https://arxiv.org/abs/1706.06083
 
     Attributes:
-        model: torch.nn.Module
-            The model on which to apply adversarial training.
-        criterion: torch.nn.Module
-            Loss function for adversarial training.
-        optimizer: torch.optim.Optimizer
-            Optimizer for adversarial training.
-        train_loader: torch.utils.data.DataLoader
-            Training data loader to adversarial training.
-        device: str
-            Device used to train model. Example: "cuda:0".
-        epochs: int
-            Determines number of iterations over training data.
-        epsilon: int
-            Controls the amount of perturbation on each image.
-            Divided by 255. See: https://arxiv.org/abs/1412.6572.
-        iterations: int
-            Number of iterations for PGD generation.
-        step_size: float
-            Step size for each attack iteration.
+        model: The model on which to apply adversarial training.
+        criterion: Loss function for adversarial training.
+        optimizer: Optimizer for adversarial training.
+        train_loader: Training data loader for adversarial training.
+        device: Device used to train model. Example: "cuda:0".
+        epochs: Number of iterations over the training data.
+        epsilon: Perturbation budget applied directly in input space.
+        iterations: Number of iterations for PGD generation.
+        step_size: Step size for each attack iteration.
+        clip_min: Lower bound to clamp perturbed inputs to.
+        clip_max: Upper bound to clamp perturbed inputs to.
     """
 
     def __init__(
@@ -66,11 +58,10 @@ class AdversarialTrainingPGD(EvasionDefense):
         self.clip_max = clip_max
 
     def train_robust(self) -> nn.Module:
-        """
-        Adversarially trains the model.
+        """Adversarially train the model.
 
         Returns:
-            Adversarially trained model of type :class:`torch.nn.Module'.
+            The adversarially trained model.
         """
         self.model.train()
         for epoch in range(self.epochs):

--- a/amulet/membership_inference/attacks/lira.py
+++ b/amulet/membership_inference/attacks/lira.py
@@ -144,6 +144,9 @@ class LiRA(MembershipInferenceAttack):
             target_in_out_labels: numpy boolean array indicating
                 membership of samples in target model
                 shape (1, num_samples)
+            fix_variance: When True, use a single standard deviation shared across
+                all samples for the in and out Gaussians; otherwise estimate a
+                separate per-sample standard deviation. Defaults to False.
 
         Returns:
             Tuple of (lira_online_preds, true_labels)
@@ -205,6 +208,9 @@ class LiRA(MembershipInferenceAttack):
             target_in_out_labels: numpy boolean array indicating
                 membership of samples in target model
                 shape (1, num_samples)
+            fix_variance: When True, use a single standard deviation shared across
+                all samples for the out Gaussian; otherwise estimate a separate
+                per-sample standard deviation. Defaults to False.
 
         Returns:
             Tuple of (lira_offline_preds, true_labels)

--- a/amulet/membership_inference/attacks/membership_inference_attack.py
+++ b/amulet/membership_inference/attacks/membership_inference_attack.py
@@ -184,6 +184,9 @@ class MembershipInferenceAttack(ABC):
             Tuple of (model, in_data) where model is eval-mode with gradients
             disabled, and in_data is the array of training-set indices this
             shadow model was trained on.
+
+        Raises:
+            FileNotFoundError: If the shadow model checkpoint does not exist.
         """
         path = self.models_dir / f"{self.dataset}_shadow_{shadow_id}_{self.exp_id}.pth"
         if not path.is_file():
@@ -203,4 +206,5 @@ class MembershipInferenceAttack(ABC):
 
     @abstractmethod
     def attack(self) -> dict[str, np.ndarray]:
+        """Run the membership inference attack and return result arrays keyed by name."""
         pass

--- a/amulet/membership_inference/defenses/dp_sgd.py
+++ b/amulet/membership_inference/defenses/dp_sgd.py
@@ -12,33 +12,24 @@ from .membership_inference_defense import MembershipInferenceDefense
 
 
 class DPSGD(MembershipInferenceDefense):
-    """
+    """Differentially private SGD defense (DP-SGD) built on Opacus.
+
     Attributes:
-        model: torch.nn.Module
-            The model on which to apply adversarial training.
-        criterion: torch.nn.Module
-            Loss function for adversarial training.
-        optimizer: torch.optim.Optimizer
-            Optimizer for adversarial training.
-        train_loader: torch.utils.data.DataLoader
-            Training data loader to adversarial training.
-        device: str
-            Device used to train model. Example: "cuda:0".
-        delta: float
-            The target delta value for the differential privacy guarantee.
-        max_per_sample_grad_norm: float,
-            The norm to which the per-sample gradients are clipped.
-        sigma:
-            Noise multiplier
-        secure_rng:
-            Whether to use secure RNG for trustworthy privacy guarantees. Comes at a privacy cost.
-        epochs: int
-            Determines number of iterations over training data.
-        max_physical_batch_size: int | None
-            When set, each logical batch is split into physical micro-batches of at most
-            this size (via Opacus' ``BatchMemoryManager``) to bound peak per-sample-gradient
-            memory. The logical batch size — and therefore the privacy accounting and expected
-            utility — is unchanged. ``None`` (default) iterates the loader without splitting.
+        model: The model trained under differential privacy.
+        criterion: Loss function for differentially private training.
+        optimizer: Optimizer for differentially private training.
+        train_loader: Training data loader for differentially private training.
+        device: Device used to train model. Example: "cuda:0".
+        delta: The target delta value for the differential privacy guarantee.
+        max_per_sample_grad_norm: The norm to which the per-sample gradients are clipped.
+        sigma: Noise multiplier.
+        secure_rng: Whether to use secure RNG for trustworthy privacy guarantees. Comes at a performance cost.
+        epochs: Determines number of iterations over training data.
+        max_physical_batch_size: When set, each logical batch is split into physical
+            micro-batches of at most this size (via Opacus' `BatchMemoryManager`) to bound
+            peak per-sample-gradient memory. The logical batch size, and therefore the privacy
+            accounting and expected utility, is unchanged. `None` (default) iterates the loader
+            without splitting.
     """
 
     def __init__(
@@ -71,11 +62,10 @@ class DPSGD(MembershipInferenceDefense):
         )
 
     def train_private(self) -> nn.Module:
-        """
-        Trains the model with differential privacy.
+        """Train the model with differential privacy.
 
         Returns:
-            Trained model of type :class:`torch.nn.Module'.
+            The differentially private trained model.
         """
 
         self.model.train()

--- a/amulet/membership_inference/defenses/membership_inference_defense.py
+++ b/amulet/membership_inference/defenses/membership_inference_defense.py
@@ -8,22 +8,15 @@ from torch.utils.data import DataLoader
 
 
 class MembershipInferenceDefense(ABC):
-    """
-    Base class for membership inference defenses.
+    """Base class for membership inference defenses.
 
     Attributes:
-        model: torch.nn.Module
-            The model on which to apply adversarial training.
-        criterion: torch.nn.Module
-            Loss function for adversarial training.
-        optimizer: torch.optim.Optimizer
-            Optimizer for adversarial training.
-        train_loader: torch.utils.data.DataLoader
-            Training data loader to adversarial training.
-        device: str
-            Device used to train model. Example: "cuda:0".
-        epochs: int
-            Determines number of iterations over training data.
+        model: The model to train with the membership inference defense.
+        criterion: Loss function for defense training.
+        optimizer: Optimizer for defense training.
+        train_loader: Training data loader for defense training.
+        device: Device used to train model. Example: "cuda:0".
+        epochs: Determines number of iterations over training data.
     """
 
     def __init__(
@@ -44,4 +37,5 @@ class MembershipInferenceDefense(ABC):
 
     @abstractmethod
     def train_private(self) -> nn.Module:
+        """Train the model with the membership inference defense and return it."""
         pass

--- a/amulet/membership_inference/metrics/compute_mi_metrics.py
+++ b/amulet/membership_inference/metrics/compute_mi_metrics.py
@@ -1,3 +1,5 @@
+"""Metrics for evaluating membership inference attacks."""
+
 import numpy as np
 from sklearn import metrics
 
@@ -11,15 +13,16 @@ def compute_mi_metrics(
     Compute key metrics for membership inference attack evaluation.
 
     Args:
-        preds (np.ndarray): Predicted membership scores or probabilities (higher means more likely member).
-        true_labels (np.ndarray): True membership labels (1 for member, 0 for non-member).
-        fpr_threshold (float): False Positive Rate threshold at which to compute True Positive Rate (default 0.01 for 1%).
+        preds: Predicted membership scores or probabilities (higher means more likely member).
+        true_labels: True membership labels (1 for member, 0 for non-member).
+        fpr_threshold: False Positive Rate threshold at which to compute True Positive Rate (default 0.01 for 1%).
 
     Returns:
-        dict: Dictionary containing:
-            - 'auc': Area Under ROC Curve.
-            - 'balanced_acc': Maximum balanced accuracy over all thresholds.
-            - 'tpr_at_fpr': True Positive Rate at specified false positive rate threshold.
+        Dictionary containing:
+            auc: Area Under ROC Curve.
+            balanced_acc: Maximum balanced accuracy over all thresholds.
+            tpr_at_fpr: True Positive Rate at specified false positive rate threshold.
+            threshold_score: Score threshold maximizing balanced accuracy.
     """
     fpr, tpr, thresholds = metrics.roc_curve(true_labels, preds, pos_label=1)
     auc_score = metrics.auc(fpr, tpr)

--- a/amulet/models/base.py
+++ b/amulet/models/base.py
@@ -15,4 +15,9 @@ class AmuletModel(nn.Module):
     """
 
     def get_hidden(self, x: torch.Tensor) -> torch.Tensor:
+        """Return intermediate-layer activations; subclasses must override this.
+
+        Raises:
+            NotImplementedError: Always, unless a subclass overrides it.
+        """
         raise NotImplementedError(f"{type(self).__name__} must implement `get_hidden`.")

--- a/amulet/models/cnn.py
+++ b/amulet/models/cnn.py
@@ -25,17 +25,15 @@ class SimpleCNN(AmuletModel):
         num_classes: int = 10,
         input_channels: int = 1,
     ):
-        """
+        """Build the CNN's convolutional stack and fully connected classifier.
+
         Args:
-            conv_channels_kernel: List of tuples (channels, kernel_size)
-                e.g., [(20,5), (50,5)] for BadNets default conv layers.
-            fc_layers: List of int
-                Sizes of fully connected layers before the final output.
-                e.g., [500]
-            num_classes: int
-                Number of classes for output layer.
-            input_channels: int
-                Number of input channels (1 for MNIST).
+            conv_channels_kernel: (channels, kernel_size) per convolution layer,
+                e.g. [(20, 5), (50, 5)] for the BadNets default. Defaults to that.
+            fc_layers: Widths of the fully connected layers before the final output,
+                e.g. [500]. Defaults to [500].
+            num_classes: Number of classes for the output layer.
+            input_channels: Number of input channels (1 for MNIST).
         """
         super().__init__()
 
@@ -80,11 +78,27 @@ class SimpleCNN(AmuletModel):
         self.classifier = nn.Sequential(*fc_modules)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the forward pass and return classification logits.
+
+        Args:
+            x: Input image batch.
+
+        Returns:
+            A (batch, num_classes) logits tensor.
+        """
         x = self.features(x)
         x = torch.flatten(x, 1)
         x = self.classifier(x)
         return x
 
     def get_hidden(self, x: torch.Tensor) -> torch.Tensor:
+        """Return the flattened convolutional feature map.
+
+        Args:
+            x: Input image batch.
+
+        Returns:
+            A (batch, features) tensor: the conv stack output flattened per sample.
+        """
         x = self.features(x)
         return torch.flatten(x, 1)

--- a/amulet/models/hf_causal_lm.py
+++ b/amulet/models/hf_causal_lm.py
@@ -33,23 +33,23 @@ class HFCausalLM(AmuletModel):
     the classification victim, the perplexity scorer a defense like ONION consumes, and a
     text generator:
 
-    - **Classify** — ``forward`` pools the last real-token hidden state and passes it
-      through a trainable classification head, returning the bare ``(batch, num_labels)``
-      logits **tensor** (not a ``SequenceClassifierOutput``). That is exactly what the
-      single-tensor loops (``train_classifier``, ``DPSGD.train_private``) and
-      ``get_accuracy`` expect, so they drive it unchanged.
-    - **Score** — ``perplexity`` uses the pretrained LM head. By default it scores the
+    - Classify — `forward` pools the last real-token hidden state and passes it
+      through a trainable classification head, returning the bare `(batch, num_labels)`
+      logits tensor (not a `SequenceClassifierOutput`). That is exactly what the
+      single-tensor loops (`train_classifier`, `DPSGD.train_private`) and
+      `get_accuracy` expect, so they drive it unchanged.
+    - Score — `perplexity` uses the pretrained LM head. By default it scores the
       clean base (LoRA adapters disabled), so a defense gets a reference LM unperturbed by
-      any poisoned fine-tuning; ``use_adapter=True`` scores through the adapters (the
+      any poisoned fine-tuning; `use_adapter=True` scores through the adapters (the
       actual fine-tuned model).
-    - **Generate** — ``generate`` delegates to the base LM's decoding.
+    - Generate — `generate` delegates to the base LM's decoding.
 
-    This works for **causal / decoder-only** LMs (Llama, GPT-2, Mistral, Mixtral-style
-    MoE decoders): anything that loads as ``AutoModelForCausalLM``. Encoder-only models
+    This works for causal / decoder-only LMs (Llama, GPT-2, Mistral, Mixtral-style
+    MoE decoders): anything that loads as `AutoModelForCausalLM`. Encoder-only models
     (BERT) and seq2seq models (T5) do not fit and are out of scope.
 
     Under differential privacy the trainable params must be fp32: bf16 grad samples break
-    Opacus per-sample clipping. Pass ``dtype=torch.float32`` for the DP run; bf16 is fine
+    Opacus per-sample clipping. Pass `dtype=torch.float32` for the DP run; bf16 is fine
     otherwise. The optional 4-bit load path is off by default and must never be used under
     DP (Opacus hooks do not compose with bitsandbytes 4-bit layers).
 
@@ -81,20 +81,20 @@ class HFCausalLM(AmuletModel):
             lora_alpha: LoRA scaling factor.
             lora_dropout: Dropout applied inside the LoRA layers.
             target_modules: Module names LoRA adapts; defaults to the Llama attention
-                projections ``["q_proj", "v_proj"]``.
-            dtype: Parameter dtype of the base model. Use ``torch.float32`` for the DP
-                run; ``torch.bfloat16`` is fine otherwise.
+                projections `["q_proj", "v_proj"]`.
+            dtype: Parameter dtype of the base model. Use `torch.float32` for the DP
+                run; `torch.bfloat16` is fine otherwise.
             load_in_4bit: Load the frozen base in 4-bit (bitsandbytes, GPU/Linux only).
                 Off by default; never valid under DP.
             config: Optional Hugging Face config for a random-init base (used by fast
-                tests). When given, it overrides ``model_name`` and no weights or
+                tests). When given, it overrides `model_name` and no weights or
                 tokenizer are downloaded.
             pad_token_id: Explicit padding token id. Defaults to the tokenizer's pad token
                 (or its eos token) for the pretrained path, or the config's
-                ``pad_token_id`` for the random-init path.
+                `pad_token_id` for the random-init path.
 
         Raises:
-            ImportError: If the optional ``llm`` extra is not installed, or 4-bit is
+            ImportError: If the optional `llm` extra is not installed, or 4-bit is
                 requested without bitsandbytes.
         """
         super().__init__()
@@ -175,7 +175,7 @@ class HFCausalLM(AmuletModel):
     def _bnb_4bit_config():
         """Build a bitsandbytes 4-bit quantization config, guarding the import.
 
-        bitsandbytes is GPU/Linux-only and deliberately outside the ``llm`` extra, so its
+        bitsandbytes is GPU/Linux-only and deliberately outside the `llm` extra, so its
         absence raises a clear message rather than a bare ImportError.
         """
         try:
@@ -194,18 +194,18 @@ class HFCausalLM(AmuletModel):
         )
 
     def _attention_mask(self, x: torch.Tensor) -> torch.Tensor:
-        """Derive a ``(batch, seq)`` attention mask from the padded ``input_ids``."""
+        """Derive a `(batch, seq)` attention mask from the padded `input_ids`."""
         return (x != self.pad_id).long()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Classify a batch of padded token ids.
 
         Args:
-            x: A ``(batch, seq)`` LongTensor of padded ``input_ids``. Named ``x`` to match
-                the ``AmuletModel`` single-tensor contract; callers pass it positionally.
+            x: A `(batch, seq)` LongTensor of padded `input_ids`. Named `x` to match
+                the `AmuletModel` single-tensor contract; callers pass it positionally.
 
         Returns:
-            A ``(batch, num_labels)`` logits tensor (not a ``SequenceClassifierOutput``).
+            A `(batch, num_labels)` logits tensor (not a `SequenceClassifierOutput`).
         """
         return self.classifier(self.get_hidden(x))
 
@@ -213,10 +213,10 @@ class HFCausalLM(AmuletModel):
         """Return the pooled last hidden state at each sequence's final real token.
 
         Args:
-            x: A ``(batch, seq)`` LongTensor of padded ``input_ids``.
+            x: A `(batch, seq)` LongTensor of padded `input_ids`.
 
         Returns:
-            A ``(batch, hidden_size)`` tensor pooled from the last non-pad position of the
+            A `(batch, hidden_size)` tensor pooled from the last non-pad position of the
             LoRA-adapted decoder.
         """
         attention_mask = self._attention_mask(x)
@@ -233,15 +233,15 @@ class HFCausalLM(AmuletModel):
         """Compute the causal LM's perplexity of a single token sequence.
 
         Args:
-            input_ids: A ``(1, seq)`` or ``(seq,)`` LongTensor of token ids for one
+            input_ids: A `(1, seq)` or `(seq,)` LongTensor of token ids for one
                 (unpadded) sequence.
-            use_adapter: When ``False`` (default) the LoRA adapters are disabled and the
+            use_adapter: When `False` (default) the LoRA adapters are disabled and the
                 clean pretrained base scores — a reference LM unperturbed by fine-tuning,
-                matching canonical ONION. When ``True`` the adapters stay on, scoring
+                matching canonical ONION. When `True` the adapters stay on, scoring
                 through the actual fine-tuned model.
 
         Returns:
-            The perplexity as a float, or ``inf`` for sequences too short to score (fewer
+            The perplexity as a float, or `inf` for sequences too short to score (fewer
             than two tokens), so a one-token candidate never looks like a fluent outlier.
         """
         ids = input_ids if input_ids.dim() == 2 else input_ids.unsqueeze(0)
@@ -261,28 +261,28 @@ class HFCausalLM(AmuletModel):
     ) -> list[float]:
         """Per-sequence perplexity for many token sequences in few padded forwards.
 
-        Equivalent to calling ``perplexity`` on each sequence — the same masked mean token
-        cross-entropy, and ``inf`` for sub-two-token sequences — but scores up to
-        ``batch_size`` sequences per forward instead of one. This is ONION's hot path: it
+        Equivalent to calling `perplexity` on each sequence — the same masked mean token
+        cross-entropy, and `inf` for sub-two-token sequences — but scores up to
+        `batch_size` sequences per forward instead of one. This is ONION's hot path: it
         replaces a forward per leave-one-out candidate with a single batched forward.
 
-        Sequences are **right-padded** so every real token keeps its original position;
+        Sequences are right-padded so every real token keeps its original position;
         under the causal mask a real token then attends to exactly the same tokens it would
         unpadded, so its logits — and the resulting per-sequence perplexity — are unchanged
         by batching (up to float reduction-order noise). Per-sequence loss is computed here
-        as the masked mean token cross-entropy, never ``outputs.loss`` (which would average
+        as the masked mean token cross-entropy, never `outputs.loss` (which would average
         over the whole batch and corrupt every score).
 
         Args:
-            sequences: Token-id tensors, each ``(seq,)`` or ``(1, seq)``, of possibly
+            sequences: Token-id tensors, each `(seq,)` or `(1, seq)`, of possibly
                 differing lengths.
             use_adapter: Score through the LoRA adapters (the fine-tuned model) rather than
                 the clean pretrained base. Defaults to the clean base, matching
-                ``perplexity``.
+                `perplexity`.
             batch_size: Maximum sequences per padded forward. Tune down if memory is tight.
 
         Returns:
-            A perplexity per input sequence, in input order; ``inf`` where a sequence has
+            A perplexity per input sequence, in input order; `inf` where a sequence has
             fewer than two tokens.
         """
         flat = [s.squeeze(0) if s.dim() == 2 else s for s in sequences]
@@ -323,15 +323,15 @@ class HFCausalLM(AmuletModel):
         return results
 
     def generate(self, input_ids: torch.Tensor, **kwargs: Any) -> torch.Tensor:
-        """Autoregressively generate a continuation of ``input_ids``.
+        """Autoregressively generate a continuation of `input_ids`.
 
         Args:
-            input_ids: A ``(batch, seq)`` LongTensor prompt.
-            **kwargs: Forwarded to the base LM's ``generate`` (e.g. ``max_new_tokens``).
+            input_ids: A `(batch, seq)` LongTensor prompt.
+            **kwargs: Forwarded to the base LM's `generate` (e.g. `max_new_tokens`).
                 Defaults to greedy decoding.
 
         Returns:
-            A ``(batch, seq + generated)`` LongTensor with the prompt preserved as a prefix.
+            A `(batch, seq + generated)` LongTensor with the prompt preserved as a prefix.
         """
         kwargs.setdefault("do_sample", False)
         kwargs.setdefault("pad_token_id", self.pad_id)

--- a/amulet/models/linear_net.py
+++ b/amulet/models/linear_net.py
@@ -7,17 +7,14 @@ from .base import AmuletModel
 
 
 class LinearNet(AmuletModel):
-    """
-    Builds a dense neural network for a multiclass image classification task.
+    """Build a dense (fully connected) network for multiclass classification.
 
     Args:
-        num_features: int
-            Number of features of input data.
-        hidden_layer_size: List of int
-            The ith number represents the number of neurons
-            in the ith hidden layer.
-        num_classes: int
-            Number of output classes.
+        num_features: Number of input features.
+        num_classes: Number of output classes.
+        hidden_layer_sizes: Width of each hidden layer; the ith value is the number
+            of neurons in the ith hidden layer. Defaults to [128, 256, 128].
+        batch_norm: Whether to add batch normalization after each hidden layer.
     """
 
     def __init__(
@@ -53,28 +50,24 @@ class LinearNet(AmuletModel):
         self.classifier = nn.Linear(hidden_layer_sizes[-1], num_classes)
 
     def forward(self, x: torch.Tensor):
-        """
-        Runs the forward pass on the neural network.
+        """Run the forward pass and return classification logits.
 
         Args:
-            x: torch.Tensor
-                Input data
+            x: Input batch.
 
         Returns:
-            Output from the model of type torch.Tensor
+            A (batch, num_classes) logits tensor.
         """
         hidden_out = self.features(x)
         return self.classifier(hidden_out)
 
     def get_hidden(self, x: torch.Tensor):
-        """
-        Gets the intermediate layer output from the model.
+        """Return the final hidden-layer activations.
 
         Args:
-            x: torch.Tensor
-                Input data to the model.
+            x: Input batch.
 
         Returns:
-            Output from the model of type torch.Tensor.
+            A (batch, hidden_layer_sizes[-1]) tensor of hidden-layer features.
         """
         return self.features(x)

--- a/amulet/models/resnet.py
+++ b/amulet/models/resnet.py
@@ -18,6 +18,8 @@ from .base import AmuletModel
 
 
 class Identity(nn.Module):
+    """Pass-through module used to replace the backbone's final fully connected layer."""
+
     def __init__(self):
         super().__init__()
 
@@ -26,6 +28,23 @@ class Identity(nn.Module):
 
 
 class ResNet(AmuletModel):
+    """Build a torchvision ResNet backbone with a fresh classification head.
+
+    The backbone's final fully connected layer is replaced with an identity, so
+    `features` yields pooled backbone embeddings and a separate `classifier`
+    produces the class logits.
+
+    Args:
+        size: Which ResNet variant to build. One of "resnet18", "resnet34",
+            "resnet50", "resnet101", "resnet152".
+        pretrained: Whether to initialize the backbone with torchvision's ImageNet
+            pretrained weights.
+        num_classes: Number of output classes.
+        replace_first: Whether to swap the initial 7x7 stride-2 convolution for a 3x3
+            stride-1 convolution and drop the first max-pool, adapting the stem for
+            low-resolution inputs such as CIFAR.
+    """
+
     def __init__(
         self,
         size: str = "resnet18",
@@ -75,29 +94,25 @@ class ResNet(AmuletModel):
             self.classifier = nn.Sequential(*layers)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        Runs the forward pass on the neural network.
+        """Run the forward pass and return classification logits.
 
         Args:
-            x: torch.Tensor
-                Input data
+            x: Input image batch.
 
         Returns:
-            Output from the model of type torch.Tensor
+            A (batch, num_classes) logits tensor.
         """
         x = self.features(x)
         x = self.classifier(x)
         return x
 
     def get_hidden(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        Gets the intermediate layer output from the model.
+        """Return the pooled backbone embedding.
 
         Args:
-            x: torch.Tensor
-                Input data to the model.
+            x: Input image batch.
 
         Returns:
-            Output from the model of type torch.Tensor.
+            The backbone feature embedding for each sample.
         """
         return self.features(x)

--- a/amulet/models/vgg.py
+++ b/amulet/models/vgg.py
@@ -7,18 +7,17 @@ from .base import AmuletModel
 
 
 class VGG(AmuletModel):
-    """
-    Builds a VGG network. Code taken from
-    https://github.com/kuangliu/pytorch-cifar/blob/master/models/vgg.py
+    """Build a VGG-style convolutional network.
+
+    Code adapted from
+    https://github.com/kuangliu/pytorch-cifar/blob/master/models/vgg.py.
 
     Args:
-        num_classes: int
-            Number of output classes in the data.
-        vgg_name: str
-            String to define which version of vgg to build.
-            Possible values: ['VGG11','VGG13','VGG16','VGG19'].
-        batch_norm: bool
-            Whether or not to use batch norm.
+        num_classes: Number of output classes in the data.
+        layer_config: Feature-extractor specification. Each int is a convolution's
+            output channel count and each "M" inserts a max-pool layer. Defaults to a
+            built-in VGG-style configuration.
+        batch_norm: Whether to add batch normalization after each convolution.
     """
 
     def __init__(
@@ -74,29 +73,26 @@ class VGG(AmuletModel):
         return nn.Sequential(*layers)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        Runs the forward pass on the neural network.
+        """Run the forward pass and return classification logits.
 
         Args:
-            x: torch.Tensor
-                Input data
+            x: Input image batch.
 
         Returns:
-            Output from the model of type torch.Tensor
+            A (batch, num_classes) logits tensor.
         """
         out = self.features(x)
         out = self.classifier(out)
         return out
 
     def get_hidden(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        Gets the intermediate layer output from the model.
+        """Return the flattened feature-extractor output.
 
         Args:
-            x: torch.Tensor
-                Input data to the model.
+            x: Input image batch.
 
         Returns:
-            Output from the model of type torch.Tensor.
+            A (batch, features) tensor of globally pooled, flattened convolutional
+            features (512 with the default configuration).
         """
         return self.features(x)

--- a/amulet/poisoning/attacks/badnets.py
+++ b/amulet/poisoning/attacks/badnets.py
@@ -6,8 +6,7 @@ from .poisoning_attack import PoisoningAttack
 
 
 class BadNets(PoisoningAttack):
-    """
-    BadNets backdoor poisoning attack.
+    """BadNets backdoor poisoning attack.
 
     Reference:
         BadNets: Identifying Vulnerabilities in the Machine Learning Model Supply Chain
@@ -17,7 +16,7 @@ class BadNets(PoisoningAttack):
     Attributes:
         trigger_label: Target label assigned to poisoned samples.
         portion: Fraction of training samples to poison.
-        dataset_type: "image" for 2D data, "tabular" for 1D data.
+        dataset_type: "image" for CxHxW image tensors (3D), "tabular" for 1D feature vectors.
         random_seed: Seed for selecting which samples to poison.
     """
 
@@ -34,6 +33,7 @@ class BadNets(PoisoningAttack):
         self.dataset_type = dataset_type
 
     def __poison_datapoint(self, data_original: torch.Tensor) -> torch.Tensor:
+        """Embed the trigger into a single datapoint, raising ValueError for an unknown dataset_type."""
         data_point = data_original.clone().detach()
         if self.dataset_type == "image":
             channels, width, height = data_point.shape
@@ -51,14 +51,13 @@ class BadNets(PoisoningAttack):
         return data_point
 
     def poison_train(self, dataset) -> TensorDataset:
-        """
-        Poison a portion of the training dataset by embedding a trigger.
+        """Poison a portion of the training dataset by embedding a trigger.
 
         Args:
             dataset: The training dataset to poison.
 
         Returns:
-            TensorDataset with trigger-embedded samples and relabeled targets.
+            A TensorDataset with trigger-embedded samples and relabeled targets.
         """
         data_points = []
         targets = []
@@ -83,14 +82,13 @@ class BadNets(PoisoningAttack):
         return TensorDataset(torch.stack(data_points), torch.stack(targets))
 
     def poison_test(self, dataset) -> TensorDataset:
-        """
-        Poison all test samples that do not already carry the trigger label.
+        """Poison all test samples that do not already carry the trigger label.
 
         Args:
             dataset: The test dataset to poison.
 
         Returns:
-            TensorDataset containing only poisoned samples with trigger-embedded inputs.
+            A TensorDataset containing only poisoned samples with trigger-embedded inputs.
         """
         data_points = []
         targets = []

--- a/amulet/poisoning/attacks/poisoning_attack.py
+++ b/amulet/poisoning/attacks/poisoning_attack.py
@@ -6,16 +6,14 @@ from torch.utils.data import TensorDataset
 
 
 class PoisoningAttack(ABC):
-    """
-    Base class for poisoning attacks.
+    """Base class for poisoning attacks.
 
     Poisoning attacks corrupt a subset of training samples before model
     training begins. Subclasses implement the concrete trigger-injection
     or label-manipulation strategy.
 
     Attributes:
-        random_seed: int
-            Seed used when randomly selecting samples to poison.
+        random_seed: Seed used when randomly selecting samples to poison.
     """
 
     def __init__(self, random_seed: int):
@@ -23,8 +21,10 @@ class PoisoningAttack(ABC):
 
     @abstractmethod
     def poison_train(self, dataset) -> TensorDataset:
+        """Return a poisoned training TensorDataset with triggers embedded and targets relabeled."""
         pass
 
     @abstractmethod
     def poison_test(self, dataset) -> TensorDataset:
+        """Return a poisoned test TensorDataset of trigger-embedded samples relabeled to the target."""
         pass

--- a/amulet/poisoning/attacks/text_badnets.py
+++ b/amulet/poisoning/attacks/text_badnets.py
@@ -17,7 +17,7 @@ _INSERT_POSITIONS = ("start", "random", "end")
 class TextBadNets(PoisoningAttack):
     """Textual backdoor poisoning by trigger insertion (BadNets / AddSent family).
 
-    The NLP analog of the image :class:`BadNets`: a rare word or short fixed phrase is
+    The NLP analog of the image ``BadNets``: a rare word or short fixed phrase is
     stamped into a fraction of training examples whose labels are flipped to a target
     class. Trigger insertion happens in **string space** (a real word/phrase, not raw
     token ids), which is what makes the trigger a genuine perplexity outlier for the
@@ -55,6 +55,11 @@ class TextBadNets(PoisoningAttack):
         max_length: int | None = None,
         insert_position: str = "start",
     ):
+        """Configure the textual BadNets attack.
+
+        Raises:
+            ValueError: If insert_position is not one of "start", "random", or "end".
+        """
         super().__init__(random_seed)
         if insert_position not in _INSERT_POSITIONS:
             raise ValueError(

--- a/amulet/poisoning/defenses/onion.py
+++ b/amulet/poisoning/defenses/onion.py
@@ -29,7 +29,7 @@ class ONION(PoisoningDefense):
     perplexity, so deleting it drops perplexity sharply. Words whose suspicion score
     (``ppl(full) - ppl(without word)``) exceeds ``threshold`` are removed.
 
-    The reference language model is the victim itself (``model``, an :class:`HFCausalLM`),
+    The reference language model is the victim itself (``model``, an ``HFCausalLM``),
     scored through its perplexity head — the same object ONION retrains in
     ``train_robust``. Like ``OutlierRemoval``, ONION thus cleans the data using the target
     model and retrains it; unlike it, ONION also exposes ``purify`` to clean inputs at test

--- a/amulet/poisoning/defenses/outlier_removal.py
+++ b/amulet/poisoning/defenses/outlier_removal.py
@@ -12,10 +12,10 @@ from .poisoning_defense import PoisoningDefense
 
 
 class OutlierRemoval(PoisoningDefense):
-    """
-    Implementation of algorithm to remove outliers from a dataset
-    using the KNN Shapley values. These values are calculated
-    using the algorithm presented in https://github.com/AI-secure/KNN-shapley.
+    """Remove dataset outliers via KNN Shapley values, then retrain the model.
+
+    Outliers are the lowest-scoring samples under KNN Shapley values, computed
+    following the algorithm at https://github.com/AI-secure/KNN-shapley.
 
     Reference:
         A Privacy-Friendly Approach to Data Valuation,
@@ -24,27 +24,16 @@ class OutlierRemoval(PoisoningDefense):
         https://openreview.net/forum?id=FAZ3i0hvm0
 
     Attributes:
-        model: torch.nn.Module
-            The model to retrain after removing outliers.
-        criterion: torch.nn.Module
-            Loss function for training model.
-        optimizer: torch.optim.Optimizer
-            Optimizer for training model.
-        train_loader: torch.utils.data.DataLoader
-            Training data loader to train model.
-        test_loader: torch.utils.data.DataLoader
-            Test data loader to calculate Shapley values.
-        train_function: Callable
-            Function used to train the model. Default function
-            used from src.utils.
-        percent: int
-            Percentage of data to remove as outlier.
-        device: str
-            Device used to train model. Example: "cuda:0".
-        epochs: int
-            Determines number of iterations over training data.
-        batch_size: int
-            Batch size of training data.
+        model: The model to retrain after removing outliers.
+        criterion: Loss function for training model.
+        optimizer: Optimizer for training model.
+        train_loader: Training data loader to train model.
+        test_loader: Test data loader to calculate Shapley values.
+        train_function: Function used to train the model. Defaults to train_classifier from amulet.utils.
+        percent: Percentage of data to remove as outliers.
+        device: Device used to train model. Example: "cuda:0".
+        epochs: Number of iterations over the training data.
+        batch_size: Batch size of training data.
     """
 
     def __init__(
@@ -111,17 +100,14 @@ class OutlierRemoval(PoisoningDefense):
             ..., tuple[np.ndarray, np.ndarray, np.ndarray]
         ] = get_intermediate_features,
     ):
-        """
-        Trains model after removing outliers.
+        """Train the model after removing outliers.
 
         Args:
-            get_hidden: Callable
-                Function to output the intermediate layer outputs of the model,
-                along with the labels and input data. See example get_intermediate_features
-                in src.utils.
+            get_hidden: Function returning the model's intermediate-layer outputs along
+                with the labels and input data. See get_intermediate_features in amulet.utils.
 
         Returns:
-            Model trained with outlier removal of type :class:`torch.nn.Module'.
+            The model retrained after outlier removal.
         """
         # Get the penultimate layer activations of the model
         train_features, train_targets, train_inputs = get_hidden(

--- a/amulet/unauth_model_ownership/attacks/model_extraction.py
+++ b/amulet/unauth_model_ownership/attacks/model_extraction.py
@@ -1,4 +1,4 @@
-"""Model Extraction implementation"""
+"""Model extraction attack that distills a target model into a surrogate."""
 
 import torch
 import torch.nn as nn
@@ -10,10 +10,10 @@ from .unauth_model_ownership_attack import UnauthModelOwnershipAttack
 
 
 class ModelExtraction(UnauthModelOwnershipAttack):
-    """
-    Implementation of algorithm to extract parameters of a model to
-    obtain a "stolen" model. Code taken from:
-    https://github.com/liuyugeng/ML-Doctor/blob/main/doctor/modsteal.py
+    """Extract a target model into a "stolen" surrogate by distillation.
+
+    Code adapted from
+    https://github.com/liuyugeng/ML-Doctor/blob/main/doctor/modsteal.py.
 
     Reference:
         ML-Doctor: Holistic Risk Assessment of Inference Attacks Against Machine Learning Models,
@@ -22,20 +22,19 @@ class ModelExtraction(UnauthModelOwnershipAttack):
         31st USENIX Security Symposium (USENIX Security 22)
         https://www.usenix.org/conference/usenixsecurity22/presentation/liu-yugeng
 
-
     Attributes:
-        target_model: torch.nn.Module
-            This model will be extracted.
-        attack_model: torch.nn.Module
-            The model trained by extracting target_model.
-        optimizer: torch.optim.Optimizer
-            Optimizer for training model.
-        train_loader: torch.utils.data.DataLoader
-            Dataloader for training model.
-        device: str
-            Device used to train model. Example: "cuda:0".
-        epochs: int
-            Determines number of iterations over training data.
+        target_model: The model to extract (steal from).
+        attack_model: The surrogate model trained to imitate the target.
+        optimizer: Optimizer for training the surrogate.
+        train_loader: Data loader used to query the target and train the surrogate.
+        device: Device used to train the model. Example: "cuda:0".
+        epochs: Number of iterations over the training data.
+        loss_type: Distillation loss matching the surrogate to the target. One of
+            "mse" (regress logits), "kl" (match softmax distributions), or "ce"
+            (train on the target's hard labels).
+
+    Raises:
+        ValueError: If `loss_type` is not one of "mse", "kl", or "ce".
     """
 
     def __init__(
@@ -64,11 +63,10 @@ class ModelExtraction(UnauthModelOwnershipAttack):
             raise ValueError(f"Unsupported loss_type: {self.loss_type}")
 
     def attack(self) -> nn.Module:
-        """
-        Trains attack model by extracting the target model.
+        """Train the surrogate model by extracting the target model.
 
         Returns:
-            Stolen model of type :class:`torch.nn.Module'.
+            The stolen (surrogate) model.
         """
         self.attack_model.train()
         self.target_model.eval()

--- a/amulet/unauth_model_ownership/attacks/unauth_model_ownership_attack.py
+++ b/amulet/unauth_model_ownership/attacks/unauth_model_ownership_attack.py
@@ -34,4 +34,8 @@ class UnauthModelOwnershipAttack(ABC):
 
     @abstractmethod
     def attack(self) -> nn.Module:
-        pass
+        """Run the ownership attack and return the surrogate model.
+
+        Returns:
+            The stolen surrogate model imitating the target.
+        """

--- a/amulet/unauth_model_ownership/defenses/fingerprint.py
+++ b/amulet/unauth_model_ownership/defenses/fingerprint.py
@@ -82,6 +82,9 @@ class DatasetInference(FingerprintDefense):
         Returns:
             Nested dict with keys "target" and "suspect", each containing
             "p-value" and "mean_diff".
+
+        Raises:
+            ValueError: If a computed p-value is negative.
         """
         train_target, test_target = self.__feature_extracter(self.target_model)
         train_suspect, test_suspect = self.__feature_extracter(self.suspect_model)

--- a/amulet/unauth_model_ownership/defenses/unauth_model_ownership_defense.py
+++ b/amulet/unauth_model_ownership/defenses/unauth_model_ownership_defense.py
@@ -26,7 +26,11 @@ class WatermarkDefense(ABC):
 
     @abstractmethod
     def watermark(self) -> nn.Module:
-        pass
+        """Embed the ownership watermark and return the watermarked model.
+
+        Returns:
+            The watermarked model.
+        """
 
 
 class FingerprintDefense(ABC):
@@ -49,4 +53,9 @@ class FingerprintDefense(ABC):
 
     @abstractmethod
     def fingerprint(self) -> dict[str, dict[str, float]]:
-        pass
+        """Fingerprint the suspect model against the target.
+
+        Returns:
+            A nested dict keyed by "target" and "suspect", each mapping "p-value"
+            and "mean_diff" to their values.
+        """

--- a/amulet/unauth_model_ownership/defenses/watermark.py
+++ b/amulet/unauth_model_ownership/defenses/watermark.py
@@ -1,3 +1,5 @@
+"""Watermarking-based ownership defense that embeds a backdoor trigger set."""
+
 from pathlib import Path
 
 import numpy as np
@@ -11,34 +13,27 @@ from .unauth_model_ownership_defense import WatermarkDefense
 
 
 class WatermarkNN(WatermarkDefense):
-    """
+    """Embed an ownership watermark into a model by backdooring a trigger set.
+
     Reference:
         Turning Your Weakness Into a Strength: Watermarking Deep Neural Networks by Backdooring
         Yossi Adi, Carsten Baum, Moustapha Cisse, Benny Pinkas, Joseph Keshet
         https://arxiv.org/abs/1802.04633
 
     Attributes:
-        model: torch.nn.Module
-            The model to watermark.
-        criterion: torch.nn.Module
-            Loss function for watermark training.
-        optimizer: torch.optim.Optimizer
-            Optimizer for watermark training.
-        train_loader: torch.utils.data.DataLoader
-            Training data loader for watermark training.
-        device: str
-            Device used to train model. Example: "cuda:0".
-        wm_path: str or Path object.
-            Location of the trigger set.
-        gray: bool
-            Used to define the kind of transformation applied to the trigger set.
-            If the original model used grayscale images, it's better to use a grayscale triggerset.
-        tabular: bool
-            If the original dataset is a tabular dataset, set this to true.
-        epochs: int
-            Determines number of iterations over training data.
-        batch_size int
-            Determines the batch size while embedding the watermark.
+        target_model: The model to watermark.
+        criterion: Loss function for watermark training.
+        optimizer: Optimizer for watermark training.
+        train_loader: Training data loader for watermark training.
+        device: Device used to train the model. Example: "cuda:0".
+        wm_path: Location of the trigger set.
+        gray: Whether to apply a grayscale transform to the trigger set. Prefer this
+            when the original model was trained on grayscale images.
+        tabular: Whether the original dataset is tabular.
+        num_classes: Number of output classes, used to sample labels for a tabular
+            trigger set.
+        epochs: Number of iterations over the training data.
+        batch_size: Batch size used while embedding the watermark.
     """
 
     def __init__(
@@ -73,6 +68,20 @@ class WatermarkNN(WatermarkDefense):
     def get_wm_loader(
         self, shape: int, wm_path: Path, gray: bool, tabular: bool
     ) -> DataLoader:
+        """Build the trigger-set data loader used to embed and verify the watermark.
+
+        Args:
+            shape: Spatial size to center-crop trigger images to, matched to the
+                model's input size.
+            wm_path: Directory holding the trigger set (a `labels.csv` file and an
+                `images` folder).
+            gray: Whether to convert trigger images to grayscale.
+            tabular: Whether to generate a random tabular trigger set instead of
+                loading images.
+
+        Returns:
+            A DataLoader over the trigger set.
+        """
         if tabular:
             wm_data = np.random.random((100, shape))
             wm_label = np.random.randint(0, self.num_classes, 100)
@@ -106,11 +115,10 @@ class WatermarkNN(WatermarkDefense):
         return wm_loader
 
     def watermark(self) -> nn.Module:
-        """
-        Embeds watermark into the model
+        """Embed the watermark into the model.
 
-        Return:
-            Model with watermark embedded
+        Returns:
+            The model with the watermark embedded.
         """
         wm_inputs, wm_labels = [], []
         for _wm_idx, (wm_input, wm_label) in enumerate(self.wm_loader):
@@ -153,18 +161,15 @@ class WatermarkNN(WatermarkDefense):
         return self.target_model
 
     def verify(self, model: nn.Module, threshold: float = 0.9) -> bool:
-        """
-        Verifies whether the given model contains the watermark or not.
+        """Verify whether the given model contains the watermark.
 
         Args:
-            model: :class:~`torch.nn.Module`
-                The model being verified for the watermark.
-            threshold: int
-                The minimum watermarking accuracy for a model to be considered
-                a surrogate model.
+            model: The model being verified for the watermark.
+            threshold: Minimum watermark accuracy for the model to be considered a
+                surrogate.
 
         Returns:
-            True if model contains the watermark. False otherwise.
+            True if the model contains the watermark, False otherwise.
         """
         model.eval()
         correct = 0

--- a/amulet/unauth_model_ownership/metrics/extraction_accuracy.py
+++ b/amulet/unauth_model_ownership/metrics/extraction_accuracy.py
@@ -1,3 +1,5 @@
+"""Accuracy and fidelity metrics for evaluating extracted (stolen) models."""
+
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader

--- a/amulet/utils/__meta_classifiers.py
+++ b/amulet/utils/__meta_classifiers.py
@@ -64,6 +64,9 @@ class PermInvModel(nn.Module):
 
         Returns:
             Logits for the meta-classification decision.
+
+        Raises:
+            ValueError: If a layer's neuron count does not match its expected shape.
         """
         reps = []
         for_prev = None

--- a/amulet/utils/__pipeline.py
+++ b/amulet/utils/__pipeline.py
@@ -45,6 +45,9 @@ def load_data(
 
     Returns:
         Loaded dataset as an AmuletDataset.
+
+    Raises:
+        ValueError: If dataset is not a recognized dataset name.
     """
 
     if isinstance(root, str):
@@ -163,11 +166,15 @@ def create_dir(path: Path | str, log: logging.Logger | None = None) -> Path:
 
 
 class CNNConfig(TypedDict):
+    """Convolutional and fully-connected layer sizes for a SimpleCNN capacity."""
+
     conv_layers: list[tuple[int, int]]
     fc_layers: list[int]
 
 
 class ModelConfig(TypedDict, total=False):
+    """Per-architecture layer configurations for one capacity tier."""
+
     vgg: list[int | str]
     resnet: str
     linearnet: list[int]
@@ -287,30 +294,25 @@ def initialize_model(
     model_conf: CapacityMap = DEFAULT_CAPACITY_MAP,
     resnet_replace_first: bool = True,
 ) -> AmuletModel:
-    """
-    Creates a model using the provided configuration.
+    """Create a model using the provided configuration.
 
     Args:
-        model_arch: str
-            Which model architecture to initialize. Options: "vgg", "resnet", "linearnet", "cnn".
-        model_capacity: str
-            Key in the configuration dict to select model capacity/size.
-        num_features: int
-            Number of input features (used by linear/dense models).
-        num_classes: int
-            Number of output classes.
-        log: logging.Logger | None, optional
-            Logger instance for logging info. Defaults to None.
-        batch_norm: bool, optional
-            Whether to use batch normalization. Defaults to True.
-        model_conf: CapacityMap, optional
-            Configuration dictionary mapping capacities to model params.
-        resnet_replace_first: bool, optional
-            Whether to replace the first conv layer of ResNet with a smaller filter. Defaults to True.
+        model_arch: Which model architecture to initialize. Options: "vgg", "resnet", "linearnet", "cnn".
+        model_capacity: Key in the configuration dict to select model capacity/size.
+        num_features: Number of input features (used by linear/dense models).
+        num_classes: Number of output classes.
+        log: Logger instance for logging info. Defaults to None.
+        batch_norm: Whether to use batch normalization. Defaults to True.
+        model_conf: Configuration dictionary mapping capacities to model params.
+        resnet_replace_first: Whether to replace the first conv layer of ResNet with a smaller filter. Defaults to True.
 
     Returns:
-        AmuletModel
-            Initialized PyTorch model instance with a `get_hidden` method.
+        Initialized PyTorch model instance with a `get_hidden` method.
+
+    Raises:
+        KeyError: If model_capacity is absent from model_conf, or the requested
+            architecture's config is missing for that capacity.
+        ValueError: If model_arch is not a recognized architecture.
     """
     if model_capacity not in model_conf:
         raise KeyError(f"Capacity '{model_capacity}' not found in model_conf")

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Amulet uses [uv](https://docs.astral.sh/uv/) for dependency management.
 2. **Implementation**: Place your file in the appropriate directory: `amulet/<risk>/<attacks|defenses|metrics>/new_module.py`.
 3. **API Contract**:
    - **Attacks**: Implement an `attack()` method (except for poisoning, which uses `poison_train` and `poison_test`).
-   - **Defenses**: Every defense **must** implement the training-shaped entry point for its risk — poisoning/evasion → `train_robust()`, membership inference → `train_private()`, fairness → `train_fair()`, ownership → `watermark()` / `fingerprint()`. This is enforced by `tests/test_api_conformance.py`: a defense that ships only a bespoke method (e.g. a `purify`-only input cleaner) fails the suite. A defense may expose extra public helpers **in addition to** its entry point, never instead of it, and should subclass its risk's existing defense base rather than introducing a new one.
+   - **Defenses**: Every defense **must** implement the training-shaped entry point for its risk: poisoning/evasion → `train_robust()`, membership inference → `train_private()`, fairness → `train_fair()`, ownership → `watermark()` / `fingerprint()`. This is enforced by `tests/test_api_conformance.py`: a defense that ships only a bespoke method (e.g. a `purify`-only input cleaner) fails the suite. A defense may expose extra public helpers **in addition to** its entry point, never instead of it, and should subclass its risk's existing defense base rather than introducing a new one.
    - **Return Values**: Attacks/defenses should return artifacts (e.g., a `DataLoader` or a `nn.Module`), not metrics directly.
 4. **Export**: Import your class in the risk's `__init__.py`.
 5. **Example**: Add a runnable script in `examples/attack_pipelines/` or `examples/defense_pipelines/`.
@@ -67,6 +67,8 @@ class AmuletDataset:
     test_set: Dataset
     num_features: int
     num_classes: int
+    modality: Literal["image", "tabular", "text"]
+    sensitive_columns: list[str] | None = None
     x_train: np.ndarray | None = None
     ...
 ```

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -57,6 +57,8 @@ class AmuletDataset:
     test_set: torch.utils.data.Dataset
     num_features: int
     num_classes: int
+    modality: Literal["image", "tabular", "text"]
+    sensitive_columns: list[str] | None = None
     x_train: np.ndarray | None = None
     x_test: np.ndarray | None = None
     y_train: np.ndarray | None = None
@@ -66,6 +68,8 @@ class AmuletDataset:
 ```
 
 - `train_set`/`test_set`: PyTorch Datasets ready for use with a `DataLoader`.
+- `modality`: Required. One of `"image"`, `"tabular"`, or `"text"`; it tells models the shape of each sample.
+- `sensitive_columns`: Column names of `z_train`/`z_test` in order, or `None` if the dataset has no sensitive attributes.
 - `x_*`/`y_*`: Raw features and labels as NumPy arrays (available for processed datasets like LFW, Census, CelebA).
 - `z_*`: Sensitive attributes used by fairness and attribute inference modules.
 

--- a/docs/module_guide/1_INTRO.md
+++ b/docs/module_guide/1_INTRO.md
@@ -14,7 +14,7 @@ The core design philosophy is to allow these components to be easily composed in
 Most Amulet components follow a consistent API:
 
 - **Attacks** generally take a `target_model` and a `DataLoader` as input and provide an `attack()` method.
-- **Defenses** provide methods like `train_robust()`, `train_private()`, or `train_fair()` depending on the risk they address; inference-time defenses (e.g. ONION) instead expose `purify(dataset)`.
+- **Defenses** provide methods like `train_robust()`, `train_private()`, or `train_fair()` depending on the risk they address; inference-time defenses (e.g. ONION) also expose `purify(dataset)` alongside `train_robust()`.
 - **Metrics** take model predictions or outputs and return standard performance scores.
 
 ### Example Pipeline

--- a/docs/module_guide/3_POISONING.md
+++ b/docs/module_guide/3_POISONING.md
@@ -2,7 +2,7 @@
 
 Data poisoning attacks involve an adversary injecting malicious samples into a model's training set. Amulet implements the BadNets backdoor attack for image/tabular data and a textual variant (`TextBadNets`) for language models. It provides an outlier-removal defense based on KNN Shapley values, and (for the textual attack) the ONION perplexity-based defense.
 
-Both poisoning defenses follow the same shape and share the `PoisoningDefense` base class: they expose `train_robust()`, which cleans the (poisoned) training set — `OutlierRemoval` drops low-Shapley outlier samples, `ONION` removes perplexity-outlier trigger words — then retrains the victim on the cleaned data and returns it. This mirrors the library-wide convention that every defense implements its risk's training entry point (`train_robust` / `train_private` / `train_fair`). `ONION` additionally exposes `purify(dataset)` to clean inputs at test time, in addition to — not instead of — `train_robust()`.
+Both poisoning defenses follow the same shape and share the `PoisoningDefense` base class. They expose `train_robust()`, which cleans the (poisoned) training set, then retrains the victim on the cleaned data and returns it. `OutlierRemoval` drops low-Shapley outlier samples, and `ONION` removes perplexity-outlier trigger words. This mirrors the library-wide convention that every defense implements its risk's training entry point (`train_robust` / `train_private` / `train_fair`). `ONION` additionally exposes `purify(dataset)` to clean inputs at test time, alongside `train_robust()`.
 
 ## Attack
 
@@ -125,6 +125,8 @@ print(f"Attack Success Rate (ASR): {asr}%")
 #    ONION scores perplexity with the victim's own base LM (its clean, pre-fine-tuning
 #    base by default), so it re-tokenizes with the victim's tokenizer.
 tokenizer = AutoTokenizer.from_pretrained(model_name)
+if tokenizer.pad_token is None:
+    tokenizer.pad_token = tokenizer.eos_token
 onion = ONION(model=victim, tokenizer=tokenizer, device=device)
 purified_test = onion.purify(poisoned_test)
 defended_asr = get_accuracy(victim, DataLoader(purified_test, batch_size=16), device)

--- a/docs/module_guide/4_UNAUTHORIZED_MODEL_OWNERSHIP.md
+++ b/docs/module_guide/4_UNAUTHORIZED_MODEL_OWNERSHIP.md
@@ -71,7 +71,7 @@ from amulet.unauth_model_ownership.defenses import WatermarkNN
 
 # Configure and apply Watermarking
 wm_model_wrapper = WatermarkNN(
-    model=target_model,
+    target_model=target_model,
     criterion=criterion,
     optimizer=optimizer,
     train_loader=train_loader,

--- a/docs/module_guide/5_MEMBERSHIP_INFERENCE.md
+++ b/docs/module_guide/5_MEMBERSHIP_INFERENCE.md
@@ -49,7 +49,7 @@ results = mem_inf.attack()
 
 # 4. Evaluate Metrics
 metrics = compute_mi_metrics(results['lira_online_preds'], results['true_labels'])
-print(f"Attack AUC: {metrics['auc_score']}")
+print(f"Attack AUC: {metrics['auc']}")
 ```
 
 ## DP-SGD Defense
@@ -73,12 +73,15 @@ dp_training = DPSGD(
     delta=1e-5,
     max_per_sample_grad_norm=1.0,
     sigma=1.0, # Noise multiplier
-    epochs=10
+    epochs=10,
+    max_physical_batch_size=32 # Optional: bound peak memory without changing accounting
 )
 
 defended_model = dp_training.train_private()
 ```
 
+The optional `max_physical_batch_size` argument opts into Opacus' `BatchMemoryManager`, which splits each logical batch into physical micro-batches of at most this size. This bounds peak per-sample-gradient memory. The logical batch size stays the same, so the privacy accounting and expected utility are unchanged. Leave it unset (the default `None`) to iterate the loader without splitting.
+
 ## Metrics
 
-Membership inference effectiveness is evaluated using the **AUC score** and **Precision at low False Positive Rates (FPR)**, which are standard for measuring how well an adversary can distinguish members from non-members. Use `amulet.membership_inference.metrics.compute_mi_metrics` to compute these values from attack results.
+Membership inference effectiveness is evaluated using the **AUC score** and the **True Positive Rate at a low target False Positive Rate (FPR)**, which are standard for measuring how well an adversary can distinguish members from non-members. Use `amulet.membership_inference.metrics.compute_mi_metrics` to compute these values from attack results. It returns the keys `auc`, `balanced_acc`, `tpr_at_fpr`, and `threshold_score`.

--- a/docs/module_guide/6_ATTRIBUTE_INFERENCE.md
+++ b/docs/module_guide/6_ATTRIBUTE_INFERENCE.md
@@ -41,7 +41,7 @@ results = attribute_inference.attack()
 
 # 5. Evaluate Metrics
 metrics = evaluate_attribute_inference(data.z_test, results)
-print(f"Attribute Inference Balanced Accuracy: {metrics[0]['balanced_accuracy']}")
+print(f"Attribute Inference Attack Accuracy: {metrics[0]['attack_accuracy']}")
 ```
 
 ## Metrics

--- a/docs/module_guide/7_DISTRIBUTION_INFERENCE.md
+++ b/docs/module_guide/7_DISTRIBUTION_INFERENCE.md
@@ -1,36 +1,110 @@
 # Distribution Inference
 
-Distribution inference attacks aim to determine if a training set follows a specific distribution (e.g., if a certain property or ratio of samples is present). Amulet implements a KL-divergence-based distinguishing test.
+Distribution inference attacks aim to determine which of two training distributions a model was trained on, for example whether a chosen sensitive attribute (like `sex` or `race`) appears in a given proportion of the training set. Amulet ships two attacks: `SuriEvans2022`, a black-box KL-divergence distinguishing test, and `WhiteBoxPIM`, a white-box attack that reads a model's raw parameters with a permutation-invariant meta-classifier.
 
-## Attack
+Both attacks share the `DistributionInferenceAttack` lifecycle:
 
-To run a distribution inference attack, use `amulet.distribution_inference.attacks.SuriEvans2022`. This attack measures how a victim model's outputs diverge from adversary baseline models trained on two different distributions.
+1. Construct the attack with the dataset arrays and a training configuration.
+2. Call `prepare_model_populations()` to train (or load cached) the four model populations: adversary distribution 1, adversary distribution 2, victim distribution 1, and victim distribution 2.
+3. Call `attack()` to run the distinguishing test.
+
+## Black-Box Attack (KL divergence)
+
+To run the KL-divergence distinguishing test, use `amulet.distribution_inference.attacks.SuriEvans2022`. It measures how each victim model's outputs diverge from the adversary baseline models trained on each distribution.
 
 ```python
 from amulet.distribution_inference.attacks import SuriEvans2022
+from amulet.distribution_inference.metrics import evaluate_distinguishing_accuracy
+from amulet.utils import load_data
 
-# 1. Prepare Victim and Adversary Models for both distributions
-# victim_models_1: list[nn.Module], victim_models_2: list[nn.Module]
-# adversary_models_1: list[nn.Module], adversary_models_2: list[nn.Module]
+# 1. Load a dataset that exposes sensitive-attribute arrays (census or lfw)
+data = load_data("./data", "census")
 
-# 2. Run the Distribution Inference attack
+# 2. Construct the attack with the data arrays and a training config.
+#    ratio1 and ratio2 are the two proportions of `filter_column == filter_value`
+#    that define the distributions to distinguish.
 dist_inf = SuriEvans2022(
-    models_vic_1=victim_models_1,
-    models_vic_2=victim_models_2,
-    models_adv_1=adversary_models_1,
-    models_adv_2=adversary_models_2,
-    test_loader_1=test_loader_dist_1,
-    test_loader_2=test_loader_dist_2,
-    device=device
+    x_train=data.x_train,
+    y_train=data.y_train,
+    z_train=data.z_train,
+    x_test=data.x_test,
+    y_test=data.y_test,
+    z_test=data.z_test,
+    sensitive_columns=data.sensitive_columns,
+    filter_column="sex",
+    ratio1=0.1,
+    ratio2=0.9,
+    model_arch="linearnet",
+    model_capacity="m1",
+    num_features=data.num_features,
+    num_classes=data.num_classes,
+    num_models=5,       # Models trained per population
+    epochs=1,
+    batch_size=256,
+    device=device,
+    models_dir="./models/distribution_inference",
+    dataset="census",
+    exp_id=0
 )
 
+# 3. Train (or load) the four model populations, then run the attack.
+dist_inf.prepare_model_populations()
 results = dist_inf.attack()
 
-# 3. Evaluate results
-# results["predictions"] contains scores in [0, 1]
-# results["ground_truth"] contains binary labels for distributions
+# results["predictions"]: attack scores in [0, 1] (threshold at 0.5 to decide)
+# results["ground_truth"]: 0 for distribution-1 victims, 1 for distribution-2 victims
+
+# 4. Evaluate results
+metrics = evaluate_distinguishing_accuracy(results["predictions"], results["ground_truth"])
+print(f"Distinguishing Accuracy: {metrics['distinguishing_accuracy']}")
+print(f"AUC Score: {metrics['auc_score']}")
+```
+
+The populations and test loaders built by `prepare_model_populations()` are the defaults for `attack()`. To score externally produced populations instead, pass them as keyword arguments (`models_adv_1`, `models_vic_1`, `test_loader_1`, and so on) to `attack()`.
+
+## White-Box Attack (Permutation Invariant Model)
+
+To run the white-box attack, use `amulet.distribution_inference.attacks.WhiteBoxPIM`. Rather than observing outputs, it reads each model's raw Linear and Conv2d weights and trains a Permutation Invariant Model (PIM) meta-classifier on the adversary populations to distinguish the two distributions, then evaluates that meta-classifier on the held-out victim populations.
+
+`WhiteBoxPIM` takes the same constructor arguments as `SuriEvans2022`, plus meta-classifier settings (`meta_epochs`, `lr`, `inside_dims`).
+
+```python
+from amulet.distribution_inference.attacks import WhiteBoxPIM
+from amulet.distribution_inference.metrics import evaluate_distinguishing_accuracy
+
+whitebox = WhiteBoxPIM(
+    x_train=data.x_train,
+    y_train=data.y_train,
+    z_train=data.z_train,
+    x_test=data.x_test,
+    y_test=data.y_test,
+    z_test=data.z_test,
+    sensitive_columns=data.sensitive_columns,
+    filter_column="sex",
+    ratio1=0.1,
+    ratio2=0.9,
+    model_arch="linearnet",
+    model_capacity="m1",
+    num_features=data.num_features,
+    num_classes=data.num_classes,
+    num_models=5,
+    epochs=1,
+    batch_size=256,
+    device=device,
+    models_dir="./models/distribution_inference",
+    dataset="census",
+    exp_id=0,
+    meta_epochs=50,  # PIM meta-classifier training epochs
+    lr=1e-2
+)
+
+whitebox.prepare_model_populations()
+results = whitebox.attack()
+
+metrics = evaluate_distinguishing_accuracy(results["predictions"], results["ground_truth"])
+print(f"Distinguishing Accuracy: {metrics['distinguishing_accuracy']}")
 ```
 
 ## Metrics
 
-Distribution inference is evaluated by the attack's **Distinguishing Accuracy**. This measures how well the adversary can correctly identify which of the two distributions was used to train a victim model. Use `amulet.distribution_inference.metrics.DistinguishingAccuracy` to compute these metrics.
+Distribution inference is evaluated by the attack's **Distinguishing Accuracy**: how often the adversary correctly identifies which of the two distributions trained a victim model. Use `amulet.distribution_inference.metrics.evaluate_distinguishing_accuracy`. It takes `results["predictions"]` and `results["ground_truth"]` and returns a dict with keys `distinguishing_accuracy` and `auc_score`.

--- a/docs/module_guide/8_DATA_RECONSTRUCTION.md
+++ b/docs/module_guide/8_DATA_RECONSTRUCTION.md
@@ -8,6 +8,7 @@ To run a data reconstruction attack, use `amulet.data_reconstruction.attacks.Fre
 
 ```python
 import torch
+from torch.utils.data import DataLoader
 from amulet.data_reconstruction.attacks import FredriksonCCS2015
 from amulet.data_reconstruction.metrics import evaluate_similarity
 from amulet.utils import load_data, initialize_model, train_classifier
@@ -21,8 +22,12 @@ target_model = train_classifier(target_model, train_loader, criterion, optimizer
 input_size = (1,) + tuple(data.test_set[0][0].shape)
 output_size = data.num_classes
 
+# FredriksonCCS2015 needs a Softmax-output model: its cost is 1 - p_target, so the
+# final layer must emit class probabilities. Wrap the classifier accordingly.
+inversion_model = torch.nn.Sequential(target_model, torch.nn.Softmax(dim=1))
+
 data_recon = FredriksonCCS2015(
-    target_model=target_model,
+    target_model=inversion_model,
     input_size=input_size,
     output_size=output_size,
     device=device,
@@ -32,7 +37,9 @@ data_recon = FredriksonCCS2015(
 # Returns a list of reconstructed tensors, one per class
 reconstructed_data = data_recon.attack()
 
-# 3. Evaluate Metrics
+# 3. Evaluate Metrics. evaluate_similarity iterates the loader one sample at a time,
+# so it must be built with batch_size=1.
+test_loader = DataLoader(data.test_set, batch_size=1, shuffle=False)
 results = evaluate_similarity(test_loader, reconstructed_data, input_size, output_size, device)
 print(f"Average MSE: {results['mean_mse']}")
 print(f"Average SSIM: {results['mean_ssim']}")
@@ -40,4 +47,4 @@ print(f"Average SSIM: {results['mean_ssim']}")
 
 ## Metrics
 
-Reconstruction quality is evaluated using **Mean Squared Error (MSE)** and **Structural Similarity Index (SSIM)**. These metrics compare the reconstructed samples to the class-wise averages of the original test set. Use `amulet.data_reconstruction.metrics.evaluate_similarity` to calculate these scores.
+Reconstruction quality is evaluated using **Mean Squared Error (MSE)** and **Structural Similarity Index (SSIM)**. These metrics compare the reconstructed samples to the class-wise averages of the original test set. Use `amulet.data_reconstruction.metrics.evaluate_similarity` to calculate these scores. Pass it a `DataLoader` built with `batch_size=1`, since it accumulates per-class averages one sample at a time.

--- a/examples/extending_amulet/custom_architecture.md
+++ b/examples/extending_amulet/custom_architecture.md
@@ -45,18 +45,28 @@ Update the models namespace.
 **File:** `amulet/models/__init__.py`
 
 ```python
-from .vgg import VGG
+from .base import AmuletModel
+from .cnn import SimpleCNN
+from .hf_causal_lm import HFCausalLM
 from .linear_net import LinearNet
 from .resnet import ResNet
-from .cnn import SimpleCNN
+from .vgg import VGG
 from .vit import VisionTransformer
 
-__all__ = ["VGG", "LinearNet", "ResNet", "SimpleCNN", "VisionTransformer"]
+__all__ = [
+    "VGG",
+    "AmuletModel",
+    "HFCausalLM",
+    "LinearNet",
+    "ResNet",
+    "SimpleCNN",
+    "VisionTransformer",
+]
 ```
 
 ## Step 3: Register the Model in the Pipeline
 
-Add a new case in the model initialization pipeline.
+Add a new case in the model initialization pipeline (`initialize_model` in `amulet/utils/__pipeline.py`).
 
 ```python
 elif model_arch == "vit":

--- a/examples/extending_amulet/custom_risk.md
+++ b/examples/extending_amulet/custom_risk.md
@@ -15,7 +15,8 @@ amulet/test_time_adaptation/attacks/
 ## Step 2: Implement the Attack
 
 Add a new attack file under the `attacks` subdirectory.
-All attacks should inherit from the `RiskAttack` base class (or a risk-specific base class if one exists).
+Amulet has no single shared attack base class. Each risk defines its own attack ABC (for example `EvasionAttack` in `amulet/evasion/attacks/` and `PoisoningAttack` in `amulet/poisoning/attacks/`).
+A new risk should define its own risk-specific base and have its attacks inherit from it. This example defines `TestTimeAdaptationAttack` for the test-time adaptation risk.
 
 **File:** `amulet/test_time_adaptation/attacks/test_time_data_poisoning.py`
 


### PR DESCRIPTION
## Summary

A comprehensive documentation sweep across the whole library, every docstring and every markdown file (excluding `experiments/` and `artifact/`). Every claim was verified against the actual source. Only docstrings, comments, and markdown changed: no code logic or signatures were touched, and the full pre-commit suite (ruff, ruff-format, basedpyright, prettier, markdownlint) passes.

## Correctness fixes

- **Six crashing doc examples now run against the real API:** the `WatermarkNN(model=…)` `TypeError`, the `auc_score` / `balanced_accuracy` `KeyError`s in the MI and AI guides, the `FredriksonCCS2015` missing-Softmax bug, and guide 7's fully broken `SuriEvans2022` example (rewritten to construct, then `prepare_model_populations()`, then `attack()`). Guide 7 also gained the missing `WhiteBoxPIM` section.
- **Phantom docstring parameters corrected:** `vgg.py` (`vgg_name` to `layer_config`), `linear_net.py` (`hidden_layer_size` to `hidden_layer_sizes`), data reconstruction (`int` to input-shape tuple), watermark (`model` to `target_model`), and the fairness defense base (dropped non-existent `lambdas` / `epochs`).
- **Wrong-technique copy-paste removed:** DP-SGD and the MI, AI, and fairness bases no longer claim "adversarial training" or "will be extracted"; the evasion `epsilon` "int, divided by 255" description is fixed; `mlconf.datasets` is now `amulet.datasets`.

## Completeness and docs

- Documented previously undocumented public API (`SimpleCNN` / `ResNet` `forward` and `get_hidden`, fairness `accuracy()` / `p_rule()`, the abstract entry-point methods) and added missing `Raises` / `Returns` sections.
- Added an `Unreleased` CHANGELOG section for the shipped textual-backdoor, ONION, and DPSGD `BatchMemoryManager` work (#105, #107, #108).
- Corrected the false `tests/unit` + `tests/integration` layout claim in AGENTS.md to the real per-risk directory plus pytest-marker tiering, added the required `modality` field to the `AmuletDataset` snippets, fixed README typos and dead links, and removed the phantom `RiskAttack` reference.

## Style

- Converted docstrings to Google style (no type repetition), removed RST markup (`:class:`, `:func:`, `::` directives), and dropped em-dashes from AGENTS.md and the modernization plan.

## Needs maintainer input

- `CODE_OF_CONDUCT.md` previously had an `[INSERT CONTACT METHOD]` placeholder. No email was fabricated: it now points to GitHub issues with an inline `TODO` asking maintainers to add a private contact address. A public issue tracker is a weak channel for conduct reports, so please replace it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
