### PR TITLE
feat(utils): let load_data subsample the test split via test_size

### DIFF
--- a/amulet/utils/__pipeline.py
+++ b/amulet/utils/__pipeline.py
@@ -4,11 +4,11 @@ Utilities to help build an ML pipeline.
 
 import logging
 from pathlib import Path
-from typing import TypedDict
+from typing import TypedDict, cast
 
-import torch
+import numpy as np
 from sklearn.model_selection import train_test_split
-from torch.utils.data import Dataset, Subset, random_split
+from torch.utils.data import Dataset, Subset
 
 from ..datasets import (
     AmuletDataset,
@@ -24,6 +24,37 @@ from ..datasets import (
 from ..models import VGG, AmuletModel, LinearNet, ResNet, SimpleCNN
 
 
+def _subset_indices(count: int, fraction: float, seed: int, label: str) -> np.ndarray:
+    """Choose which records of a split to keep, as one shared index array.
+
+    Every view of a split (the `Dataset` and the NumPy arrays beside it) is
+    indexed with the array returned here, which is what keeps them aligned:
+    subsampling them through independent generators leaves `x_train[i]` and
+    `train_set[i]` describing different records.
+
+    Args:
+        count: Number of records in the split.
+        fraction: Proportion of the split to keep.
+        seed: Random seed, so a given seed always selects the same records.
+        label: Name of the parameter being applied, for the error message.
+
+    Returns:
+        Indices of the kept records, in the order the subsample drew them.
+
+    Raises:
+        ValueError: If `fraction` is not in (0, 1] or would keep no records.
+    """
+    if not 0.0 < fraction <= 1.0:
+        raise ValueError(f"{label} must lie in (0, 1]; got {fraction}.")
+    if int(fraction * count) < 1:
+        raise ValueError(
+            f"{label}={fraction} keeps no records of a {count}-record split. "
+            f"Use at least {1 / count:.3g}."
+        )
+    keep, _ = train_test_split(np.arange(count), train_size=fraction, random_state=seed)
+    return cast(np.ndarray, keep)
+
+
 def load_data(
     root: Path | str,
     dataset: str,
@@ -31,9 +62,15 @@ def load_data(
     log: logging.Logger | None = None,
     exp_id: int = 0,
     celeba_target: str = "Smiling",
+    test_size: float = 1.0,
 ) -> AmuletDataset:
     """
     Load data given the dataset name and training size.
+
+    `training_size` and `test_size` are independent and shrink only the split
+    they name. Both matter for cost: an algorithm that walks the test split
+    (kNN-Shapley outlier removal, for one) is unaffected by `training_size`
+    alone, so a cheap run has to reduce both.
 
     Args:
         root: Root directory of the pipeline.
@@ -42,12 +79,14 @@ def load_data(
         log: Logging facility.
         exp_id: Used as a random seed.
         celeba_target: Target attribute for CelebA. Example: "Smiling".
+        test_size: Proportion of test data to use.
 
     Returns:
         Loaded dataset as an AmuletDataset.
 
     Raises:
-        ValueError: If dataset is not a recognized dataset name.
+        ValueError: If dataset is not a recognized dataset name, or if either
+            fraction is outside (0, 1] or would empty its split.
     """
 
     if isinstance(root, str):
@@ -77,23 +116,30 @@ def load_data(
         raise ValueError(f"Unknown dataset: {dataset!r}")
 
     if training_size < 1.0:
-        if data.x_train is not None:
-            data.x_train, _, data.y_train, _, data.z_train, _ = train_test_split(  # type: ignore[reportAttributeAccessIssue]
-                data.x_train,
-                data.y_train,
-                data.z_train,
-                train_size=training_size,
-                random_state=exp_id,
-            )
-
-        new_train_size = int(training_size * len(data.train_set))  # type: ignore[reportAttributeAccessIssue]
-        generator = torch.Generator().manual_seed(exp_id)
-        train_set, _ = random_split(
-            data.train_set,
-            [new_train_size, len(data.train_set) - new_train_size],  # type: ignore[reportAttributeAccessIssue]
-            generator=generator,
+        keep = _subset_indices(
+            len(data.train_set),  # type: ignore[reportArgumentType]
+            training_size,
+            exp_id,
+            "training_size",
         )
-        data.train_set = train_set
+        data.train_set = Subset(data.train_set, keep.tolist())
+        if data.x_train is not None:
+            data.x_train = data.x_train[keep]
+            data.y_train = None if data.y_train is None else data.y_train[keep]
+            data.z_train = None if data.z_train is None else data.z_train[keep]
+
+    if test_size < 1.0:
+        keep = _subset_indices(
+            len(data.test_set),  # type: ignore[reportArgumentType]
+            test_size,
+            exp_id,
+            "test_size",
+        )
+        data.test_set = Subset(data.test_set, keep.tolist())
+        if data.x_test is not None:
+            data.x_test = data.x_test[keep]
+            data.y_test = None if data.y_test is None else data.y_test[keep]
+            data.z_test = None if data.z_test is None else data.z_test[keep]
 
     return data
 

--- a/tests/utils/test_pipeline.py
+++ b/tests/utils/test_pipeline.py
@@ -1,14 +1,23 @@
 """Tests for the pipeline helpers in amulet/utils/__pipeline.py:
-create_dir, initialize_model, and stratified_split."""
+create_dir, initialize_model, load_data, and stratified_split."""
 
+from collections.abc import Sized
 from pathlib import Path
+from typing import cast
 
+import numpy as np
 import pytest
 import torch
-from torch.utils.data import TensorDataset
+from torch.utils.data import Dataset, TensorDataset
 
+from amulet.datasets import AmuletDataset
 from amulet.models import VGG, AmuletModel, LinearNet, ResNet, SimpleCNN
-from amulet.utils.__pipeline import create_dir, initialize_model, stratified_split
+from amulet.utils.__pipeline import (
+    create_dir,
+    initialize_model,
+    load_data,
+    stratified_split,
+)
 
 # ---------------------------------------------------------------------------
 # create_dir
@@ -103,6 +112,234 @@ def test_initialize_model_invalid_arch():
 def test_initialize_model_invalid_capacity():
     with pytest.raises(KeyError, match="not found in model_conf"):
         initialize_model("vgg", "invalid", 10, 2)
+
+
+# ---------------------------------------------------------------------------
+# load_data
+# ---------------------------------------------------------------------------
+
+# Row i of every split is the constant vector [i, i, i], so a record's identity
+# survives subsetting. That is what makes misalignment between the NumPy views
+# and the Dataset detectable: if the two are subsampled independently, the
+# tensor at position i stops matching x_*[i] and the assertions below fail.
+_FEATURES = 3
+
+
+def _indexed_split(count: int, offset: int) -> tuple[np.ndarray, ...]:
+    """Build (x, y, z) whose row i is identifiable by its own value."""
+    x = np.repeat(np.arange(offset, offset + count, dtype=np.float32), _FEATURES)
+    x = x.reshape(count, _FEATURES)
+    y = (np.arange(count) % 2).astype(np.int64)
+    z = (np.arange(count) % 3).reshape(-1, 1).astype(np.int64)
+    return x, y, z
+
+
+def _tensor_set(x: np.ndarray, y: np.ndarray) -> TensorDataset:
+    return TensorDataset(
+        torch.from_numpy(x).type(torch.float), torch.from_numpy(y).type(torch.long)
+    )
+
+
+def _tabular_dataset(n_train: int = 100, n_test: int = 60) -> AmuletDataset:
+    """A census-shaped dataset: both a Dataset and the NumPy views, aligned."""
+    x_train, y_train, z_train = _indexed_split(n_train, 0)
+    # Offset the test split so a train row can never be mistaken for a test row.
+    x_test, y_test, z_test = _indexed_split(n_test, 1000)
+    return AmuletDataset(
+        train_set=_tensor_set(x_train, y_train),
+        test_set=_tensor_set(x_test, y_test),
+        num_features=_FEATURES,
+        num_classes=2,
+        modality="tabular",
+        sensitive_columns=["dummy"],
+        x_train=x_train,
+        x_test=x_test,
+        y_train=y_train,
+        y_test=y_test,
+        z_train=z_train,
+        z_test=z_test,
+    )
+
+
+def _vision_dataset(n_train: int = 100, n_test: int = 60) -> AmuletDataset:
+    """A CIFAR-shaped dataset: Datasets only, no NumPy views (x_train is None)."""
+    x_train, y_train, _ = _indexed_split(n_train, 0)
+    x_test, y_test, _ = _indexed_split(n_test, 1000)
+    return AmuletDataset(
+        train_set=_tensor_set(x_train, y_train),
+        test_set=_tensor_set(x_test, y_test),
+        num_features=_FEATURES,
+        num_classes=2,
+        modality="image",
+    )
+
+
+@pytest.fixture
+def stub_census(monkeypatch):
+    """Serve a synthetic census in place of the real download."""
+
+    def factory(n_train: int = 100, n_test: int = 60) -> AmuletDataset:
+        data = _tabular_dataset(n_train, n_test)
+        monkeypatch.setattr("amulet.utils.__pipeline.load_census", lambda *a, **k: data)
+        return data
+
+    return factory
+
+
+@pytest.fixture
+def stub_cifar(monkeypatch):
+    """Serve a synthetic CIFAR-shaped dataset carrying no NumPy views."""
+
+    def factory(n_train: int = 100, n_test: int = 60) -> AmuletDataset:
+        data = _vision_dataset(n_train, n_test)
+        monkeypatch.setattr(
+            "amulet.utils.__pipeline.load_cifar10", lambda *a, **k: data
+        )
+        return data
+
+    return factory
+
+
+def _size(dataset: Dataset) -> int:
+    """Length of a split. `Dataset` does not declare `__len__`, so this casts."""
+    return len(cast("Sized", dataset))
+
+
+def _dataset_ids(dataset: Dataset) -> list[int]:
+    """Recover each record's identity from the Dataset, in dataset order."""
+    indexable = cast("TensorDataset", dataset)
+    return [int(indexable[i][0][0].item()) for i in range(_size(dataset))]
+
+
+def _array_ids(array: np.ndarray | None) -> list[int]:
+    """Recover each record's identity from a NumPy view, in array order."""
+    assert array is not None, "the census stand-in always carries its NumPy views"
+    return [int(value) for value in array[:, 0]]
+
+
+def _labels(dataset: Dataset) -> list[int]:
+    """Recover the label the Dataset yields for each record, in dataset order."""
+    indexable = cast("TensorDataset", dataset)
+    return [int(indexable[i][1].item()) for i in range(_size(dataset))]
+
+
+def test_load_data_defaults_keep_both_splits_whole(tmp_path, stub_census):
+    stub_census(n_train=100, n_test=60)
+
+    data = load_data(tmp_path, "census")
+
+    assert _size(data.train_set) == 100
+    assert _size(data.test_set) == 60
+    assert len(_array_ids(data.x_train)) == 100
+    assert len(_array_ids(data.x_test)) == 60
+
+
+def test_load_data_test_size_shrinks_the_test_split(tmp_path, stub_census):
+    stub_census(n_train=100, n_test=60)
+
+    data = load_data(tmp_path, "census", test_size=0.25)
+
+    assert _size(data.test_set) == 15
+    assert len(_array_ids(data.x_test)) == 15
+    assert data.y_test is not None and data.y_test.shape[0] == 15
+    assert data.z_test is not None and data.z_test.shape[0] == 15
+
+
+def test_load_data_test_size_leaves_the_train_split_whole(tmp_path, stub_census):
+    stub_census(n_train=100, n_test=60)
+
+    data = load_data(tmp_path, "census", test_size=0.25)
+
+    assert _size(data.train_set) == 100
+    assert len(_array_ids(data.x_train)) == 100
+
+
+def test_load_data_training_size_leaves_the_test_split_whole(tmp_path, stub_census):
+    """The knobs are independent: this is the regression the artifact tripped on."""
+    stub_census(n_train=100, n_test=60)
+
+    data = load_data(tmp_path, "census", training_size=0.25)
+
+    assert _size(data.test_set) == 60
+    assert len(_array_ids(data.x_test)) == 60
+
+
+@pytest.mark.parametrize("training_size, test_size", [(0.25, 0.5), (0.5, 0.25)])
+def test_load_data_subsets_both_splits_together(
+    tmp_path, stub_census, training_size, test_size
+):
+    stub_census(n_train=100, n_test=60)
+
+    data = load_data(tmp_path, "census", training_size, test_size=test_size)
+
+    assert _size(data.train_set) == int(training_size * 100)
+    assert _size(data.test_set) == int(test_size * 60)
+
+
+def test_load_data_keeps_train_views_index_aligned(tmp_path, stub_census):
+    """train_set[i] must be the same record as x_train[i] after subsetting."""
+    stub_census(n_train=100, n_test=60)
+
+    data = load_data(tmp_path, "census", training_size=0.25)
+
+    assert _dataset_ids(data.train_set) == _array_ids(data.x_train)
+
+
+def test_load_data_keeps_test_views_index_aligned(tmp_path, stub_census):
+    """test_set[i] must be the same record as x_test[i] after subsetting."""
+    stub_census(n_train=100, n_test=60)
+
+    data = load_data(tmp_path, "census", test_size=0.25)
+
+    assert _dataset_ids(data.test_set) == _array_ids(data.x_test)
+
+
+def test_load_data_keeps_labels_aligned_with_features(tmp_path, stub_census):
+    """The label the Dataset yields must match y_test for the same record."""
+    stub_census(n_train=100, n_test=60)
+
+    data = load_data(tmp_path, "census", test_size=0.25)
+
+    assert data.y_test is not None
+    assert _labels(data.test_set) == [int(value) for value in data.y_test]
+
+
+def test_load_data_subset_is_deterministic_in_exp_id(tmp_path, stub_census):
+    stub_census(n_train=100, n_test=60)
+    first = load_data(tmp_path, "census", 0.25, test_size=0.25, exp_id=7)
+    stub_census(n_train=100, n_test=60)
+    second = load_data(tmp_path, "census", 0.25, test_size=0.25, exp_id=7)
+
+    assert _array_ids(first.x_test) == _array_ids(second.x_test)
+    assert _array_ids(first.x_train) == _array_ids(second.x_train)
+
+
+def test_load_data_subset_varies_with_exp_id(tmp_path, stub_census):
+    stub_census(n_train=100, n_test=60)
+    first = load_data(tmp_path, "census", test_size=0.25, exp_id=0)
+    stub_census(n_train=100, n_test=60)
+    second = load_data(tmp_path, "census", test_size=0.25, exp_id=1)
+
+    assert _array_ids(first.x_test) != _array_ids(second.x_test)
+
+
+def test_load_data_subsets_datasets_lacking_numpy_views(tmp_path, stub_cifar):
+    """CIFAR-shaped loaders carry no arrays; the Datasets must still shrink."""
+    stub_cifar(n_train=100, n_test=60)
+
+    data = load_data(tmp_path, "cifar10", 0.25, test_size=0.5)
+
+    assert _size(data.train_set) == 25
+    assert _size(data.test_set) == 30
+    assert data.x_train is None
+
+
+def test_load_data_rejects_a_fraction_that_empties_a_split(tmp_path, stub_census):
+    """A silently empty test split would make every downstream metric a NaN."""
+    stub_census(n_train=100, n_test=60)
+
+    with pytest.raises(ValueError, match="test_size"):
+        _ = load_data(tmp_path, "census", test_size=0.001)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a `test_size` parameter to `load_data`, mirroring `training_size` but for the test split.

`training_size` and `test_size` are **independent** and shrink only the split they name. Both matter for cost: an algorithm that walks the test split (kNN-Shapley outlier removal, for one) is unaffected by `training_size` alone, so a cheap run has to reduce both.

## What changed

- New `test_size: float = 1.0` argument on `load_data`. Default keeps the full test split, so existing callers are unaffected.
- Both splits now subsample through a shared `_subset_indices` helper that returns **one index array** applied to every view of a split — the `Dataset` and the NumPy arrays (`x_*`, `y_*`, `z_*`) beside it. This keeps `x_train[i]` and `train_set[i]` describing the same record.
  - The previous `training_size` path drew the `Dataset` (`random_split`) and the arrays (`train_test_split`) from **independent** generators, so the two views drifted out of alignment. The shared-index approach fixes that regression too.
- `_subset_indices` rejects a fraction outside `(0, 1]` or one that would empty a split, instead of silently producing an empty split whose downstream metrics are all `NaN`.

## Tests

Adds `load_data` coverage in `tests/utils/test_pipeline.py`:
- defaults keep both splits whole; `test_size` shrinks only the test split; `training_size` leaves the test split whole; both together;
- Dataset↔NumPy index alignment for train and test views, and label↔feature alignment;
- determinism in `exp_id` and variation across `exp_id`;
- datasets lacking NumPy views (CIFAR-shaped) still shrink;
- a fraction that would empty a split raises `ValueError`.

Full `tests/utils/test_pipeline.py` (37 tests) passes locally; `pre-commit` (ruff, ruff-format, basedpyright) clean.
