### PR TITLE
refactor(dist-inf): rename victim -> target across the library

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,10 +85,10 @@ hard convention, not a suggestion, and it is enforced by `tests/test_api_conform
 A defense may expose extra public helpers in addition to its entry point, never instead
 of it. `ONION` is the reference case: it is a poisoning defense subclassing
 `PoisoningDefense` alongside `OutlierRemoval`, so it implements `train_robust()` (purify the
-poisoned training data, then retrain the victim), and it also exposes
+poisoned training data, then retrain the target), and it also exposes
 `purify(dataset)` for cleaning inputs at test time. Do not add a defense on a bespoke base
 class with a non-standard entry point; reshape the shared base instead. The textual backdoor
-attack `TextBadNets` and the LoRA-LLM victim `HFCausalLM` need the optional `llm` extra; see
+attack `TextBadNets` and the LoRA-LLM target `HFCausalLM` need the optional `llm` extra; see
 [Optional extras](#optional-extras).
 
 Some classes expose additional public helpers for experimentation. For example, `MembershipInferenceAttack` has `train_shadow_model()` / `prepare_shadow_models()` and `DistributionInferenceAttack` has `train_model_population()` / `prepare_model_populations()`.
@@ -100,7 +100,7 @@ Any model under `amulet/models/` must subclass `AmuletModel` ([`amulet/models/ba
 Several modules depend on intermediate activations; omitting `get_hidden` breaks them silently.
 Match the base signature's parameter name `x` on both `forward` and `get_hidden` (basedpyright enforces override compatibility), even when the input is token ids rather than pixels.
 
-`HFCausalLM` ([`amulet/models/hf_causal_lm.py`](amulet/models/hf_causal_lm.py)) is the reference example of subclassing `AmuletModel` around a real pretrained backbone: a LoRA-adapted HuggingFace **causal (decoder-only) LM** (Llama, GPT-2, Mistral, …) that keeps its generative base. One shared adapted decoder backs three roles: classification (`forward` returns the bare logits tensor, not the `SequenceClassifierOutput`, so `train_classifier`, `DPSGD.train_private`, and `get_accuracy` drive it unchanged), perplexity scoring (`perplexity`, what `ONION` consumes, since the victim itself is the reference LM), and generation (`generate`). Encoder-only (BERT) and seq2seq (T5) models do not fit and are out of scope. It needs the `llm` extra.
+`HFCausalLM` ([`amulet/models/hf_causal_lm.py`](amulet/models/hf_causal_lm.py)) is the reference example of subclassing `AmuletModel` around a real pretrained backbone: a LoRA-adapted HuggingFace **causal (decoder-only) LM** (Llama, GPT-2, Mistral, …) that keeps its generative base. One shared adapted decoder backs three roles: classification (`forward` returns the bare logits tensor, not the `SequenceClassifierOutput`, so `train_classifier`, `DPSGD.train_private`, and `get_accuracy` drive it unchanged), perplexity scoring (`perplexity`, what `ONION` consumes, since the target itself is the reference LM), and generation (`generate`). Encoder-only (BERT) and seq2seq (T5) models do not fit and are out of scope. It needs the `llm` extra.
 
 `initialize_model` uses a central capacity map and only covers the built-in CNNs; models whose constructors do not fit its `(arch, capacity, num_features, num_classes)` signature (e.g. `HFCausalLM`) are constructed directly. See #104.
 
@@ -115,7 +115,7 @@ Image loaders follow a 3-step fallback to ensure availability:
 2. **Raw local** (e.g. `img_align_celeba/`, `lfw_home/`)
 3. **GDrive download**: IDs are hard-coded in [`amulet/datasets/__image_datasets.py`](amulet/datasets/__image_datasets.py) (similar to how PyTorch ships dataset URLs), so no configuration is needed.
 
-Text loaders ([`amulet/datasets/__text_datasets.py`](amulet/datasets/__text_datasets.py): `load_sst2`, `load_agnews`, `load_imdb`) instead pull from the Hugging Face hub via `datasets` into a project-local `./data/<name>` cache. That divergence is intentional: HF manages text corpora and their splits. They return an `AmuletDataset` with `modality="text"` whose `train_set`/`test_set` are `TextTensorDataset` instances, a `TensorDataset` of padded `input_ids` that also carries the raw `.texts` (so ONION can re-score perplexity before the victim tokenizer runs) and the `tokenizer_name`. `AmuletDataset.modality` is `Literal["image", "tabular", "text"]`. Text loaders need the `llm` extra.
+Text loaders ([`amulet/datasets/__text_datasets.py`](amulet/datasets/__text_datasets.py): `load_sst2`, `load_agnews`, `load_imdb`) instead pull from the Hugging Face hub via `datasets` into a project-local `./data/<name>` cache. That divergence is intentional: HF manages text corpora and their splits. They return an `AmuletDataset` with `modality="text"` whose `train_set`/`test_set` are `TextTensorDataset` instances, a `TensorDataset` of padded `input_ids` that also carries the raw `.texts` (so ONION can re-score perplexity before the target tokenizer runs) and the `tokenizer_name`. `AmuletDataset.modality` is `Literal["image", "tabular", "text"]`. Text loaders need the `llm` extra.
 
 ### Optional extras
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Features
 
-* **poisoning:** textual backdoor attack with `TextBadNets`, the LoRA `HFCausalLM` victim, an ONION text purifier, and Hugging Face text loaders ([#105](https://github.com/ssg-research/amulet/issues/105)) ([eab3fa6](https://github.com/ssg-research/amulet/commit/eab3fa6c5447a9c936c2b3ecfe5f519b2d53dc88))
+* **poisoning:** textual backdoor attack with `TextBadNets`, the LoRA `HFCausalLM` target, an ONION text purifier, and Hugging Face text loaders ([#105](https://github.com/ssg-research/amulet/issues/105)) ([eab3fa6](https://github.com/ssg-research/amulet/commit/eab3fa6c5447a9c936c2b3ecfe5f519b2d53dc88))
 * **dp:** opt-in `BatchMemoryManager` for DP-SGD ([#108](https://github.com/ssg-research/amulet/issues/108)) ([ca1f65a](https://github.com/ssg-research/amulet/commit/ca1f65a1e930b6de60f9296ee4b11bc4dc8c477c))
 
 

--- a/amulet/datasets/__data.py
+++ b/amulet/datasets/__data.py
@@ -54,7 +54,7 @@ class AmuletDataset:
 class TextTensorDataset(TensorDataset):
     """TensorDataset of `(input_ids, label)` that also carries the raw strings.
 
-    This is the single artifact that flows attack -> victim -> defense for the text
+    This is the single artifact that flows attack -> target -> defense for the text
     modality. Because it subclasses `torch.utils.data.TensorDataset` over
     `(input_ids, labels)`, it is a `TensorDataset`: the
     `PoisoningAttack.poison_* -> TensorDataset` return type, every
@@ -65,7 +65,7 @@ class TextTensorDataset(TensorDataset):
 
     A `DataLoader` collates only the tensors; a consumer that needs the strings
     reads `loader.dataset.texts` (dataset order), which is why a defense must
-    purify the dataset before the (optionally shuffled) victim loader is built.
+    purify the dataset before the (optionally shuffled) target loader is built.
 
     Attributes:
         texts: The raw (possibly poisoned) strings in dataset order, one per row.

--- a/amulet/datasets/__text_datasets.py
+++ b/amulet/datasets/__text_datasets.py
@@ -9,7 +9,7 @@ The Hugging Face stack ships in the optional `amuletml[llm]` extra, so its impor
 are guarded: `import amulet` still works without the extra, and calling a loader
 without it raises a clear "install amuletml[llm]" error.
 
-Each loader tokenizes the raw strings with the victim tokenizer, pads `input_ids` to
+Each loader tokenizes the raw strings with the target tokenizer, pads `input_ids` to
 a fixed per-dataset max sequence length, and retains the raw strings on the returned
 `TextTensorDataset` so an input-purification defense (ONION) can re-score and
 re-tokenize them. SST-2 uses `validation` as its labelled test split (the public
@@ -36,7 +36,7 @@ _LLM_INSTALL_HINT = (
     "`pip install amuletml[llm]` (or `uv sync --extra llm`)."
 )
 
-# The plan's license-free fallback victim; its tokenizer produces the input_ids.
+# The plan's license-free fallback target; its tokenizer produces the input_ids.
 _DEFAULT_TOKENIZER = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
 
 

--- a/amulet/distribution_inference/attacks/distribution_inference_attack.py
+++ b/amulet/distribution_inference/attacks/distribution_inference_attack.py
@@ -23,7 +23,7 @@ class DistributionInferenceAttack(ABC):
     Follows the same lifecycle as MembershipInferenceAttack:
     1. Construct with data and training parameters.
     2. Call prepare_model_populations() to train and cache the four model
-       populations (adversary D1, adversary D2, victim D1, victim D2).
+       populations (adversary D1, adversary D2, target D1, target D2).
     3. Call attack() to run the distinguishing test.
 
     Attributes:
@@ -114,8 +114,8 @@ class DistributionInferenceAttack(ABC):
         self.splits: DistributionSplits | None = None
         self.models_adv_1: list[nn.Module] = []
         self.models_adv_2: list[nn.Module] = []
-        self.models_vic_1: list[nn.Module] = []
-        self.models_vic_2: list[nn.Module] = []
+        self.models_target_1: list[nn.Module] = []
+        self.models_target_2: list[nn.Module] = []
 
     def train_model_population(
         self,
@@ -190,7 +190,7 @@ class DistributionInferenceAttack(ABC):
 
         Calls prepare_distribution_splits internally, then trains num_models
         models on each of the four resulting loaders (adversary D1, adversary D2,
-        victim D1, victim D2). Models are saved to models_dir; already-saved
+        target D1, target D2). Models are saved to models_dir; already-saved
         checkpoints are loaded rather than retrained.
 
         Must be called before attack().
@@ -226,11 +226,11 @@ class DistributionInferenceAttack(ABC):
         self.models_adv_2 = self.train_model_population(
             self.splits.adv_trainloader_2, checkpoint_tag=_tag("adv", "2")
         )
-        self.models_vic_1 = self.train_model_population(
-            self.splits.vic_trainloader_1, checkpoint_tag=_tag("vic", "1")
+        self.models_target_1 = self.train_model_population(
+            self.splits.target_trainloader_1, checkpoint_tag=_tag("target", "1")
         )
-        self.models_vic_2 = self.train_model_population(
-            self.splits.vic_trainloader_2, checkpoint_tag=_tag("vic", "2")
+        self.models_target_2 = self.train_model_population(
+            self.splits.target_trainloader_2, checkpoint_tag=_tag("target", "2")
         )
 
     @abstractmethod
@@ -239,7 +239,7 @@ class DistributionInferenceAttack(ABC):
 
         Returns:
             Dictionary with two 1-D arrays: "predictions" (attack scores) and
-            "ground_truth" (0 for distribution-1 victims, 1 for distribution-2
-            victims).
+            "ground_truth" (0 for distribution-1 targets, 1 for distribution-2
+            targets).
         """
         pass

--- a/amulet/distribution_inference/attacks/suri_evans_2022.py
+++ b/amulet/distribution_inference/attacks/suri_evans_2022.py
@@ -22,11 +22,11 @@ class SuriEvans2022(DistributionInferenceAttack):
     """
     KL-divergence distinguishing test between two training distributions.
 
-    Given two adversary model populations (one per distribution) and two victim
-    model populations, the attack measures how each victim's output distribution
+    Given two adversary model populations (one per distribution) and two target
+    model populations, the attack measures how each target's output distribution
     diverges from each adversary baseline. The resulting pairwise KL differences
     are min-max normalized into continuous distinguishing scores in [0, 1], one
-    per victim model.
+    per target model.
 
     Inherits all constructor parameters from DistributionInferenceAttack.
     Call prepare_model_populations() before attack(), or pass populations and
@@ -80,13 +80,13 @@ class SuriEvans2022(DistributionInferenceAttack):
     def _kl_predictions(
         adv_preds_1: np.ndarray,
         adv_preds_2: np.ndarray,
-        vic_preds_1: np.ndarray,
-        vic_preds_2: np.ndarray,
+        target_preds_1: np.ndarray,
+        target_preds_2: np.ndarray,
     ) -> tuple[np.ndarray, np.ndarray]:
         """Turn raw logits into pairwise KL distinguishing scores."""
-        adv_1, adv_2, vic_1, vic_2 = (
+        adv_1, adv_2, target_1, target_2 = (
             torch.sigmoid(torch.from_numpy(p)).numpy()
-            for p in (adv_preds_1, adv_preds_2, vic_preds_1, vic_preds_2)
+            for p in (adv_preds_1, adv_preds_2, target_preds_1, target_preds_2)
         )
 
         eps = 1e-4
@@ -95,13 +95,13 @@ class SuriEvans2022(DistributionInferenceAttack):
         ordering = np.argsort(np.mean(np.abs(log_a - log_b), axis=0))[::-1]
         ordering = ordering[: len(ordering) // 2]
         adv_1, adv_2 = adv_1[:, ordering], adv_2[:, ordering]
-        vic_1, vic_2 = vic_1[:, ordering], vic_2[:, ordering]
+        target_1, target_2 = target_1[:, ordering], target_2[:, ordering]
 
         # Clip once to keep KL finite; PyTorch's kl_divergence has no eps parameter.
         adv_1_t = torch.from_numpy(np.clip(adv_1, eps, 1 - eps))
         adv_2_t = torch.from_numpy(np.clip(adv_2, eps, 1 - eps))
-        vic_1_t = torch.from_numpy(np.clip(vic_1, eps, 1 - eps))
-        vic_2_t = torch.from_numpy(np.clip(vic_2, eps, 1 - eps))
+        target_1_t = torch.from_numpy(np.clip(target_1, eps, 1 - eps))
+        target_2_t = torch.from_numpy(np.clip(target_2, eps, 1 - eps))
 
         xx, yy = np.triu_indices(adv_preds_1.shape[0], k=1)
         random_pick = np.random.permutation(xx.shape[0])[: int(0.8 * xx.shape[0])]
@@ -109,7 +109,7 @@ class SuriEvans2022(DistributionInferenceAttack):
 
         # PyTorch's Bernoulli KL has a broadcasting bug — its internal mask
         # indexing fails when the two probs tensors don't share a shape. Expand
-        # each victim row to adv's shape before constructing the distributions.
+        # each target row to adv's shape before constructing the distributions.
         kl_1_a = np.array([
             kl_divergence(
                 Bernoulli(probs=adv_1_t),
@@ -117,7 +117,7 @@ class SuriEvans2022(DistributionInferenceAttack):
             )
             .mean(dim=1)
             .numpy()
-            for v in vic_1_t
+            for v in target_1_t
         ])
         SuriEvans2022._check_finite(kl_1_a)
         kl_1_b = np.array([
@@ -127,7 +127,7 @@ class SuriEvans2022(DistributionInferenceAttack):
             )
             .mean(dim=1)
             .numpy()
-            for v in vic_1_t
+            for v in target_1_t
         ])
         SuriEvans2022._check_finite(kl_1_b)
         kl_2_a = np.array([
@@ -137,7 +137,7 @@ class SuriEvans2022(DistributionInferenceAttack):
             )
             .mean(dim=1)
             .numpy()
-            for v in vic_2_t
+            for v in target_2_t
         ])
         SuriEvans2022._check_finite(kl_2_a)
         kl_2_b = np.array([
@@ -147,7 +147,7 @@ class SuriEvans2022(DistributionInferenceAttack):
             )
             .mean(dim=1)
             .numpy()
-            for v in vic_2_t
+            for v in target_2_t
         ])
         SuriEvans2022._check_finite(kl_2_b)
 
@@ -160,8 +160,8 @@ class SuriEvans2022(DistributionInferenceAttack):
         *,
         models_adv_1: list[nn.Module] | None = None,
         models_adv_2: list[nn.Module] | None = None,
-        models_vic_1: list[nn.Module] | None = None,
-        models_vic_2: list[nn.Module] | None = None,
+        models_target_1: list[nn.Module] | None = None,
+        models_target_2: list[nn.Module] | None = None,
         test_loader_1: DataLoader | None = None,
         test_loader_2: DataLoader | None = None,
     ) -> dict[str, np.ndarray]:
@@ -177,10 +177,10 @@ class SuriEvans2022(DistributionInferenceAttack):
                 the prepared adversary-D1 population.
             models_adv_2: Adversary models trained on distribution 2. Defaults to
                 the prepared adversary-D2 population.
-            models_vic_1: Victim models trained on distribution 1. Defaults to the
-                prepared victim-D1 population.
-            models_vic_2: Victim models trained on distribution 2. Defaults to the
-                prepared victim-D2 population.
+            models_target_1: Target models trained on distribution 1. Defaults to the
+                prepared target-D1 population.
+            models_target_2: Target models trained on distribution 2. Defaults to the
+                prepared target-D2 population.
             test_loader_1: Test loader for distribution 1. Defaults to the prepared
                 distribution-1 test loader.
             test_loader_2: Test loader for distribution 2. Defaults to the prepared
@@ -190,8 +190,8 @@ class SuriEvans2022(DistributionInferenceAttack):
             A dictionary with two 1-D arrays of equal length:
                 - "predictions": attack scores in [0, 1]. Thresholding at 0.5
                   yields the distinguishing decision.
-                - "ground_truth": 0 for distribution-1 victims, 1 for
-                  distribution-2 victims.
+                - "ground_truth": 0 for distribution-1 targets, 1 for
+                  distribution-2 targets.
 
         Raises:
             RuntimeError: If the test loaders are not supplied and
@@ -200,8 +200,12 @@ class SuriEvans2022(DistributionInferenceAttack):
         """
         models_adv_1 = models_adv_1 if models_adv_1 is not None else self.models_adv_1
         models_adv_2 = models_adv_2 if models_adv_2 is not None else self.models_adv_2
-        models_vic_1 = models_vic_1 if models_vic_1 is not None else self.models_vic_1
-        models_vic_2 = models_vic_2 if models_vic_2 is not None else self.models_vic_2
+        models_target_1 = (
+            models_target_1 if models_target_1 is not None else self.models_target_1
+        )
+        models_target_2 = (
+            models_target_2 if models_target_2 is not None else self.models_target_2
+        )
 
         if test_loader_1 is None or test_loader_2 is None:
             if self.splits is None:
@@ -212,24 +216,24 @@ class SuriEvans2022(DistributionInferenceAttack):
             test_loader_1 = test_loader_1 or self.splits.test_loader_1
             test_loader_2 = test_loader_2 or self.splits.test_loader_2
 
-        if not (models_adv_1 and models_adv_2 and models_vic_1 and models_vic_2):
+        if not (models_adv_1 and models_adv_2 and models_target_1 and models_target_2):
             raise RuntimeError("All four model populations must be non-empty.")
 
         adv1_on_1, _ = self._collect_predictions(test_loader_1, models_adv_1)
         adv2_on_1, _ = self._collect_predictions(test_loader_1, models_adv_2)
-        vic1_on_1, _ = self._collect_predictions(test_loader_1, models_vic_1)
-        vic2_on_1, _ = self._collect_predictions(test_loader_1, models_vic_2)
+        target1_on_1, _ = self._collect_predictions(test_loader_1, models_target_1)
+        target2_on_1, _ = self._collect_predictions(test_loader_1, models_target_2)
 
         adv1_on_2, _ = self._collect_predictions(test_loader_2, models_adv_1)
         adv2_on_2, _ = self._collect_predictions(test_loader_2, models_adv_2)
-        vic1_on_2, _ = self._collect_predictions(test_loader_2, models_vic_1)
-        vic2_on_2, _ = self._collect_predictions(test_loader_2, models_vic_2)
+        target1_on_2, _ = self._collect_predictions(test_loader_2, models_target_1)
+        target2_on_2, _ = self._collect_predictions(test_loader_2, models_target_2)
 
         preds_1_first, preds_1_second = self._kl_predictions(
-            adv1_on_1, adv2_on_1, vic1_on_1, vic2_on_1
+            adv1_on_1, adv2_on_1, target1_on_1, target2_on_1
         )
         preds_2_first, preds_2_second = self._kl_predictions(
-            adv1_on_2, adv2_on_2, vic1_on_2, vic2_on_2
+            adv1_on_2, adv2_on_2, target1_on_2, target2_on_2
         )
 
         preds_first = np.concatenate((preds_1_first, preds_2_first), axis=1)

--- a/amulet/distribution_inference/attacks/white_box_pim.py
+++ b/amulet/distribution_inference/attacks/white_box_pim.py
@@ -73,10 +73,10 @@ class WhiteBoxPIM(DistributionInferenceAttack):
     Extracts the raw weights of adversary-population models, trains a
     Permutation Invariant Model (PIM) meta-classifier to distinguish
     distribution 1 from distribution 2, then evaluates it on held-out
-    victim models.
+    target models.
 
     Adversary populations supply the meta-classifier's training data.
-    Victim populations are the evaluation set that determines the attack's
+    Target populations are the evaluation set that determines the attack's
     distinguishing accuracy — they must not overlap with the adversary sets.
 
     Reference:
@@ -184,7 +184,7 @@ class WhiteBoxPIM(DistributionInferenceAttack):
 
     def attack(self) -> dict[str, np.ndarray]:
         """
-        Train the PIM meta-classifier on adversary models and evaluate on victims.
+        Train the PIM meta-classifier on adversary models and evaluate on targets.
 
         Must call prepare_model_populations() first.
 
@@ -192,8 +192,8 @@ class WhiteBoxPIM(DistributionInferenceAttack):
             Dictionary with two 1-D arrays of equal length:
                 - "predictions": sigmoid scores in [0, 1]. Values close to 1
                   indicate the model is more likely from distribution 2.
-                - "ground_truth": 0 for distribution-1 victims, 1 for
-                  distribution-2 victims.
+                - "ground_truth": 0 for distribution-1 targets, 1 for
+                  distribution-2 targets.
 
         Raises:
             RuntimeError: If prepare_model_populations() has not been called.
@@ -205,7 +205,7 @@ class WhiteBoxPIM(DistributionInferenceAttack):
             torch.manual_seed(self.random_seed)
 
         train_data = self._build_dataset(self.models_adv_1, self.models_adv_2)
-        eval_data = self._build_dataset(self.models_vic_1, self.models_vic_2)
+        eval_data = self._build_dataset(self.models_target_1, self.models_target_2)
 
         train_loader = self._make_loader(train_data, shuffle=True)
         eval_loader = self._make_loader(eval_data, shuffle=False)
@@ -242,8 +242,8 @@ class WhiteBoxPIM(DistributionInferenceAttack):
                 predictions.extend(scores.cpu().tolist())
 
         ground_truth = np.concatenate([
-            np.zeros(len(self.models_vic_1)),
-            np.ones(len(self.models_vic_2)),
+            np.zeros(len(self.models_target_1)),
+            np.ones(len(self.models_target_2)),
         ])
         return {
             "predictions": np.array(predictions),

--- a/amulet/distribution_inference/dataset_utils.py
+++ b/amulet/distribution_inference/dataset_utils.py
@@ -3,7 +3,7 @@ Dataset preparation helpers for distribution inference attacks.
 
 A distribution inference attack distinguishes two training distributions
 that differ in the proportion of samples satisfying some filter (e.g.
-`sex == 1`). Each side of the attack (victim and adversary) requires
+`sex == 1`). Each side of the attack (target and adversary) requires
 training data sampled to the target proportion. These helpers perform the
 ratio-preserving subsampling and return the six DataLoaders the attack
 consumes.
@@ -21,8 +21,8 @@ from torch.utils.data import ConcatDataset, DataLoader, TensorDataset
 class DistributionSplits:
     """DataLoaders produced by prepare_distribution_splits."""
 
-    vic_trainloader_1: DataLoader
-    vic_trainloader_2: DataLoader
+    target_trainloader_1: DataLoader
+    target_trainloader_2: DataLoader
     adv_trainloader_1: DataLoader
     adv_trainloader_2: DataLoader
     test_loader_1: DataLoader
@@ -136,7 +136,7 @@ def prepare_distribution_splits(
     """
     Build the six DataLoaders a distribution inference attack consumes.
 
-    The train/test arrays are each split 50/50 into victim and adversary halves
+    The train/test arrays are each split 50/50 into target and adversary halves
     (stratified on labels and every sensitive column). Each half is then
     subsampled twice, once for `ratio1` and once for `ratio2`, to produce
     the four training loaders plus two combined test loaders.
@@ -169,7 +169,7 @@ def prepare_distribution_splits(
         seed: Random seed for the 50/50 train/test split.
 
     Returns:
-        A DistributionSplits holding six DataLoaders: victim train loaders for
+        A DistributionSplits holding six DataLoaders: target train loaders for
         distributions 1 and 2, adversary train loaders for distributions 1 and 2,
         and combined test loaders for distributions 1 and 2.
 
@@ -226,10 +226,12 @@ def prepare_distribution_splits(
             z[right_idx],
         )
 
-    (x_vic, y_vic, z_vic), (x_adv, y_adv, z_adv) = split_50_50(
+    (x_target, y_target, z_target), (x_adv, y_adv, z_adv) = split_50_50(
         x_train, y_train, z_train
     )
-    (x_tv, y_tv, z_tv), (x_ta, y_ta, z_ta) = split_50_50(x_test, y_test, z_test)
+    (x_target_test, y_target_test, z_target_test), (x_ta, y_ta, z_ta) = split_50_50(
+        x_test, y_test, z_test
+    )
 
     def draw(
         x: np.ndarray, y: np.ndarray, z: np.ndarray, ratio: float, subsample: int
@@ -244,18 +246,22 @@ def prepare_distribution_splits(
         )
         return _build_tensor_dataset(x[idx], y[idx])
 
-    vic_train_1 = draw(x_vic, y_vic, z_vic, ratio1, train_subsample)
-    vic_train_2 = draw(x_vic, y_vic, z_vic, ratio2, train_subsample)
+    target_train_1 = draw(x_target, y_target, z_target, ratio1, train_subsample)
+    target_train_2 = draw(x_target, y_target, z_target, ratio2, train_subsample)
     adv_train_1 = draw(x_adv, y_adv, z_adv, ratio1, train_subsample)
     adv_train_2 = draw(x_adv, y_adv, z_adv, ratio2, train_subsample)
 
-    vic_test_1 = draw(x_tv, y_tv, z_tv, ratio1, test_subsample)
-    vic_test_2 = draw(x_tv, y_tv, z_tv, ratio2, test_subsample)
+    target_test_1 = draw(
+        x_target_test, y_target_test, z_target_test, ratio1, test_subsample
+    )
+    target_test_2 = draw(
+        x_target_test, y_target_test, z_target_test, ratio2, test_subsample
+    )
     adv_test_1 = draw(x_ta, y_ta, z_ta, ratio1, test_subsample)
     adv_test_2 = draw(x_ta, y_ta, z_ta, ratio2, test_subsample)
 
-    test_1: ConcatDataset = ConcatDataset([adv_test_1, vic_test_1])
-    test_2: ConcatDataset = ConcatDataset([adv_test_2, vic_test_2])
+    test_1: ConcatDataset = ConcatDataset([adv_test_1, target_test_1])
+    test_2: ConcatDataset = ConcatDataset([adv_test_2, target_test_2])
 
     def make_train_loader(ds: TensorDataset) -> DataLoader:  # type: ignore[type-arg]
         if len(ds) == 0:
@@ -268,8 +274,8 @@ def prepare_distribution_splits(
         return DataLoader(dataset=ds, batch_size=batch_size, shuffle=False)
 
     return DistributionSplits(
-        vic_trainloader_1=make_train_loader(vic_train_1),
-        vic_trainloader_2=make_train_loader(vic_train_2),
+        target_trainloader_1=make_train_loader(target_train_1),
+        target_trainloader_2=make_train_loader(target_train_2),
         adv_trainloader_1=make_train_loader(adv_train_1),
         adv_trainloader_2=make_train_loader(adv_train_2),
         test_loader_1=make_test_loader(test_1),

--- a/amulet/models/hf_causal_lm.py
+++ b/amulet/models/hf_causal_lm.py
@@ -1,4 +1,4 @@
-"""LoRA-adapted HuggingFace causal-LM victim, usable as classifier, scorer, or generator."""
+"""LoRA-adapted HuggingFace causal-LM target, usable as classifier, scorer, or generator."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ from .base import AmuletModel
 if TYPE_CHECKING:
     from transformers import PretrainedConfig, PreTrainedModel
 
-# The plan's license-free fallback victim (Llama architecture, not gated).
+# The plan's license-free fallback target (Llama architecture, not gated).
 _DEFAULT_MODEL = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
 # Llama attention projections that LoRA adapts.
 _DEFAULT_TARGET_MODULES = ["q_proj", "v_proj"]
@@ -30,7 +30,7 @@ class HFCausalLM(AmuletModel):
     """A HuggingFace causal (decoder-only) LM adapted with LoRA for three roles.
 
     One shared, LoRA-adapted decoder backs all three capabilities, so the same object is
-    the classification victim, the perplexity scorer a defense like ONION consumes, and a
+    the classification target, the perplexity scorer a defense like ONION consumes, and a
     text generator:
 
     - Classify — `forward` pools the last real-token hidden state and passes it

--- a/amulet/poisoning/defenses/onion.py
+++ b/amulet/poisoning/defenses/onion.py
@@ -29,11 +29,11 @@ class ONION(PoisoningDefense):
     perplexity, so deleting it drops perplexity sharply. Words whose suspicion score
     (``ppl(full) - ppl(without word)``) exceeds ``threshold`` are removed.
 
-    The reference language model is the victim itself (``model``, an ``HFCausalLM``),
+    The reference language model is the target itself (``model``, an ``HFCausalLM``),
     scored through its perplexity head — the same object ONION retrains in
     ``train_robust``. Like ``OutlierRemoval``, ONION thus cleans the data using the target
     model and retrains it; unlike it, ONION also exposes ``purify`` to clean inputs at test
-    time without retraining. By default scoring uses the victim's clean pretrained base
+    time without retraining. By default scoring uses the target's clean pretrained base
     (LoRA adapters off), an unpoisoned reference LM as in canonical ONION;
     ``score_with_adapters=True`` scores through the fine-tuned model instead.
 
@@ -44,10 +44,10 @@ class ONION(PoisoningDefense):
     Attributes:
         threshold: Suspicion cutoff; words scoring above it are removed. Higher keeps more
             words (weaker filtering); lower removes more.
-        score_with_adapters: Whether perplexity scoring runs through the victim's LoRA
+        score_with_adapters: Whether perplexity scoring runs through the target's LoRA
             adapters (the fine-tuned model) rather than its clean pretrained base.
         tokenizer: Tokenizer used to score candidate strings and to re-tokenize purified
-            text; matches the victim's tokenizer.
+            text; matches the target's tokenizer.
     """
 
     def __init__(
@@ -69,12 +69,12 @@ class ONION(PoisoningDefense):
         """Configure the ONION defense.
 
         Args:
-            model: The victim causal LM used both to score perplexity and to retrain in
+            model: The target causal LM used both to score perplexity and to retrain in
                 ``train_robust``.
             tokenizer: Tokenizer matching ``model``; used to score candidate strings and to
-                re-tokenize purified text for the victim.
+                re-tokenize purified text for the target.
             threshold: Suspicion cutoff for removing a word.
-            score_with_adapters: Score perplexity through the victim's LoRA adapters (the
+            score_with_adapters: Score perplexity through the target's LoRA adapters (the
                 fine-tuned model) instead of its clean pretrained base.
             score_batch_size: Candidate strings scored per padded forward when purifying a
                 row. Higher is faster but uses more memory; tune down if it is tight.
@@ -83,10 +83,10 @@ class ONION(PoisoningDefense):
             train_loader: Loader over the (poisoned) training data, carrying a
                 ``TextTensorDataset``; purified and retrained on by ``train_robust``.
             test_loader: Unused by ONION; accepted for base-class symmetry.
-            device: Device the victim runs on.
+            device: Device the target runs on.
             epochs: Number of retraining epochs in ``train_robust``.
             batch_size: Batch size used to rebuild the purified training loader.
-            train_function: Function used to retrain the victim. Defaults to
+            train_function: Function used to retrain the target. Defaults to
                 ``train_classifier`` from ``amulet.utils``.
         """
         super().__init__(
@@ -106,7 +106,7 @@ class ONION(PoisoningDefense):
         self._train_fn = train_function
 
     def _perplexities(self, texts: list[str]) -> list[float]:
-        """Compute the victim's perplexity of each string in one batched pass.
+        """Compute the target's perplexity of each string in one batched pass.
 
         Scores all candidates for a row (the full string plus every leave-one-out
         variant) in as few padded forwards as ``score_batch_size`` allows, instead of one
@@ -130,7 +130,7 @@ class ONION(PoisoningDefense):
 
         Returns:
             The purified string. If purification would empty the string, the original is
-            returned so the victim always receives a non-empty input.
+            returned so the target always receives a non-empty input.
         """
         words = text.strip().split()
         if len(words) <= 1:
@@ -154,7 +154,7 @@ class ONION(PoisoningDefense):
         return purified if purified else text.strip()
 
     def purify(self, dataset: TextTensorDataset) -> TextTensorDataset:
-        """Purify every row's text and re-tokenize under the victim's tokenizer.
+        """Purify every row's text and re-tokenize under the target's tokenizer.
 
         Args:
             dataset: A ``TextTensorDataset`` carrying the raw strings to purify.
@@ -181,13 +181,13 @@ class ONION(PoisoningDefense):
         )
 
     def train_robust(self) -> nn.Module:
-        """Purify the poisoned training data, retrain the victim on it, and return it.
+        """Purify the poisoned training data, retrain the target on it, and return it.
 
         Mirrors ``OutlierRemoval``: clean the training set (here by removing trigger words),
-        rebuild a loader, retrain the victim, and return the robust model.
+        rebuild a loader, retrain the target, and return the robust model.
 
         Returns:
-            The victim retrained on the purified training data.
+            The target retrained on the purified training data.
 
         Raises:
             ValueError: If the retraining collaborators were not supplied at construction.

--- a/amulet/poisoning/defenses/poisoning_defense.py
+++ b/amulet/poisoning/defenses/poisoning_defense.py
@@ -12,7 +12,7 @@ class PoisoningDefense(ABC):
 
     A poisoning defense produces a robust model via ``train_robust``: it cleans the
     (poisoned) training set — by removing outlier samples (``OutlierRemoval``) or purifying
-    trigger content (``ONION``) — then retrains the victim on the cleaned data and returns
+    trigger content (``ONION``) — then retrains the target on the cleaned data and returns
     it. Both defenses share that shape; only the cleaning mechanism differs.
 
     The retraining collaborators below are the standard, shared ingredients, and all are
@@ -21,7 +21,7 @@ class PoisoningDefense(ABC):
     it retrains with.
 
     Attributes:
-        model: The victim model to retrain on the cleaned data.
+        model: The target model to retrain on the cleaned data.
         criterion: Loss function for retraining.
         optimizer: Optimizer for retraining.
         train_loader: Loader over the (poisoned) training data to clean and retrain on.
@@ -54,4 +54,4 @@ class PoisoningDefense(ABC):
 
     @abstractmethod
     def train_robust(self) -> nn.Module:
-        """Clean the training set, retrain the victim on it, and return the robust model."""
+        """Clean the training set, retrain the target on it, and return the robust model."""

--- a/docs/module_guide/3_POISONING.md
+++ b/docs/module_guide/3_POISONING.md
@@ -2,7 +2,7 @@
 
 Data poisoning attacks involve an adversary injecting malicious samples into a model's training set. Amulet implements the BadNets backdoor attack for image/tabular data and a textual variant (`TextBadNets`) for language models. It provides an outlier-removal defense based on KNN Shapley values, and (for the textual attack) the ONION perplexity-based defense.
 
-Both poisoning defenses follow the same shape and share the `PoisoningDefense` base class. They expose `train_robust()`, which cleans the (poisoned) training set, then retrains the victim on the cleaned data and returns it. `OutlierRemoval` drops low-Shapley outlier samples, and `ONION` removes perplexity-outlier trigger words. This mirrors the library-wide convention that every defense implements its risk's training entry point (`train_robust` / `train_private` / `train_fair`). `ONION` additionally exposes `purify(dataset)` to clean inputs at test time, alongside `train_robust()`.
+Both poisoning defenses follow the same shape and share the `PoisoningDefense` base class. They expose `train_robust()`, which cleans the (poisoned) training set, then retrains the target on the cleaned data and returns it. `OutlierRemoval` drops low-Shapley outlier samples, and `ONION` removes perplexity-outlier trigger words. This mirrors the library-wide convention that every defense implements its risk's training entry point (`train_robust` / `train_private` / `train_fair`). `ONION` additionally exposes `purify(dataset)` to clean inputs at test time, alongside `train_robust()`.
 
 ## Attack
 
@@ -88,7 +88,7 @@ print(f"ASR after defense: {defended_asr}%")
 
 ## Textual Backdoor (LLM)
 
-`amulet.poisoning.attacks.TextBadNets` is the NLP analog of `BadNets`: it inserts a rare-word or short-phrase trigger into a fraction of training examples (in string space) and relabels them to a target class. The victim is `HFCausalLM`, a LoRA-adapted HuggingFace causal (decoder-only) LM that keeps its generative base: it classifies (trainable head over the frozen base), scores perplexity (its base LM), and generates. This path requires the optional `llm` extra (`uv sync --extra <cuxxx> --extra llm`).
+`amulet.poisoning.attacks.TextBadNets` is the NLP analog of `BadNets`: it inserts a rare-word or short-phrase trigger into a fraction of training examples (in string space) and relabels them to a target class. The target is `HFCausalLM`, a LoRA-adapted HuggingFace causal (decoder-only) LM that keeps its generative base: it classifies (trainable head over the frozen base), scores perplexity (its base LM), and generates. This path requires the optional `llm` extra (`uv sync --extra <cuxxx> --extra llm`).
 
 ```python
 import torch
@@ -103,7 +103,7 @@ from amulet.utils import get_accuracy, train_classifier
 device = "cuda:0"
 model_name = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
 
-# 1. Load a text dataset (tokenized with the victim's tokenizer)
+# 1. Load a text dataset (tokenized with the target's tokenizer)
 data = load_sst2(path="./data/sst2", tokenizer_name=model_name, max_length=128)
 
 # 2. Poison: trigger + relabel a fraction of train; trigger every non-target test row
@@ -111,29 +111,29 @@ attack = TextBadNets(trigger="cf", trigger_label=1, portion=0.1, random_seed=0)
 poisoned_train = attack.poison_train(data.train_set)
 poisoned_test = attack.poison_test(data.test_set)   # accuracy on this vs. trigger_label is ASR
 
-# 3. Fine-tune the LoRA victim on the poisoned data
-victim = HFCausalLM(model_name=model_name, num_labels=data.num_classes).to(device)
-optimizer = torch.optim.Adam(victim.trainable_parameters(), lr=2e-4)
+# 3. Fine-tune the LoRA target on the poisoned data
+target = HFCausalLM(model_name=model_name, num_labels=data.num_classes).to(device)
+optimizer = torch.optim.Adam(target.trainable_parameters(), lr=2e-4)
 criterion = torch.nn.CrossEntropyLoss()
 train_loader = DataLoader(poisoned_train, batch_size=16, shuffle=True)
-victim = train_classifier(victim, train_loader, criterion, optimizer, 3, device)
+target = train_classifier(target, train_loader, criterion, optimizer, 3, device)
 
-asr = get_accuracy(victim, DataLoader(poisoned_test, batch_size=16), device)
+asr = get_accuracy(target, DataLoader(poisoned_test, batch_size=16), device)
 print(f"Attack Success Rate (ASR): {asr}%")
 
-# 4. Defend with ONION: purify triggered inputs, then re-measure ASR on the same victim.
-#    ONION scores perplexity with the victim's own base LM (its clean, pre-fine-tuning
-#    base by default), so it re-tokenizes with the victim's tokenizer.
+# 4. Defend with ONION: purify triggered inputs, then re-measure ASR on the same target.
+#    ONION scores perplexity with the target's own base LM (its clean, pre-fine-tuning
+#    base by default), so it re-tokenizes with the target's tokenizer.
 tokenizer = AutoTokenizer.from_pretrained(model_name)
 if tokenizer.pad_token is None:
     tokenizer.pad_token = tokenizer.eos_token
-onion = ONION(model=victim, tokenizer=tokenizer, device=device)
+onion = ONION(model=target, tokenizer=tokenizer, device=device)
 purified_test = onion.purify(poisoned_test)
-defended_asr = get_accuracy(victim, DataLoader(purified_test, batch_size=16), device)
+defended_asr = get_accuracy(target, DataLoader(purified_test, batch_size=16), device)
 print(f"ASR after ONION: {defended_asr}%")
 ```
 
-An unintended cross-risk interaction is available by reusing the `DPSGD` membership-inference defense to fine-tune the LoRA victim with per-example clipping and noise (construct the victim with `dtype=torch.float32`, since bf16 trainable parameters break Opacus per-sample clipping). See `examples/attack_pipelines/run_text_backdoor.py` for the full pipeline reporting both the ONION and DP-LoRA interactions.
+An unintended cross-risk interaction is available by reusing the `DPSGD` membership-inference defense to fine-tune the LoRA target with per-example clipping and noise (construct the target with `dtype=torch.float32`, since bf16 trainable parameters break Opacus per-sample clipping). See `examples/attack_pipelines/run_text_backdoor.py` for the full pipeline reporting both the ONION and DP-LoRA interactions.
 
 ## Metrics
 

--- a/docs/module_guide/7_DISTRIBUTION_INFERENCE.md
+++ b/docs/module_guide/7_DISTRIBUTION_INFERENCE.md
@@ -5,12 +5,12 @@ Distribution inference attacks aim to determine which of two training distributi
 Both attacks share the `DistributionInferenceAttack` lifecycle:
 
 1. Construct the attack with the dataset arrays and a training configuration.
-2. Call `prepare_model_populations()` to train (or load cached) the four model populations: adversary distribution 1, adversary distribution 2, victim distribution 1, and victim distribution 2.
+2. Call `prepare_model_populations()` to train (or load cached) the four model populations: adversary distribution 1, adversary distribution 2, target distribution 1, and target distribution 2.
 3. Call `attack()` to run the distinguishing test.
 
 ## Black-Box Attack (KL divergence)
 
-To run the KL-divergence distinguishing test, use `amulet.distribution_inference.attacks.SuriEvans2022`. It measures how each victim model's outputs diverge from the adversary baseline models trained on each distribution.
+To run the KL-divergence distinguishing test, use `amulet.distribution_inference.attacks.SuriEvans2022`. It measures how each target model's outputs diverge from the adversary baseline models trained on each distribution.
 
 ```python
 from amulet.distribution_inference.attacks import SuriEvans2022
@@ -52,7 +52,7 @@ dist_inf.prepare_model_populations()
 results = dist_inf.attack()
 
 # results["predictions"]: attack scores in [0, 1] (threshold at 0.5 to decide)
-# results["ground_truth"]: 0 for distribution-1 victims, 1 for distribution-2 victims
+# results["ground_truth"]: 0 for distribution-1 targets, 1 for distribution-2 targets
 
 # 4. Evaluate results
 metrics = evaluate_distinguishing_accuracy(results["predictions"], results["ground_truth"])
@@ -60,11 +60,11 @@ print(f"Distinguishing Accuracy: {metrics['distinguishing_accuracy']}")
 print(f"AUC Score: {metrics['auc_score']}")
 ```
 
-The populations and test loaders built by `prepare_model_populations()` are the defaults for `attack()`. To score externally produced populations instead, pass them as keyword arguments (`models_adv_1`, `models_vic_1`, `test_loader_1`, and so on) to `attack()`.
+The populations and test loaders built by `prepare_model_populations()` are the defaults for `attack()`. To score externally produced populations instead, pass them as keyword arguments (`models_adv_1`, `models_target_1`, `test_loader_1`, and so on) to `attack()`.
 
 ## White-Box Attack (Permutation Invariant Model)
 
-To run the white-box attack, use `amulet.distribution_inference.attacks.WhiteBoxPIM`. Rather than observing outputs, it reads each model's raw Linear and Conv2d weights and trains a Permutation Invariant Model (PIM) meta-classifier on the adversary populations to distinguish the two distributions, then evaluates that meta-classifier on the held-out victim populations.
+To run the white-box attack, use `amulet.distribution_inference.attacks.WhiteBoxPIM`. Rather than observing outputs, it reads each model's raw Linear and Conv2d weights and trains a Permutation Invariant Model (PIM) meta-classifier on the adversary populations to distinguish the two distributions, then evaluates that meta-classifier on the held-out target populations.
 
 `WhiteBoxPIM` takes the same constructor arguments as `SuriEvans2022`, plus meta-classifier settings (`meta_epochs`, `lr`, `inside_dims`).
 
@@ -107,4 +107,4 @@ print(f"Distinguishing Accuracy: {metrics['distinguishing_accuracy']}")
 
 ## Metrics
 
-Distribution inference is evaluated by the attack's **Distinguishing Accuracy**: how often the adversary correctly identifies which of the two distributions trained a victim model. Use `amulet.distribution_inference.metrics.evaluate_distinguishing_accuracy`. It takes `results["predictions"]` and `results["ground_truth"]` and returns a dict with keys `distinguishing_accuracy` and `auc_score`.
+Distribution inference is evaluated by the attack's **Distinguishing Accuracy**: how often the adversary correctly identifies which of the two distributions trained a target model. Use `amulet.distribution_inference.metrics.evaluate_distinguishing_accuracy`. It takes `results["predictions"]` and `results["ground_truth"]` and returns a dict with keys `distinguishing_accuracy` and `auc_score`.

--- a/examples/attack_pipelines/run_distribution_inference.py
+++ b/examples/attack_pipelines/run_distribution_inference.py
@@ -2,7 +2,7 @@
 End-to-end pipeline: run the Suri & Evans 2022 distribution inference attack.
 
 The adversary trains num_models models per distribution and uses them to infer
-which of two training distributions a set of victim models was drawn from.
+which of two training distributions a set of target models was drawn from.
 Distributions differ in the proportion of training samples where a chosen
 sensitive attribute equals filter_value.
 """

--- a/examples/attack_pipelines/run_text_backdoor.py
+++ b/examples/attack_pipelines/run_text_backdoor.py
@@ -2,7 +2,7 @@
 
 This is the runnable efficacy surface for the LLM backdoor work and doubles as the
 "how to extend Amulet to an LLM" example. It flows the standard pipeline shape
-(AmuletDataset -> attack -> train -> metric) with a genuine decoder LLM victim:
+(AmuletDataset -> attack -> train -> metric) with a genuine decoder LLM target:
 
   1. Load a text dataset (SST-2 / AG News / IMDB) as token-id tensors.
   2. TextBadNets stamps a trigger into a fraction of training rows and flips their
@@ -10,7 +10,7 @@ This is the runnable efficacy surface for the LLM backdoor work and doubles as t
   3. Fine-tune HFCausalLM (AutoModelForCausalLM + LoRA, with a classification head) on
      the poisoned data and report clean accuracy and ASR.
   4. Report two interactions:
-       - intended:   ONION (scoring with the victim's own base LM) purifies the
+       - intended:   ONION (scoring with the target's own base LM) purifies the
                      triggered inputs, then re-measure ASR.
        - unintended: DP-LoRA fine-tuning (reused DPSGD) bounds each example's
                      influence; re-measure ASR and report epsilon.
@@ -129,7 +129,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--onion_score_with_adapters",
         action="store_true",
-        help="Score ONION perplexity through the victim's LoRA adapters (the fine-tuned "
+        help="Score ONION perplexity through the target's LoRA adapters (the fine-tuned "
         "model) instead of its clean base LM (canonical ONION uses the clean base).",
     )
     parser.add_argument("--sigma", type=float, default=1.0, help="DP noise multiplier.")
@@ -161,7 +161,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def load_text_dataset(args: argparse.Namespace) -> AmuletDataset:
-    """Load the requested text dataset, tokenized with the victim's tokenizer."""
+    """Load the requested text dataset, tokenized with the target's tokenizer."""
     max_train = None if args.max_train_samples < 0 else args.max_train_samples
     max_test = None if args.max_test_samples < 0 else args.max_test_samples
     data_path = Path(args.root) / "data" / args.dataset
@@ -174,8 +174,8 @@ def load_text_dataset(args: argparse.Namespace) -> AmuletDataset:
     )
 
 
-def build_victim(args: argparse.Namespace, num_classes: int, dtype: torch.dtype):
-    """Construct a fresh LoRA causal-LM victim (with a classification head) on device."""
+def build_target(args: argparse.Namespace, num_classes: int, dtype: torch.dtype):
+    """Construct a fresh LoRA causal-LM target (with a classification head) on device."""
     return HFCausalLM(
         model_name=args.model_name,
         num_labels=num_classes,
@@ -221,21 +221,21 @@ def main(args: argparse.Namespace) -> None:
     clean_test_loader = DataLoader(data.test_set, batch_size=args.batch_size)
     asr_loader = DataLoader(poisoned_test, batch_size=args.batch_size)
 
-    # Undefended backdoor: fine-tune the LoRA victim on the poisoned data.
+    # Undefended backdoor: fine-tune the LoRA target on the poisoned data.
     criterion = torch.nn.CrossEntropyLoss()
-    victim = build_victim(args, data.num_classes, torch.bfloat16)
-    optimizer = torch.optim.Adam(victim.trainable_parameters(), lr=args.lr)
-    victim = train_classifier(
-        victim, train_loader, criterion, optimizer, args.epochs, args.device
+    target = build_target(args, data.num_classes, torch.bfloat16)
+    optimizer = torch.optim.Adam(target.trainable_parameters(), lr=args.lr)
+    target = train_classifier(
+        target, train_loader, criterion, optimizer, args.epochs, args.device
     )
 
-    clean_acc = get_accuracy(victim, clean_test_loader, args.device)
-    asr = get_accuracy(victim, asr_loader, args.device)
+    clean_acc = get_accuracy(target, clean_test_loader, args.device)
+    asr = get_accuracy(target, asr_loader, args.device)
     log.info("Undefended | clean accuracy: %.2f | ASR: %.2f", clean_acc, asr)
 
     # Intended interaction: ONION purifies the triggered inputs before classification.
-    # ONION scores perplexity with the victim itself (its clean base LM by default), so
-    # the tokenizer it scores and re-tokenizes with must be the victim's own.
+    # ONION scores perplexity with the target itself (its clean base LM by default), so
+    # the tokenizer it scores and re-tokenizes with must be the target's own.
     if args.defense in ("onion", "both"):
         from transformers import AutoTokenizer
 
@@ -244,8 +244,8 @@ def main(args: argparse.Namespace) -> None:
             tokenizer.pad_token = tokenizer.eos_token
         onion = ONION(
             # train_classifier returns the shared nn.Module type; narrow back to the
-            # victim's concrete type, which ONION needs for its `perplexity` scorer.
-            model=cast(HFCausalLM, victim),
+            # target's concrete type, which ONION needs for its `perplexity` scorer.
+            model=cast(HFCausalLM, target),
             tokenizer=tokenizer,
             threshold=args.onion_threshold,
             score_with_adapters=args.onion_score_with_adapters,
@@ -253,20 +253,20 @@ def main(args: argparse.Namespace) -> None:
         )
         purified_test = onion.purify(poisoned_test)
         purified_loader = DataLoader(purified_test, batch_size=args.batch_size)
-        onion_asr = get_accuracy(victim, purified_loader, args.device)
+        onion_asr = get_accuracy(target, purified_loader, args.device)
         log.info(
-            "ONION | ASR %.2f -> %.2f (clean accuracy unchanged: victim is the same)",
+            "ONION | ASR %.2f -> %.2f (clean accuracy unchanged: target is the same)",
             asr,
             onion_asr,
         )
 
     # Unintended cross-risk interaction: DP-LoRA fine-tuning (reused DPSGD). The DP
-    # victim must be fp32 (bf16 trainable params break Opacus per-sample clipping).
+    # target must be fp32 (bf16 trainable params break Opacus per-sample clipping).
     if args.defense in ("dp", "both"):
-        dp_victim = build_victim(args, data.num_classes, torch.float32)
-        dp_optimizer = torch.optim.Adam(dp_victim.trainable_parameters(), lr=args.dp_lr)
+        dp_target = build_target(args, data.num_classes, torch.float32)
+        dp_optimizer = torch.optim.Adam(dp_target.trainable_parameters(), lr=args.dp_lr)
         dp_training = DPSGD(
-            model=dp_victim,
+            model=dp_target,
             criterion=criterion,
             optimizer=dp_optimizer,
             train_loader=train_loader,

--- a/examples/attack_pipelines/run_whitebox_dist_inference.py
+++ b/examples/attack_pipelines/run_whitebox_dist_inference.py
@@ -3,7 +3,7 @@ End-to-end pipeline: run the White-Box PIM distribution inference attack.
 
 Trains two populations of models (one per distribution ratio) on a tabular
 dataset, then uses a Permutation Invariant Model (PIM) meta-classifier to
-infer which distribution a held-out victim model was trained on based on
+infer which distribution a held-out target model was trained on based on
 its raw parameters.
 """
 

--- a/examples/defense_pipelines/run_fingerprint.py
+++ b/examples/defense_pipelines/run_fingerprint.py
@@ -84,7 +84,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--k", help="For L1 attack", type=int, default=1)
     parser.add_argument(
         "--regressor_embed",
-        help="Victim Embeddings for training regressor",
+        help="Target Embeddings for training regressor",
         type=int,
         default=0,
         choices=[0, 1],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ cpu = ["torch==2.11.0", "torchvision==0.26.0"]
 cu128 = ["torch==2.11.0", "torchvision==0.26.0"]
 cu130 = ["torch==2.11.0", "torchvision==0.26.0"]
 # LLM stack for the text-backdoor pipeline (TextBadNets attack, HFTextClassifier
-# victim, ONION defense). Kept optional so the base install stays lean and the
+# target, ONION defense). Kept optional so the base install stays lean and the
 # macOS dev machine / fast CI tier never pull the heavy Hugging Face stack. Every
 # module that imports these guards the import and raises a clear
 # "install amuletml[llm]" message when an LLM component is actually constructed.

--- a/tests/distribution_inference/test_dataset_utils.py
+++ b/tests/distribution_inference/test_dataset_utils.py
@@ -22,8 +22,8 @@ from amulet.distribution_inference.dataset_utils import (
 
 def _loaders(result: DistributionSplits) -> list[DataLoader]:
     return [
-        result.vic_trainloader_1,
-        result.vic_trainloader_2,
+        result.target_trainloader_1,
+        result.target_trainloader_2,
         result.adv_trainloader_1,
         result.adv_trainloader_2,
         result.test_loader_1,
@@ -439,8 +439,8 @@ class TestPrepareDistributionSplits:
 
         # all six attributes are DataLoader instances
         loaders = [
-            result.vic_trainloader_1,
-            result.vic_trainloader_2,
+            result.target_trainloader_1,
+            result.target_trainloader_2,
             result.adv_trainloader_1,
             result.adv_trainloader_2,
             result.test_loader_1,
@@ -475,8 +475,8 @@ class TestPrepareDistributionSplits:
         result = prepare_distribution_splits(*args, **splits_kwargs)
 
         for loader in [
-            result.vic_trainloader_1,
-            result.vic_trainloader_2,
+            result.target_trainloader_1,
+            result.target_trainloader_2,
             result.adv_trainloader_1,
             result.adv_trainloader_2,
             result.test_loader_1,
@@ -494,7 +494,7 @@ class TestPrepareDistributionSplits:
         result = prepare_distribution_splits(*args, **splits_kwargs)
 
         # each x batch has shape (batch, n_features)
-        x_batch, _ = next(iter(result.vic_trainloader_1))
+        x_batch, _ = next(iter(result.target_trainloader_1))
         assert x_batch.ndim == 2
         assert x_batch.shape[1] == n_features
 
@@ -521,7 +521,7 @@ class TestPrepareDistributionSplits:
         )
 
         # each x sample has shape (C, H, W)
-        x_batch, _ = next(iter(result.vic_trainloader_1))
+        x_batch, _ = next(iter(result.target_trainloader_1))
         assert x_batch.shape[1:] == (c, h, w)
 
     def test_y_shape_2d_accepted(self, splits_inputs_factory, splits_kwargs):
@@ -537,7 +537,7 @@ class TestPrepareDistributionSplits:
         args = splits_inputs_factory()
 
         result = prepare_distribution_splits(*args, **splits_kwargs)
-        x_batch, _ = next(iter(result.vic_trainloader_1))
+        x_batch, _ = next(iter(result.target_trainloader_1))
 
         assert x_batch.dtype == torch.float32
 
@@ -545,7 +545,7 @@ class TestPrepareDistributionSplits:
         args = splits_inputs_factory()
 
         result = prepare_distribution_splits(*args, **splits_kwargs)
-        _, y_batch = next(iter(result.vic_trainloader_1))
+        _, y_batch = next(iter(result.target_trainloader_1))
 
         assert y_batch.dtype == torch.int64
 
@@ -595,8 +595,8 @@ class TestPrepareDistributionSplits:
 
         # dataset sizes must be identical when numpy state is reset
         for attr in [
-            "vic_trainloader_1",
-            "vic_trainloader_2",
+            "target_trainloader_1",
+            "target_trainloader_2",
             "adv_trainloader_1",
             "adv_trainloader_2",
             "test_loader_1",
@@ -617,7 +617,7 @@ class TestPrepareDistributionSplits:
         args = splits_inputs_factory()
         # Reseed the global RNG identically before each call, so any difference
         # is attributable to the ratio rather than RNG drift between calls. With
-        # the ratios swapped, vic_trainloader_1 (which uses ratio1) must sample a
+        # the ratios swapped, target_trainloader_1 (which uses ratio1) must sample a
         # different set of rows; a function that ignored the ratios would return
         # byte-identical data.
         np.random.seed(123)
@@ -629,8 +629,8 @@ class TestPrepareDistributionSplits:
             *args, **{**splits_kwargs, "ratio1": ratio2, "ratio2": ratio1}
         )
 
-        x1 = _all_x(result_1.vic_trainloader_1)
-        x2 = _all_x(result_2.vic_trainloader_1)
+        x1 = _all_x(result_1.target_trainloader_1)
+        x2 = _all_x(result_2.target_trainloader_1)
         assert not (x1.shape == x2.shape and torch.equal(x1, x2))
 
     @pytest.mark.parametrize("ratio1,ratio2", [(0.2, 0.8), (0.3, 0.7)])
@@ -659,12 +659,12 @@ class TestPrepareDistributionSplits:
         }
         result = prepare_distribution_splits(x, y, z, x_test, y_test, z_test, **kwargs)
 
-        frac_1 = float((_all_x(result.vic_trainloader_1)[:, 0] == 1).float().mean())
-        frac_2 = float((_all_x(result.vic_trainloader_2)[:, 0] == 1).float().mean())
+        frac_1 = float((_all_x(result.target_trainloader_1)[:, 0] == 1).float().mean())
+        frac_2 = float((_all_x(result.target_trainloader_2)[:, 0] == 1).float().mean())
         assert abs(frac_1 - ratio1) < 0.12
         assert abs(frac_2 - ratio2) < 0.12
 
-    def test_test_loaders_are_concatenated_from_vic_and_adv(
+    def test_test_loaders_are_concatenated_from_target_and_adv(
         self, splits_inputs_factory, splits_kwargs
     ):
         args = splits_inputs_factory(n_train=600, n_test=400)
@@ -672,7 +672,7 @@ class TestPrepareDistributionSplits:
 
         result = prepare_distribution_splits(*args, **splits_kwargs)
 
-        # Each test half (adv, vic) draws int(class_imbalance * test_subsample) +
+        # Each test half (adv, target) draws int(class_imbalance * test_subsample) +
         # test_subsample = 3*15 + 15 = 60 samples, so the concatenation of both
         # halves is exactly 120. A concat bug that dropped one half would halve
         # each combined test loader to 60.

--- a/tests/distribution_inference/test_distribution_inference_attack.py
+++ b/tests/distribution_inference/test_distribution_inference_attack.py
@@ -405,19 +405,19 @@ class TestPrepareModelPopulationsState:
 
         assert len(attack.models_adv_2) > 0
 
-    def test_models_vic_1_non_empty(self, attack_factory) -> None:
+    def test_models_target_1_non_empty(self, attack_factory) -> None:
         attack = attack_factory(num_models=1)
 
         attack.prepare_model_populations()
 
-        assert len(attack.models_vic_1) > 0
+        assert len(attack.models_target_1) > 0
 
-    def test_models_vic_2_non_empty(self, attack_factory) -> None:
+    def test_models_target_2_non_empty(self, attack_factory) -> None:
         attack = attack_factory(num_models=1)
 
         attack.prepare_model_populations()
 
-        assert len(attack.models_vic_2) > 0
+        assert len(attack.models_target_2) > 0
 
     @pytest.mark.parametrize("n_models", [1, 2])
     def test_each_population_length_equals_num_models(
@@ -429,8 +429,8 @@ class TestPrepareModelPopulationsState:
 
         assert len(attack.models_adv_1) == n_models
         assert len(attack.models_adv_2) == n_models
-        assert len(attack.models_vic_1) == n_models
-        assert len(attack.models_vic_2) == n_models
+        assert len(attack.models_target_1) == n_models
+        assert len(attack.models_target_2) == n_models
 
 
 # ---------------------------------------------------------------------------
@@ -481,7 +481,7 @@ class TestPrepareModelPopulationsCheckpoints:
         # every checkpoint filename must match the expected pattern
         # {dataset}_dist_inf_{role}_{dist}_{arch}_{capacity}_{model_id}_{exp_id}.pth
         pattern = re.compile(
-            rf"^{re.escape(dataset)}_dist_inf_(adv|vic)_(1|2)_{re.escape(arch)}"
+            rf"^{re.escape(dataset)}_dist_inf_(adv|target)_(1|2)_{re.escape(arch)}"
             rf"_{re.escape(capacity)}_\d+_{re.escape(str(exp_id))}\.pth$"
         )
         for p in tmp_path.glob("*.pth"):
@@ -499,7 +499,12 @@ class TestPrepareModelPopulationsCheckpoints:
         names = " ".join(p.name for p in tmp_path.glob("*.pth"))
 
         # each role+dist combination must appear once
-        for role, dist in [("adv", "1"), ("adv", "2"), ("vic", "1"), ("vic", "2")]:
+        for role, dist in [
+            ("adv", "1"),
+            ("adv", "2"),
+            ("target", "1"),
+            ("target", "2"),
+        ]:
             assert f"_dist_inf_{role}_{dist}_" in names, (
                 f"No checkpoint for role='{role}', dist='{dist}'"
             )

--- a/tests/distribution_inference/test_suri_evans_2022.py
+++ b/tests/distribution_inference/test_suri_evans_2022.py
@@ -11,7 +11,7 @@ import pytest
 from amulet.distribution_inference.attacks.suri_evans_2022 import SuriEvans2022
 
 N_ADV_MODELS = 4
-N_VIC_MODELS = 3
+N_TARGET_MODELS = 3
 N_SAMPLES = 6
 # _kl_predictions keeps 80% of the C(N_ADV_MODELS, 2) upper-triangle pairs.
 N_PAIRS = int(0.8 * (N_ADV_MODELS * (N_ADV_MODELS - 1) // 2))
@@ -24,15 +24,15 @@ def test_kl_predictions_finite_on_saturated_logits(seed_everything) -> None:
     rng = np.random.default_rng(0)
     adv_1 = rng.choice([-1e4, 1e4], size=(N_ADV_MODELS, N_SAMPLES))
     adv_2 = rng.choice([-1e4, 1e4], size=(N_ADV_MODELS, N_SAMPLES))
-    vic_1 = rng.choice([-1e4, 1e4], size=(N_VIC_MODELS, N_SAMPLES))
-    vic_2 = rng.choice([-1e4, 1e4], size=(N_VIC_MODELS, N_SAMPLES))
+    target_1 = rng.choice([-1e4, 1e4], size=(N_TARGET_MODELS, N_SAMPLES))
+    target_2 = rng.choice([-1e4, 1e4], size=(N_TARGET_MODELS, N_SAMPLES))
 
     preds_first, preds_second = SuriEvans2022._kl_predictions(
-        adv_1, adv_2, vic_1, vic_2
+        adv_1, adv_2, target_1, target_2
     )
 
-    assert preds_first.shape == (N_VIC_MODELS, N_PAIRS)
-    assert preds_second.shape == (N_VIC_MODELS, N_PAIRS)
+    assert preds_first.shape == (N_TARGET_MODELS, N_PAIRS)
+    assert preds_second.shape == (N_TARGET_MODELS, N_PAIRS)
     assert np.isfinite(preds_first).all()
     assert np.isfinite(preds_second).all()
 
@@ -48,10 +48,10 @@ def test_kl_predictions_zero_when_all_models_agree(seed_everything) -> None:
     seed_everything(0)
     rng = np.random.default_rng(0)
     adv_logits = np.tile(rng.standard_normal((1, N_SAMPLES)), (N_ADV_MODELS, 1))
-    vic_logits = adv_logits[:N_VIC_MODELS].copy()
+    target_logits = adv_logits[:N_TARGET_MODELS].copy()
 
     preds_first, preds_second = SuriEvans2022._kl_predictions(
-        adv_logits, adv_logits.copy(), vic_logits, vic_logits.copy()
+        adv_logits, adv_logits.copy(), target_logits, target_logits.copy()
     )
 
     np.testing.assert_allclose(preds_first, 0.0, atol=1e-12)

--- a/tests/distribution_inference/test_white_box_pim.py
+++ b/tests/distribution_inference/test_white_box_pim.py
@@ -226,7 +226,7 @@ def test_whitebox_pim_predictions_in_unit_interval(whitebox_attack_factory):
 @pytest.mark.integration
 @pytest.mark.timeout(300)
 def test_whitebox_pim_ground_truth_binary(whitebox_attack_factory):
-    """ground_truth must contain only 0s and 1s (dist-1 vs dist-2 victims)."""
+    """ground_truth must contain only 0s and 1s (dist-1 vs dist-2 targets)."""
     attack = whitebox_attack_factory(seed=4)
     attack.prepare_model_populations()
     results = attack.attack()

--- a/tests/models/test_hf_causal_lm.py
+++ b/tests/models/test_hf_causal_lm.py
@@ -1,4 +1,4 @@
-"""Unit tests for the unified HF causal-LM victim (`HFCausalLM`).
+"""Unit tests for the unified HF causal-LM target (`HFCausalLM`).
 
 `HFCausalLM` wraps a HuggingFace causal (decoder-only) LM and exposes three roles over
 one shared, LoRA-adapted decoder: classification (a trainable head over the pooled last
@@ -179,7 +179,7 @@ def test_generate_extends_prompt(tiny_causal_lm_factory):
 @pytest.mark.integration
 @pytest.mark.timeout(120)
 def test_overfits_single_classification_batch(tiny_causal_lm_factory):
-    """The victim can memorize one tiny batch: gradients reach the LoRA adapters + head.
+    """The target can memorize one tiny batch: gradients reach the LoRA adapters + head.
 
     A plateauing loss would mean broken gradient flow (frozen adapters, an untrained head,
     a wrong loss reduction). This is the load-bearing "does it learn" check.

--- a/tests/poisoning/test_onion.py
+++ b/tests/poisoning/test_onion.py
@@ -1,6 +1,6 @@
 """Tests for the ONION input-purification poisoning defense.
 
-ONION scores word fluency with the victim's perplexity head and removes perplexity
+ONION scores word fluency with the target's perplexity head and removes perplexity
 outliers (likely triggers). Two layers are covered:
 
 - The **removal algorithm** (leave-one-out suspicion, threshold, empty-fallback) is pinned
@@ -8,7 +8,7 @@ outliers (likely triggers). Two layers are covered:
   pretrained LM to be meaningful, and ``HFCausalLM.perplexity`` is tested in isolation in
   ``tests/models/test_hf_causal_lm.py``; stubbing it here isolates the algorithm around it.
 - The **dataset / retrain wiring** (``purify`` round-trip, ``train_robust``) runs against
-  the real tiny victim, so the perplexity oracle is exercised for real end to end.
+  the real tiny target, so the perplexity oracle is exercised for real end to end.
 """
 
 import pytest
@@ -21,7 +21,7 @@ from amulet.poisoning.defenses import ONION, PoisoningDefense
 
 @pytest.fixture
 def onion(tiny_text_classifier, text_tokenizer, cpu_device):
-    """An ONION whose reference LM is the tiny random-init victim."""
+    """An ONION whose reference LM is the tiny random-init target."""
     return ONION(
         model=tiny_text_classifier,
         tokenizer=text_tokenizer,
@@ -98,7 +98,7 @@ def test_purify_text_falls_back_to_original_when_emptied(onion, mocker):
     """A threshold so low every word is removed must not yield an empty string.
 
     ``purify_text`` returns the original (stripped) text rather than an empty input, so the
-    victim always receives something to classify.
+    target always receives something to classify.
     """
     mocker.patch.object(onion, "_perplexities", side_effect=_fake_ppls)
     onion.threshold = -1e9  # remove every word
@@ -140,7 +140,7 @@ def test_purify_text_scores_row_in_one_forward(onion, tiny_text_classifier):
 @pytest.mark.integration
 @pytest.mark.timeout(120)
 def test_purify_round_trips_dataset(onion, tiny_text_dataset):
-    """purify returns a valid TextTensorDataset (real victim scores perplexity)."""
+    """purify returns a valid TextTensorDataset (real target scores perplexity)."""
     max_len = tiny_text_dataset.tensors[0].shape[1]
     purified = onion.purify(tiny_text_dataset)
 
@@ -164,10 +164,10 @@ def test_purify_rejects_non_text_dataset(onion):
 
 @pytest.mark.integration
 @pytest.mark.timeout(180)
-def test_train_robust_returns_retrained_victim(
+def test_train_robust_returns_retrained_target(
     tiny_text_classifier, text_tokenizer, tiny_text_dataset, cpu_device
 ):
-    """train_robust purifies the training data, retrains the victim, and returns it.
+    """train_robust purifies the training data, retrains the target, and returns it.
 
     Mirrors OutlierRemoval's contract: a robust ``nn.Module`` comes back, and its trainable
     parameters have moved (retraining actually ran on the purified data).

--- a/tests/poisoning/test_text_backdoor_integration.py
+++ b/tests/poisoning/test_text_backdoor_integration.py
@@ -1,8 +1,8 @@
 """End-to-end integration for the text-backdoor pipeline.
 
-These build tiny random-init LoRA victims and train them a few steps on CPU, so they are
+These build tiny random-init LoRA targets and train them a few steps on CPU, so they are
 marked ``integration`` and time-bounded. The north star is that the pipeline runs and
-reproduces (same seed -> same result); the overfit test guards that the victim can learn
+reproduces (same seed -> same result); the overfit test guards that the target can learn
 at all (gradients reach the LoRA adapters and the classification head).
 """
 
@@ -22,8 +22,8 @@ def _state_dicts_equal(a: dict, b: dict) -> bool:
 
 @pytest.mark.integration
 @pytest.mark.timeout(120)
-def test_lora_victim_overfits_single_batch(tiny_text_classifier, tiny_text_dataset):
-    """The victim can memorize one tiny batch: proof gradients reach LoRA + the head.
+def test_lora_target_overfits_single_batch(tiny_text_classifier, tiny_text_dataset):
+    """The target can memorize one tiny batch: proof gradients reach LoRA + the head.
 
     A plateauing loss would mean broken gradient flow (frozen adapters, an untrained
     head, a wrong loss reduction). This is the load-bearing "does it learn" check.
@@ -82,10 +82,10 @@ def test_text_backdoor_pipeline_runs_and_reproduces(
 
 @pytest.mark.integration
 @pytest.mark.timeout(180)
-def test_dpsgd_runs_one_epoch_on_lora_victim(
+def test_dpsgd_runs_one_epoch_on_lora_target(
     tiny_text_classifier, tiny_text_dataset, cpu_device
 ):
-    """The reused DPSGD defense drives the single-tensor LoRA victim end-to-end."""
+    """The reused DPSGD defense drives the single-tensor LoRA target end-to-end."""
     from amulet.membership_inference.defenses import DPSGD
 
     attack = TextBadNets(trigger="cf", trigger_label=1, portion=0.5, random_seed=0)
@@ -117,7 +117,7 @@ def test_dpsgd_runs_one_epoch_on_lora_victim(
 
 @pytest.mark.integration
 @pytest.mark.timeout(120)
-def test_victim_forward_returns_bare_logits(tiny_text_classifier, tiny_text_dataset):
+def test_target_forward_returns_bare_logits(tiny_text_classifier, tiny_text_dataset):
     """The DPSGD/get_accuracy contract: one input tensor in, a bare logits tensor out.
 
     Returning the raw ``(batch, num_labels)`` tensor (not ``SequenceClassifierOutput``)
@@ -131,7 +131,7 @@ def test_victim_forward_returns_bare_logits(tiny_text_classifier, tiny_text_data
 
 @pytest.mark.integration
 @pytest.mark.timeout(120)
-def test_victim_get_hidden_pools_per_row(tiny_text_classifier, tiny_text_dataset):
+def test_target_get_hidden_pools_per_row(tiny_text_classifier, tiny_text_dataset):
     """get_hidden returns one pooled hidden vector per input row."""
     input_ids = tiny_text_dataset.tensors[0][:2]
     hidden = tiny_text_classifier.get_hidden(input_ids)


### PR DESCRIPTION
## What

Standardize on **target** for the model under attack. The distribution-inference module and the text/LLM additions used *victim* / *vic*, while the rest of the library (and the docs) use `target_model`. This aligns the terminology.

## Changes (mechanical rename, no logic change)

- `DistributionSplits.vic_trainloader_1/2` → `target_trainloader_1/2`
- `DistributionInferenceAttack.models_vic_1/2` → `models_target_1/2`, and the matching `SuriEvans2022` / `WhiteBoxPIM` `attack()` keyword arguments
- checkpoint-tag role string `"vic"` → `"target"`: per-model checkpoints now read `<dataset>_dist_inf_target_<dist>_<arch>_<capacity>_<id>_<exp_id>.pth` (the two naming tests were updated to match)
- internal locals, docstrings, and comments across `distribution_inference`, `poisoning` (ONION), `datasets`, and `models`
- prose in `AGENTS.md`, `CHANGELOG.md`, `pyproject.toml`, and the module guide

The paired **adversary** / `adv` terminology is intentionally left unchanged.

## Verification

- `ruff check`, `ruff format`, `basedpyright`: clean
- full pre-commit: pass
- fast test tier: **282 passed, 103 deselected** (integration/gpu/slow run in CI)
- zero residual `victim` / `vic` tokens outside the intended `adversary` pairings